### PR TITLE
issue: 737508 Intenal thread TCP timer handling mode

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -167,6 +167,7 @@ Example:
  VMA DETAILS: Internal Thread Affinity       -1                         [VMA_INTERNAL_THREAD_AFFINITY]
  VMA DETAILS: Internal Thread Cpuset                                    [VMA_INTERNAL_THREAD_CPUSET]
  VMA DETAILS: Internal Thread Arm CQ         Disabled                   [VMA_INTERNAL_THREAD_ARM_CQ]
+ VMA DETAILS: Internal Thread TCP Handling   0 (deferred)               [VMA_INTERNAL_THREAD_TCP_TIMER_HANDLING]
  VMA DETAILS: Thread mode                    Multi spin lock            [VMA_THREAD_MODE]
  VMA DETAILS: Buffer batching mode           1 (Batch and reclaim buffers) [VMA_BUFFER_BATCHING_MODE]
  VMA DETAILS: Mem Allocate type              1 (Contig Pages)           [VMA_MEM_ALLOC_TYPE]
@@ -673,6 +674,14 @@ Select a cpuset for VMA internal thread (see man page of cpuset).
 The value is the path to the cpuset (for example: /dev/cpuset/my_set), or an empty
 string to run it on the same cpuset the process runs on.
 Default value is an empty string. 
+
+VMA_INTERNAL_THREAD_TCP_TIMER_HANDLING
+Select the internal thread policy when handling TCP timers 
+Use value of 0 for deferred handling. The internal thread will not handle TCP timers upon timer 
+expiration (once every 100ms) in order to let application threads handling it first
+Use value of 1 for immediate handling. The internal thread will try locking and handling TCP timers upon 
+timer expiration (once every 100ms).  Application threads may be blocked till internal thread finishes handling TCP timers
+Default value is 0 (deferred handling)
 
 VMA_INTERNAL_THREAD_ARM_CQ
 Wakeup the internal thread for each packet that the CQ recieve. 

--- a/src/vma/main.cpp
+++ b/src/vma/main.cpp
@@ -727,6 +727,7 @@ void print_vma_global_settings()
 	VLOG_STR_PARAM_STRING("Internal Thread Affinity", safe_mce_sys().internal_thread_affinity_str, MCE_DEFAULT_INTERNAL_THREAD_AFFINITY_STR, SYS_VAR_INTERNAL_THREAD_AFFINITY, safe_mce_sys().internal_thread_affinity_str);
 	VLOG_STR_PARAM_STRING("Internal Thread Cpuset", safe_mce_sys().internal_thread_cpuset, MCE_DEFAULT_INTERNAL_THREAD_CPUSET, SYS_VAR_INTERNAL_THREAD_CPUSET, safe_mce_sys().internal_thread_cpuset);
 	VLOG_PARAM_STRING("Internal Thread Arm CQ", safe_mce_sys().internal_thread_arm_cq_enabled, MCE_DEFAULT_INTERNAL_THREAD_ARM_CQ_ENABLED, SYS_VAR_INTERNAL_THREAD_ARM_CQ, safe_mce_sys().internal_thread_arm_cq_enabled ? "Enabled " : "Disabled");
+	VLOG_PARAM_NUMSTR("Internal Thread TCP Handling", safe_mce_sys().internal_thread_tcp_timer_handling, MCE_DEFAULT_INTERNAL_THREAD_TCP_TIMER_HANDLING, SYS_VAR_INTERNAL_THREAD_TCP_TIMER_HANDLING, internal_thread_tcp_timer_handling_str(safe_mce_sys().internal_thread_tcp_timer_handling));	
 	VLOG_PARAM_STRING("Thread mode", safe_mce_sys().thread_mode, MCE_DEFAULT_THREAD_MODE, SYS_VAR_THREAD_MODE, thread_mode_str(safe_mce_sys().thread_mode));
 	VLOG_PARAM_NUMSTR("Buffer batching mode", safe_mce_sys().buffer_batching_mode, MCE_DEFAULT_BUFFER_BATCHING_MODE, SYS_VAR_BUFFER_BATCHING_MODE, buffer_batching_mode_str(safe_mce_sys().buffer_batching_mode));
 	switch (safe_mce_sys().mem_alloc_type) {
@@ -890,7 +891,8 @@ void get_env_params()
 
 	safe_mce_sys().offloaded_sockets	= MCE_DEFAULT_OFFLOADED_SOCKETS;
 	safe_mce_sys().timer_resolution_msec	= MCE_DEFAULT_TIMER_RESOLUTION_MSEC;
-	safe_mce_sys().tcp_timer_resolution_msec	= MCE_DEFAULT_TCP_TIMER_RESOLUTION_MSEC;
+	safe_mce_sys().tcp_timer_resolution_msec= MCE_DEFAULT_TCP_TIMER_RESOLUTION_MSEC;
+	safe_mce_sys().internal_thread_tcp_timer_handling = MCE_DEFAULT_INTERNAL_THREAD_TCP_TIMER_HANDLING;
 	safe_mce_sys().tcp_ctl_thread		= MCE_DEFAULT_TCP_CTL_THREAD;
 	safe_mce_sys().tcp_ts_opt		= MCE_DEFAULT_TCP_TIMESTAMP_OPTION;
 //	safe_mce_sys().exception_handling is handled by its CTOR
@@ -1283,8 +1285,12 @@ void get_env_params()
 	if ((env_ptr = getenv(SYS_VAR_TIMER_RESOLUTION_MSEC)) != NULL)
 			safe_mce_sys().timer_resolution_msec = atoi(env_ptr);
 
-	if ((env_ptr = getenv(SYS_VAR_TCP_TIMER_RESOLUTION_MSEC)) != NULL) {
+	if ((env_ptr = getenv(SYS_VAR_TCP_TIMER_RESOLUTION_MSEC)) != NULL)
 			safe_mce_sys().tcp_timer_resolution_msec = atoi(env_ptr);
+
+	if ((env_ptr = getenv(SYS_VAR_INTERNAL_THREAD_TCP_TIMER_HANDLING)) != NULL) {
+			safe_mce_sys().internal_thread_tcp_timer_handling = 
+			atoi(env_ptr) == 1 ?  INTERNAL_THREAD_TCP_TIMER_HANDLING_IMMEDIATE : INTERNAL_THREAD_TCP_TIMER_HANDLING_DEFERRED;
 	}
 
 	if ((env_ptr = getenv(SYS_VAR_TCP_CTL_THREAD)) != NULL) {

--- a/src/vma/util/sys_vars.h
+++ b/src/vma/util/sys_vars.h
@@ -174,6 +174,21 @@ static inline const char* ctl_thread_str(tcp_ctl_thread_t logic)
 	return "unsupported";
 }
 
+typedef enum {
+	INTERNAL_THREAD_TCP_TIMER_HANDLING_DEFERRED = 0,
+	INTERNAL_THREAD_TCP_TIMER_HANDLING_IMMEDIATE
+} internal_thread_tcp_timer_handling_t;
+
+static inline const char* internal_thread_tcp_timer_handling_str(internal_thread_tcp_timer_handling_t handling)
+{
+	switch (handling) { 
+	case INTERNAL_THREAD_TCP_TIMER_HANDLING_DEFERRED: return "(deferred)";
+	case INTERNAL_THREAD_TCP_TIMER_HANDLING_IMMEDIATE: return "(immediate)";
+	default:					break;
+	}
+	return "unsupported";
+}
+
 ////////////////////////////////////////////////////////////////////////////////
 class vma_exception_handling
 {
@@ -359,6 +374,7 @@ struct mce_sys_var {
 	char		internal_thread_affinity_str[CPU_SETSIZE/4];
 	cpu_set_t	internal_thread_affinity;
 	bool		internal_thread_arm_cq_enabled;
+	internal_thread_tcp_timer_handling_t internal_thread_tcp_timer_handling;	
 	bool 		handle_bf;
 
 	bool 		enable_ipoib;
@@ -478,6 +494,7 @@ private:
 #define SYS_VAR_INTERNAL_THREAD_AFFINITY		"VMA_INTERNAL_THREAD_AFFINITY"
 #define SYS_VAR_INTERNAL_THREAD_CPUSET			"VMA_INTERNAL_THREAD_CPUSET"
 #define SYS_VAR_INTERNAL_THREAD_ARM_CQ			"VMA_INTERNAL_THREAD_ARM_CQ"
+#define SYS_VAR_INTERNAL_THREAD_TCP_TIMER_HANDLING	"VMA_INTERNAL_THREAD_TCP_TIMER_HANDLING"
 
 #define SYS_VAR_NETLINK_TIMER_MSEC			"VMA_NETLINK_TIMER"
 
@@ -584,6 +601,7 @@ private:
 #define MCE_DEFAULT_INTERNAL_THREAD_AFFINITY		(-1)
 #define MCE_DEFAULT_INTERNAL_THREAD_AFFINITY_STR	("-1")
 #define MCE_DEFAULT_INTERNAL_THREAD_CPUSET		("")
+#define MCE_DEFAULT_INTERNAL_THREAD_TCP_TIMER_HANDLING	(INTERNAL_THREAD_TCP_TIMER_HANDLING_DEFERRED)
 #define MCE_DEFAULT_NETLINK_TIMER_MSEC			(10000)
 
 #define MCE_DEFAULT_NEIGH_UC_ARP_QUATA			3


### PR DESCRIPTION
Add environment parameter VMA_INTERNAL_THREAD_TCP_TIMER_HANDLING
0 - deferred handling. The internal thread will not always handle TCP timer upon timer
expiration (once every 100ms) in order to let application threads handling it first if possible
1 - immediate handling. The internal thread will try locking and handle TCP timer upon
timer expiration (once every 100ms).
Default: 0 (deferred handling)

Signed-off-by: Ophir Munk <ophirmu@mellanox.com>