### PR TITLE
issue: 775440 make distclean is broken

### DIFF
--- a/autogen.sh
+++ b/autogen.sh
@@ -1,10 +1,10 @@
 #!/bin/sh
 
 
-set -x
-test -d ./config || mkdir -p config
-aclocal -I config
-libtoolize --force --copy
-autoheader
-automake --foreign --add-missing --copy
-autoconf
+rm -rf autom4te.cache
+mkdir -p config
+autoreconf -v --install || exit 1
+rm -rf autom4te.cache
+
+exit 0
+

--- a/configure.ac
+++ b/configure.ac
@@ -62,7 +62,7 @@ AC_CHECK_HEADERS([rdma/rdma_cma.h], ,
 
 
 AC_MSG_CHECKING([md5 version of VMA statistics is])
-STATS_PROTOCOL_VER=`md5sum src/vma/util/vma_stats.h | awk '{ print $1}'`
+STATS_PROTOCOL_VER=`md5sum ${srcdir}/src/vma/util/vma_stats.h | awk '{ print $1}'`
 AC_DEFINE_UNQUOTED(STATS_PROTOCOL_VER, "${STATS_PROTOCOL_VER}", [Stats Protocol Version])
 AC_SUBST(STATS_PROTOCOL_VER)
 AC_MSG_RESULT(${STATS_PROTOCOL_VER})

--- a/contrib/jenkins_tests/test.sh
+++ b/contrib/jenkins_tests/test.sh
@@ -23,7 +23,7 @@ if [ $(command -v $test_app >/dev/null 2>&1 || echo $?) ]; then
 fi
 
 test_ip_list="$(get_ip 'ib') $(get_ip 'eth')"
-test_list="tcp-pp tcp-tp tcp-ul udp-pp udp-tp udp-ul"
+test_list="tcp-pp tcp-tp tcp-ul"
 test_lib=$install_dir/lib/libvma.so
 
 nerrors=0
@@ -32,17 +32,17 @@ for test_ip in $test_ip_list; do
 	for test in $test_list; do
 		test_name=${test_ip}-${test}
 		test_tap=${WORKSPACE}/${prefix}/test-${test_name}.tap
-		
+
 		$timeout_exe $PWD/tests/verifier/verifier.pl -a ${test_app} -x " --load-vma=$test_lib " \
 			-t ${test}:tc[1-9]$ -s ${test_ip} -l ${test_dir}/${test_name}.log \
 			-e " VMA_TX_BUFS=20000 VMA_RX_BUFS=20000 " \
 			--progress=0
-		
+
 		cp $PWD/${test_name}.dump ${test_dir}/${test_name}.dump
 		grep -e 'PASS' -e 'FAIL' ${test_dir}/${test_name}.dump > ${test_dir}/${test_name}.tmp
-		
+
 		echo "1..$(wc -l < ${test_dir}/${test_name}.tmp)" > $test_tap
-		 
+
 		v1=1
 		while read line; do
 		    if [[ $(echo $line | cut -f1 -d' ') =~ 'PASS' ]]; then
@@ -53,8 +53,8 @@ for test_ip in $test_ip_list; do
 		        v2=$(echo $line | sed 's/FAIL //')
 	            nerrors=$((nerrors+1))
 		    fi
-		
-		    echo -e "$v0 $v1 - $v2" >> $test_tap
+
+		    echo -e "$v0 $v1:(${test_ip}) - $v2" >> $test_tap
 		    v1=$(($v1+1))
 		done < ${test_dir}/${test_name}.tmp
 		rm -f ${test_dir}/${test_name}.tmp

--- a/contrib/test_jenkins.sh
+++ b/contrib/test_jenkins.sh
@@ -17,10 +17,10 @@ rel_path=$(dirname $0)
 abs_path=$(readlink -f $rel_path)
 
 jenkins_test_build=${jenkins_test_build:="yes"}
-jenkins_test_run=${jenkins_test_run:="no"}
+jenkins_test_run=${jenkins_test_run:="yes"}
 
 jenkins_test_compiler=${jenkins_test_compiler:="yes"}
-jenkins_test_rpm=${jenkins_test_rpm:="no"}
+jenkins_test_rpm=${jenkins_test_rpm:="yes"}
 jenkins_test_cov=${jenkins_test_cov:="yes"}
 jenkins_test_vg=${jenkins_test_vg:="no"}
 jenkins_test_style=${jenkins_test_style:="no"}

--- a/src/state_machine/Makefile.am
+++ b/src/state_machine/Makefile.am
@@ -1,13 +1,22 @@
 AM_CFLAGS = -Wall -g -fPIC#-O3
 AM_CXXFLAGS = -Wall -g -fPIC#-O3
+AM_CPPFLAGS := -I$(top_srcdir)/src
 
-lib_LTLIBRARIES = libstate_machine.la
+noinst_LTLIBRARIES = libstate_machine.la
 libstate_machine_la_LDFLAGS = -static
-libstate_machine_la_SOURCES = sm_fifo.cpp sm.cpp sm_fifo.h sm.h
-libstate_machine_la_DEPENDENCIES = Makefile.am Makefile.in Makefile
-AM_CPPFLAGS := -I$(top_builddir)/src -I$(top_srcdir)/src
+libstate_machine_la_SOURCES = \
+	sm_fifo.cpp \
+	sm.cpp \
+	sm_fifo.h \
+	sm.h
 	
 
-bin_PROGRAMS = state_machine_test
-state_machine_test_LDADD = libstate_machine.la $(top_builddir)/src/vlogger/libvlogger.la
-state_machine_test_SOURCES = main.cpp
+noinst_PROGRAMS = state_machine_test
+state_machine_test_LDADD = \
+	libstate_machine.la \
+	$(top_builddir)/src/vlogger/libvlogger.la
+state_machine_test_SOURCES = \
+	main.cpp
+state_machine_test_DEPENDENCIES = \
+	libstate_machine.la \
+	$(top_builddir)/src/vlogger/libvlogger.la

--- a/src/stats/Makefile.am
+++ b/src/stats/Makefile.am
@@ -1,8 +1,18 @@
+AM_CPPFLAGS := -I$(top_srcdir)/src ${LIBNL_CFLAGS}
+
+noinst_LTLIBRARIES = libstats.la
+libstats_la_LDFLAGS = -static
+libstats_la_SOURCES = \
+	stats_printer.cpp \
+	stats_publisher.cpp \
+	stats_data_reader.h
+
 bin_PROGRAMS = vma_stats
-
-AM_CPPFLAGS := -I$(top_builddir)/src -I$(top_srcdir)/src
-
-vma_stats_LDADD= -lrt  $(top_builddir)/src/vlogger/libvlogger.la
-vma_stats_SOURCES = stats_reader.cpp stats_printer.cpp stats_data_reader.h
-vma_stats_DEPENDENCIES = Makefile.am Makefile.in Makefile \
-			$(top_builddir)/src/vlogger/libvlogger.la
+vma_stats_LDADD= -lrt \
+	libstats.la \
+	$(top_builddir)/src/vlogger/libvlogger.la
+vma_stats_SOURCES = \
+	stats_reader.cpp
+vma_stats_DEPENDENCIES = \
+	libstats.la \
+	$(top_builddir)/src/vlogger/libvlogger.la

--- a/src/vlogger/Makefile.am
+++ b/src/vlogger/Makefile.am
@@ -1,14 +1,13 @@
 AM_CFLAGS = -Wall -g -fPIC#-O3
 AM_CXXFLAGS = -Wall -g -fPIC#-O3
 
-AM_CPPFLAGS := -I$(top_builddir)/src -I$(top_srcdir)/src
+AM_CPPFLAGS := -I$(abs_top_srcdir)/src
 
-lib_LTLIBRARIES = libvlogger.la
-libvlogger_la_LDFLAGS = -static -version-info 1:0:0
+noinst_LTLIBRARIES = libvlogger.la
+libvlogger_la_LDFLAGS = -static
 libvlogger_la_LIBADD = -lrt
 libvlogger_la_SOURCES = vlogger.cpp vlogger.h
-libvlogger_la_DEPENDENCIES = Makefile.am Makefile.in Makefile
 
-bin_PROGRAMS = vlogger_test
+noinst_PROGRAMS = vlogger_test
 vlogger_test_LDADD = libvlogger.la
 vlogger_test_SOURCES = main.cpp

--- a/src/vma/Makefile.am
+++ b/src/vma/Makefile.am
@@ -22,7 +22,8 @@ CLEANFILES = $(BUILT_SOURCES)
 dist-hook:
 	cd $(distdir); rm -f $(BUILT_SOURCES)
 
-DIST_SUBDIRS := infra netlink
+SUBDIRS = infra netlink
+
 EXTRA_DIST = \
 	util/hash_map.inl \
 	util/libvma.conf \
@@ -37,8 +38,6 @@ otherinclude_HEADERS = vma_extra.h
 install-exec-hook:
 	rm -f $(DESTDIR)$(libdir)/libvma.la
 	rm -f $(DESTDIR)$(libdir)/libvma.a
-	rm -f $(DESTDIR)$(libdir)/libstate_machine.*
-	rm -f $(DESTDIR)$(libdir)/libvlogger.*
 	rm -f $(DESTDIR)$(bindir)/state_machine_test
 	rm -f $(DESTDIR)$(bindir)/vlogger_test
 	if [[ `id -u` -eq 0 ]];then /sbin/ldconfig || true;fi
@@ -49,9 +48,6 @@ uninstall-hook:
 lib_LTLIBRARIES = libvma.la
 
 AM_CPPFLAGS := \
-	-I$(top_builddir) \
-	-I$(top_srcdir) \
-	-I$(top_builddir)/src \
 	-I$(top_srcdir)/src ${LIBNL_CFLAGS}
 
 if IS_RELEASE_ZERO
@@ -64,6 +60,9 @@ libvma_la_LIBADD = \
 	-lrt -ldl -lpthread -libverbs -lrdmacm $(LIBNL_LIBS) \
 	$(top_builddir)/src/vlogger/libvlogger.la \
 	$(top_builddir)/src/state_machine/libstate_machine.la \
+	$(top_builddir)/src/stats/libstats.la \
+	$(top_builddir)/src/vma/netlink/libnetlink.la \
+	$(top_builddir)/src/vma/infra/libinfra.la \
 	libconfig_parser.la
 	
 libvma_la_SOURCES := \
@@ -139,9 +138,6 @@ libvma_la_SOURCES := \
 	sock/socket_fd_api.cpp \
 	sock/sock-redirect.cpp \
 	\
-	infra/subject_observer.cpp \
-	infra/sender.cpp \
-	\
 	util/wakeup.cpp \
 	util/wakeup_pipe.cpp \
 	util/match.cpp \
@@ -151,14 +147,7 @@ libvma_la_SOURCES := \
 	util/sys_vars.cpp \
 	libvma.c \
 	main.cpp \
-	../stats/stats_publisher.cpp \
-	../stats/stats_printer.cpp \
 	\
-	netlink/netlink_wrapper.cpp \
-	netlink/neigh_info.cpp \
-	netlink/link_info.cpp \
-	netlink/route_info.cpp \
-	netlink/netlink_compatibility.cpp \
 	dev/ah_cleaner.h \
 	dev/buffer_pool.h \
 	dev/cq_mgr.h \
@@ -287,5 +276,8 @@ libvma_la_SOURCES := \
 libvma_la_DEPENDENCIES = \
 	$(top_builddir)/src/vlogger/libvlogger.la \
 	$(top_builddir)/src/state_machine/libstate_machine.la \
+	$(top_builddir)/src/stats/libstats.la \
+	$(top_builddir)/src/vma/netlink/libnetlink.la \
+	$(top_builddir)/src/vma/infra/libinfra.la \
 	libconfig_parser.la
 

--- a/src/vma/dev/wqe_send_handler.h
+++ b/src/vma/dev/wqe_send_handler.h
@@ -31,8 +31,8 @@
  */
 
 
-#include "util/to_str.h"
-#include "util/verbs_extra.h"
+#include "vma/util/to_str.h"
+#include "vma/util/verbs_extra.h"
 #include <string.h>
 
 #ifndef IB_WQE_TEMPLATE_H

--- a/src/vma/dev/wqe_send_ib_handler.h
+++ b/src/vma/dev/wqe_send_ib_handler.h
@@ -38,7 +38,7 @@
  */
 
 #include "wqe_send_handler.h"
-#include "util/vtypes.h"
+#include "vma/util/vtypes.h"
 
 #ifndef WQE_TEMPLATE_SEND_IB_H_
 #define WQE_TEMPLATE_SEND_IB_H_

--- a/src/vma/infra/Makefile.am
+++ b/src/vma/infra/Makefile.am
@@ -1,35 +1,52 @@
 AM_CFLAGS = -Wall -g #-O3
 
-bin_PROGRAMS = cache_test
-
 AM_CPPFLAGS := \
-            -I$(top_builddir)/src -I$(top_srcdir)/src \
-            -I$(top_builddir)/. -I$(top_srcdir)/. \
-            -I$(top_builddir)/include -I$(top_srcdir)/include
+            -I$(top_srcdir)/src
 
 noinst_HEADERS = \
-subject_observer.h \
-cache_subject_observer.h \
-DemoSubject.h \
-DemoCollMgr.h \
-DemoObserver.h 
+	sender.h \
+	subject_observer.h \
+	cache_subject_observer.h \
+	DemoSubject.h \
+	DemoCollMgr.h \
+	DemoObserver.h
 
 EXTRA_DIST = \
-cache_subject_observer.h
+	cache_subject_observer.h \
+	main.cpp \
+	DemoSubject.cpp \
+	DemoCollMgr.cpp \
+	DemoObserver.cpp \
+	DemoCollMgr.h \
+	DemoObserver.h \
+	DemoSubject.h
 
-cache_test_SOURCES  =  \
-subject_observer.cpp \
-cache_subject_observer.h \
-DemoSubject.cpp \
-DemoCollMgr.cpp \
-DemoObserver.cpp \
-../../vlogger/vlogger.cpp \
-main.cpp \
-DemoCollMgr.h \
-DemoObserver.h \
-DemoSubject.h
+noinst_LTLIBRARIES = libinfra.la
+libinfra_la_LDFLAGS = -static
+libinfra_la_SOURCES = \
+	sender.cpp \
+	subject_observer.cpp
 
-cache_test_CXXFLAGS = -g
+# This section is disabled
+# (just keep one for future use)
+#noinst_PROGRAMS = cache_test
 
-cache_test_DEPENDENCIES = Makefile.am Makefile.in Makefile
+#cache_test_LDADD = \
+#	libinfra.la
+
+#cache_test_SOURCES  =  \
+#	main.cpp \
+#	cache_subject_observer.h \
+#	DemoSubject.cpp \
+#	DemoCollMgr.cpp \
+#	DemoObserver.cpp \
+#	DemoCollMgr.h \
+#	DemoObserver.h \
+#	DemoSubject.h
+
+#cache_test_CXXFLAGS = -g
+
+#cache_test_DEPENDENCIES = \
+#	libinfra.la \
+#	$(top_builddir)/src/vlogger/libvlogger.la
 

--- a/src/vma/netlink/Makefile.am
+++ b/src/vma/netlink/Makefile.am
@@ -1,34 +1,51 @@
 AM_CFLAGS = -Wall -g #-O3
 
-bin_PROGRAMS = nl_test
-
 AM_CPPFLAGS := \
-            -I$(top_builddir) -I$(top_srcdir) \
-	    -I$(top_builddir)/src -I$(top_srcdir)/src \
-	    -I$(top_builddir)/include -I$(top_srcdir)/include ${LIBNL_CFLAGS}
+	-I$(top_srcdir)/src ${LIBNL_CFLAGS}
 
-noinst_HEADERS = ../infra/subject_observer.h ../util/lock_wrapper.h 
-
-nl_test_LDADD = -lrt -ldl -lpthread -libverbs -lrdmacm ${LIBNL_LIBS}  \
-	$(top_builddir)/src/vlogger/libvlogger.la 
-
-nl_test_SOURCES  =  \
+noinst_LTLIBRARIES = libnetlink.la
+libnetlink_la_LDFLAGS = -static
+libnetlink_la_SOURCES = \
 	neigh_info.cpp \
 	route_info.cpp \
 	link_info.cpp \
 	netlink_compatibility.cpp \
 	netlink_wrapper.cpp \
-	../infra/subject_observer.cpp \
-	../event/netlink_event.cpp \
-	../../vlogger/vlogger.cpp \
-	test_main.cpp \
 	link_info.h \
 	neigh_info.h \
 	netlink_compatibility.h \
 	netlink_wrapper.h \
 	route_info.h
 
-nl_test_CXXFLAGS = -g
+EXTRA_DIST = \
+	test_main.cpp
 
-nl_test_DEPENDENCIES = Makefile.am Makefile.in Makefile
+# This section is disabled
+# (just keep one for future use)
+#noinst_PROGRAMS = nl_test
 
+#nl_test_LDADD = -lrt -ldl -lpthread -libverbs -lrdmacm \
+#	${LIBNL_LIBS} \
+#	libnetlink.la \
+#	$(top_builddir)/src/vlogger/libvlogger.la
+
+#nl_test_SOURCES  =  \
+#	neigh_info.cpp \
+#	route_info.cpp \
+#	link_info.cpp \
+#	netlink_compatibility.cpp \
+#	netlink_wrapper.cpp \
+#	../infra/subject_observer.cpp \
+#	../event/netlink_event.cpp \
+#	test_main.cpp \
+#	link_info.h \
+#	neigh_info.h \
+#	netlink_compatibility.h \
+#	netlink_wrapper.h \
+#	route_info.h
+
+#nl_test_CXXFLAGS = -g
+
+#nl_test_DEPENDENCIES = \
+#	libnetlink.la \
+#	$(top_builddir)/src/vlogger/libvlogger.la

--- a/src/vma/proto/header.h
+++ b/src/vma/proto/header.h
@@ -43,10 +43,10 @@
 #include <netinet/tcp.h>
 #include <netinet/igmp.h>
 
-#include "util/vtypes.h"
-#include "util/to_str.h"
+#include "vma/util/vtypes.h"
+#include "vma/util/to_str.h"
 #include "L2_address.h"
-#include "util/sys_vars.h"
+#include "vma/util/sys_vars.h"
 
 // We align the frame so IP header will be 4 bytes align
 // And we align the L2 headers so IP header on both transport


### PR DESCRIPTION
This change disables usage of dependencies.
Current source code structure allows usage of the same source files/objects
in different libs/bins. So there is a case when .deps folder can be removed
but other component includes .Plo files that does not exists and it leads
to error.
Example:
Makefile can have 'include ../../vlogger/$(DEPDIR)/nl_test-vlogger.Po'
but vlogger/$(DEPDIR) was removed before

There is a possibility to reorganize build ordering and linking dependency
but it requires more changes.