### PR TITLE
issue: 842673 Add time measurement possibilty using libibprof

### DIFF
--- a/config/m4/prof.m4
+++ b/config/m4/prof.m4
@@ -1,0 +1,34 @@
+# prof.m4 - Profiling, instrumentation
+# 
+# Copyright (C) Mellanox Technologies Ltd. 2016.  ALL RIGHTS RESERVED.
+# See file LICENSE for terms.
+#
+
+##########################
+# libibprof profiling support
+#
+AC_ARG_WITH([ibprof],
+    AC_HELP_STRING([--with-ibprof],
+                   [Search ibprof location (default NO)]),
+    [],
+    [with_ibprof=no]
+)
+
+AS_IF([test "x$with_ibprof" == xno],
+    [],
+    [AC_CHECK_HEADER(
+        [$with_ibprof/include/ibprof_api.h],
+        [
+         CFLAGS="$CFLAGS -DVMA_TIME_IBPROF"
+         CXXFLAGS="$CXXFLAGS -DVMA_TIME_IBPROF"
+         CPPFLAGS="$CPPFLAGS -I$with_ibprof/include"
+         if test -d "$with_ibprof/lib64"; then
+             LDFLAGS="$LDFLAGS -L$with_ibprof/lib64 -Wl,--rpath,$with_ibprof/lib64"
+         else
+             LDFLAGS="$LDFLAGS -L$with_ibprof/lib -Wl,--rpath,$with_ibprof/lib"
+         fi
+         AC_SUBST([LIBIBPROF_LIBS], "-libprof")
+        ],
+        [AC_MSG_ERROR([ibprof support requested, but <$with_ibprof/include/ibprof_api.h> not found.])])
+])
+

--- a/configure.ac
+++ b/configure.ac
@@ -56,6 +56,7 @@ AC_SUBST(LIBALIC_FLAG)
 AC_SUBST([BUILD_DATE], [$(date +'%b/%d/%Y')])
 AC_SUBST([BUILD_TIME], [$(date +'%H:%M:%S')])
 
+m4_include([config/m4/prof.m4])
 m4_include([config/m4/opt.m4])
 m4_include([config/m4/pkg.m4])
 PKG_PROG_PKG_CONFIG
@@ -248,7 +249,7 @@ if test "x${with_debug}" = "xyes" ; then
 else
 	CFLAGS="-O3 $CFLAGS"
 	CXXFLAGS="-O3 $CXXFLAGS"
-	
+
 	if test "x${with_debug_info}" = "xyes" ; then
 		CFLAGS="-g $CFLAGS"
         	CXXFLAGS="-g $CXXFLAGS"

--- a/src/vma/Makefile.am
+++ b/src/vma/Makefile.am
@@ -58,7 +58,7 @@ libvma_la_LDFLAGS := -no-undefined -version-number @VMA_LIBRARY_MAJOR@:@VMA_LIBR
 endif
 
 libvma_la_LIBADD = \
-	-lrt -ldl -lpthread $(VERBS_FLAGS) $(LIBNL_LIBS) \
+	-lrt -ldl -lpthread $(VERBS_FLAGS) $(LIBNL_LIBS) $(LIBIBPROF_LIBS) \
 	$(top_builddir)/src/utils/libutils.la \
 	$(top_builddir)/src/vlogger/libvlogger.la \
 	$(top_builddir)/src/state_machine/libstate_machine.la \

--- a/src/vma/util/instrumentation.h
+++ b/src/vma/util/instrumentation.h
@@ -172,4 +172,14 @@ void finit_instrumentation(char* dump_file_name);
 
 #endif //VMA_TIME_MEASURE
 
+#ifdef VMA_TIME_IBPROF
+#include <ibprof_api.h>
+
+#define VMA_TIME_IBPROF_START(_id, _tag)    ibprof_interval_start((_id), _tag)
+#define VMA_TIME_IBPROF_END(_id)            ibprof_interval_end((_id))
+#else
+#define VMA_TIME_IBPROF_START(_id, _tag)
+#define VMA_TIME_IBPROF_END(_id)
+#endif //VMA_TIME_IBPROF
+
 #endif //INSTRUMENTATION


### PR DESCRIPTION
This PR provides ability to measure performance in different parts of source code using libibprof utility.
It can be used during development process and this capacity is OFF by default.
libibprof is a part of MOFED package but it is possible to build and install one from source code.

Location: https://github.com/mellanox-hpc/libibprof
Configuration: --with-ibprof=<dir>

Usage:
Wrap code you need to profile by
VMA_TIME_IBPROF_START(id, "user defined label")
VMA_TIME_IBPROF_END(id)
to get timing.

```
    sock->m_vma_thr = p_rx_pkt_mem_buf_desc_info->path.rx.is_vma_thr;

    VMA_TIME_IBPROF_START(1, "rx_input_cb:L3_level_tcp_input");
    L3_level_tcp_input((pbuf *)p_rx_pkt_mem_buf_desc_info, pcb);
    VMA_TIME_IBPROF_END(1);

    sock->m_vma_thr = false;
```

Please review and accept if you find it useful
