### PR TITLE
issue: 764912 Expand vma_stats to include: Send-Q & Recv-Q

### DIFF
--- a/src/stats/stats_printer.cpp
+++ b/src/stats/stats_printer.cpp
@@ -309,7 +309,7 @@ static const char *state2str(tcp_state state)
 void print_netstat_like_headers(FILE* file)
 {
 	static bool already_printed = false;
-	if(!already_printed) fprintf(file, "Proto Offloaded Local Address          Foreign Address       State       Inode      PID/Program name\n");
+	if(!already_printed) fprintf(file, "Proto Offloaded Recv-Q Send-Q Local Address          Foreign Address       State       Inode      PID/Program name\n");
 	already_printed = true;
 }
 
@@ -322,6 +322,7 @@ void print_netstat_like(socket_stats_t* p_si_stats, mc_grp_info_t* , FILE* file,
 	if(! p_si_stats->inode) return; // shmem is not updated yet
 
 	fprintf(file, "%-5s %-9s ", to_str_socket_type_netstat_like(p_si_stats->socket_type), p_si_stats->b_is_offloaded ? "Yes" : "No");
+	fprintf(file, "%-6d %-6d ", (int)p_si_stats->n_rx_ready_byte_count, (int)p_si_stats->n_tx_ready_byte_count);
 
 	//
 	// Bounded + Connected information

--- a/src/stats/stats_reader.cpp
+++ b/src/stats/stats_reader.cpp
@@ -190,6 +190,7 @@ void update_delta_stat(socket_stats_t* p_curr_stat, socket_stats_t* p_prev_stat)
 	p_prev_stat->counters.n_rx_poll_miss = (p_curr_stat->counters.n_rx_poll_miss - p_prev_stat->counters.n_rx_poll_miss) / delay;
 	p_prev_stat->counters.n_rx_poll_hit = (p_curr_stat->counters.n_rx_poll_hit - p_prev_stat->counters.n_rx_poll_hit) / delay;
 	p_prev_stat->n_rx_ready_byte_count = p_curr_stat->n_rx_ready_byte_count;
+	p_prev_stat->n_tx_ready_byte_count = p_curr_stat->n_tx_ready_byte_count;
 	p_prev_stat->n_rx_ready_byte_limit = p_curr_stat->n_rx_ready_byte_limit;
 	p_prev_stat->counters.n_rx_ready_byte_max = p_curr_stat->counters.n_rx_ready_byte_max;
 	p_prev_stat->counters.n_rx_ready_byte_drop = (p_curr_stat->counters.n_rx_ready_byte_drop - p_prev_stat->counters.n_rx_ready_byte_drop) / delay;

--- a/src/vma/sock/pipeinfo.cpp
+++ b/src/vma/sock/pipeinfo.cpp
@@ -78,6 +78,7 @@ pipeinfo::pipeinfo(int fd) : socket_fd_api(fd),
 	m_p_socket_stats->n_rx_ready_pkt_count = 0;
 	m_p_socket_stats->counters.n_rx_ready_pkt_max = 0;
 	m_p_socket_stats->n_rx_ready_byte_count = 0;
+	m_p_socket_stats->n_tx_ready_byte_count = 0;
 	m_p_socket_stats->counters.n_rx_ready_byte_max = 0;
 	m_p_socket_stats->n_rx_zcopy_pkt_count = 0;
 

--- a/src/vma/sock/sockinfo_tcp.cpp
+++ b/src/vma/sock/sockinfo_tcp.cpp
@@ -729,6 +729,7 @@ done:
 	if (total_tx) {
 		m_p_socket_stats->counters.n_tx_sent_byte_count += total_tx;
 		m_p_socket_stats->counters.n_tx_sent_pkt_count++;
+		m_p_socket_stats->n_tx_ready_byte_count += total_tx;
 	}
 
 	tcp_output(&m_pcb); // force data out
@@ -1209,13 +1210,15 @@ int sockinfo_tcp::handle_child_FIN(sockinfo_tcp* child_conn)
 
 err_t sockinfo_tcp::ack_recvd_lwip_cb(void *arg, struct tcp_pcb *tpcb, u16_t ack)
 {
-	NOT_IN_USE(ack);
-	NOT_IN_USE(tpcb);
 	sockinfo_tcp *conn = (sockinfo_tcp *)arg;
+
+	assert((uintptr_t)tpcb->my_container == (uintptr_t)arg);
 
 	vlog_func_enter();
 
 	ASSERT_LOCKED(conn->m_tcp_con_lock);
+
+	conn->m_p_socket_stats->n_tx_ready_byte_count -= ack;
 
 	// notify epoll
 	conn->notify_epoll_context(EPOLLOUT);
@@ -1229,13 +1232,14 @@ err_t sockinfo_tcp::rx_lwip_cb(void *arg, struct tcp_pcb *pcb,
                         struct pbuf *p, err_t err)
 {
 
+	sockinfo_tcp *conn = (sockinfo_tcp *)arg;
 	uint32_t bytes_to_tcp_recved, non_tcp_receved_bytes_remaining, bytes_to_shrink;
 	int rcv_buffer_space;
-	sockinfo_tcp *conn = (sockinfo_tcp *)pcb->my_container;
-	NOT_IN_USE(arg);
 
-	//vlog_printf(VLOG_ERROR, "%s:%d %s\n", __func__, __LINE__, "RX CB");
+	assert((uintptr_t)pcb->my_container == (uintptr_t)arg);
+
 	vlog_func_enter();
+
 	ASSERT_LOCKED(conn->m_tcp_con_lock);
 
 	//if is FIN

--- a/src/vma/util/vma_stats.h
+++ b/src/vma/util/vma_stats.h
@@ -226,6 +226,7 @@ typedef struct {
 	uint32_t		n_rx_ready_byte_count;
 	uint32_t 		n_rx_ready_byte_limit;
 	uint32_t		n_rx_zcopy_pkt_count;
+	uint32_t		n_tx_ready_byte_count;
 	socket_counters_t	counters;
 } socket_stats_t;
 


### PR DESCRIPTION
This PR add Recv-Q and Send-Q columns in output generated by vma_stats -v5
Where
Recv-Q
       The count of bytes not copied by the user program connected to this socket.
Send-Q
       The count of bytes not acknowledged by the remote host.

PR is spitted into two commits to look at the second commit carefully. It is not clear if one is excessive.
May be some possible cases are not covered by this change.

@rosenbaumalex @OphirMunk could you look at and comment.  