### PR TITLE
issue: 777063 Fixed: Use safe_mce_sys() calls instead of unsafe mce_sys calls

### DIFF
--- a/src/stats/stats_publisher.cpp
+++ b/src/stats/stats_publisher.cpp
@@ -176,7 +176,7 @@ void vma_shmem_stats_open(vlog_levels_t** p_p_vma_log_level, uint8_t** p_p_vma_l
 	}
 	BULLSEYE_EXCLUDE_BLOCK_END
 
-	shmem_size = SHMEM_STATS_SIZE(mce_sys.stats_fd_num_max);
+	shmem_size = SHMEM_STATS_SIZE(safe_mce_sys().stats_fd_num_max);
 	buf = malloc(shmem_size);
 	if (buf == NULL)
 		goto shmem_error;
@@ -184,12 +184,12 @@ void vma_shmem_stats_open(vlog_levels_t** p_p_vma_log_level, uint8_t** p_p_vma_l
 
 	p_shmem = buf;
 	
-	if (strlen(mce_sys.stats_shmem_dirname) <= 0)
+	if (strlen(safe_mce_sys().stats_shmem_dirname) <= 0)
 		goto no_shmem;
 
 	g_sh_mem_info.filename_sh_stats[0] = '\0';
 	g_sh_mem_info.p_sh_stats = MAP_FAILED;
-	sprintf(g_sh_mem_info.filename_sh_stats, "%s/vmastat.%d", mce_sys.stats_shmem_dirname, getpid());
+	sprintf(g_sh_mem_info.filename_sh_stats, "%s/vmastat.%d", safe_mce_sys().stats_shmem_dirname, getpid());
 	saved_mode = umask(0);
 	g_sh_mem_info.fd_sh_stats = open(g_sh_mem_info.filename_sh_stats, O_CREAT|O_RDWR, S_IRWXU | S_IRGRP | S_IWGRP | S_IROTH | S_IWOTH);
 	umask(saved_mode);
@@ -242,9 +242,9 @@ success:
 	
 	write_version_details_to_shmem(&g_sh_mem->ver_info);
 	memcpy(g_sh_mem->stats_protocol_ver, STATS_PROTOCOL_VER, min(sizeof(g_sh_mem->stats_protocol_ver), sizeof(STATS_PROTOCOL_VER)));
-	g_sh_mem->max_skt_inst_num = mce_sys.stats_fd_num_max;
+	g_sh_mem->max_skt_inst_num = safe_mce_sys().stats_fd_num_max;
         g_sh_mem->reader_counter = 0;
-	vlog_printf(VLOG_DEBUG, "%s: file '%s' fd %d shared memory at %p with %d max blocks\n", __func__, g_sh_mem_info.filename_sh_stats, g_sh_mem_info.fd_sh_stats, g_sh_mem_info.p_sh_stats, mce_sys.stats_fd_num_max);
+	vlog_printf(VLOG_DEBUG, "%s: file '%s' fd %d shared memory at %p with %d max blocks\n", __func__, g_sh_mem_info.filename_sh_stats, g_sh_mem_info.fd_sh_stats, g_sh_mem_info.p_sh_stats, safe_mce_sys().stats_fd_num_max);
 
 	// Update the shmem initial log values
 	g_sh_mem->log_level = **p_p_vma_log_level;
@@ -273,10 +273,10 @@ shmem_error:
 void vma_shmem_stats_close()
 {
 	if (g_sh_mem_info.p_sh_stats && g_sh_mem_info.p_sh_stats != MAP_FAILED) {
-		vlog_printf(VLOG_DEBUG, "%s: file '%s' fd %d shared memory at %p with %d max blocks\n", __func__, g_sh_mem_info.filename_sh_stats, g_sh_mem_info.fd_sh_stats, g_sh_mem_info.p_sh_stats, mce_sys.stats_fd_num_max);
+		vlog_printf(VLOG_DEBUG, "%s: file '%s' fd %d shared memory at %p with %d max blocks\n", __func__, g_sh_mem_info.filename_sh_stats, g_sh_mem_info.fd_sh_stats, g_sh_mem_info.p_sh_stats, safe_mce_sys().stats_fd_num_max);
 
 		BULLSEYE_EXCLUDE_BLOCK_START
-		if (munmap(g_sh_mem_info.p_sh_stats, SHMEM_STATS_SIZE(mce_sys.stats_fd_num_max)) != 0) {
+		if (munmap(g_sh_mem_info.p_sh_stats, SHMEM_STATS_SIZE(safe_mce_sys().stats_fd_num_max)) != 0) {
 			vlog_printf(VLOG_ERROR, "%s: file [%s] fd [%d] error while unmap shared memory at [%p]\n", __func__, g_sh_mem_info.filename_sh_stats, g_sh_mem_info.fd_sh_stats, g_sh_mem_info.p_sh_stats);
 		}
 		BULLSEYE_EXCLUDE_BLOCK_END
@@ -311,7 +311,7 @@ void vma_stats_instance_create_socket_block(socket_stats_t* local_stats_addr)
 		}
 
 	}
-	if (g_sh_mem->max_skt_inst_num + 1 < mce_sys.stats_fd_num_max) {
+	if (g_sh_mem->max_skt_inst_num + 1 < safe_mce_sys().stats_fd_num_max) {
 		// allocate next sh_mem block 
 		p_skt_stats = &g_sh_mem->skt_inst_arr[g_sh_mem->max_skt_inst_num].skt_stats;
 		g_sh_mem->skt_inst_arr[g_sh_mem->max_skt_inst_num].b_enabled = true;
@@ -321,7 +321,7 @@ void vma_stats_instance_create_socket_block(socket_stats_t* local_stats_addr)
 	else {
 		if (!printed_sock_limit_info) {
 			printed_sock_limit_info = true;
-			vlog_printf(VLOG_INFO, "Can only monitor %d socket in statistics - increase VMA_STATS_FD_NUM!\n", mce_sys.stats_fd_num_max);
+			vlog_printf(VLOG_INFO, "Can only monitor %d socket in statistics - increase VMA_STATS_FD_NUM!\n", safe_mce_sys().stats_fd_num_max);
 		}
 		goto out;
 	}

--- a/src/vma/dev/buffer_pool.cpp
+++ b/src/vma/dev/buffer_pool.cpp
@@ -103,7 +103,7 @@ buffer_pool::buffer_pool(size_t buffer_count, size_t buf_size, ib_ctx_handler *p
 	//
 	//Huge pages falls back to Contiguous pages that falls back to Anon (Malloc).
 	//
-	switch (mce_sys.mem_alloc_type) {
+	switch (safe_mce_sys().mem_alloc_type) {
 	case ALLOC_TYPE_HUGEPAGES:
 		if (!hugetlb_alloc(size)) {
 			__log_info_dbg("Failed allocating huge pages, falling back to contiguous pages");
@@ -233,7 +233,7 @@ bool buffer_pool::hugetlb_alloc(size_t sz_bytes)
 	if (m_shmid < 0) {
 
 		// Stop trying to use HugePage if failed even once
-		mce_sys.mem_alloc_type = ALLOC_TYPE_CONTIG;
+		safe_mce_sys().mem_alloc_type = ALLOC_TYPE_CONTIG;
 
 		vlog_printf(VLOG_WARNING, "***************************************************************\n");
 		vlog_printf(VLOG_WARNING, "* NO IMMEDIATE ACTION NEEDED!                                 *\n");

--- a/src/vma/dev/cq_mgr.cpp
+++ b/src/vma/dev/cq_mgr.cpp
@@ -160,7 +160,7 @@ inline uint32_t cq_mgr::process_recv_queue(void* pv_fd_ready_array)
 		mem_buf_desc_t* buff = m_rx_queue.front();
 		m_rx_queue.pop_front();
 		process_recv_buffer(buff, pv_fd_ready_array);
-		if (++processed >= mce_sys.cq_poll_batch_max)
+		if (++processed >= safe_mce_sys().cq_poll_batch_max)
 			break;
 	}
 	m_p_cq_stat->n_rx_sw_queue_len = m_rx_queue.size();
@@ -328,7 +328,7 @@ void cq_mgr::add_qp_rx(qp_mgr* qp)
 	uint32_t qp_rx_wr_num = qp->get_rx_max_wr_num();
 	cq_logdbg("Trying to push %d WRE to allocated qp (%p)", qp_rx_wr_num, qp);
 	while (qp_rx_wr_num) {
-		uint32_t n_num_mem_bufs = mce_sys.rx_num_wr_to_post_recv;
+		uint32_t n_num_mem_bufs = safe_mce_sys().rx_num_wr_to_post_recv;
 		if (n_num_mem_bufs > qp_rx_wr_num)
 			n_num_mem_bufs = qp_rx_wr_num;
 		p_temp_desc_list = g_buffer_pool_rx->get_buffers_thread_safe(n_num_mem_bufs, m_p_ib_ctx_handler);
@@ -384,11 +384,11 @@ bool cq_mgr::request_more_buffers()
 {
 	mem_buf_desc_t *p_temp_desc_list, *p_temp_buff;
 
-	cq_logfuncall("Allocating additional %d buffers for internal use", mce_sys.qp_compensation_level);
+	cq_logfuncall("Allocating additional %d buffers for internal use", safe_mce_sys().qp_compensation_level);
 
 	// Assume locked!
 	// Add an additional free buffer descs to RX cq mgr
-	p_temp_desc_list = g_buffer_pool_rx->get_buffers_thread_safe(mce_sys.qp_compensation_level, m_p_ib_ctx_handler);
+	p_temp_desc_list = g_buffer_pool_rx->get_buffers_thread_safe(safe_mce_sys().qp_compensation_level, m_p_ib_ctx_handler);
 	if (p_temp_desc_list == NULL) {
 		cq_logfunc("Out of mem_buf_desc from RX free pool for internal object pool");
 		return false;
@@ -408,9 +408,9 @@ bool cq_mgr::request_more_buffers()
 
 void cq_mgr::return_extra_buffers()
 {
-	if (m_rx_pool.size() < mce_sys.qp_compensation_level * 2)
+	if (m_rx_pool.size() < safe_mce_sys().qp_compensation_level * 2)
 		return;
-	int buff_to_rel = m_rx_pool.size() - mce_sys.qp_compensation_level;
+	int buff_to_rel = m_rx_pool.size() - safe_mce_sys().qp_compensation_level;
 
 	cq_logfunc("releasing %d buffers to global rx pool", buff_to_rel);
 	g_buffer_pool_rx->put_buffers_thread_safe(&m_rx_pool, buff_to_rel);
@@ -554,7 +554,7 @@ mem_buf_desc_t* cq_mgr::process_cq_element_rx(vma_ibv_wc* p_wce)
 		return NULL;
 	}
 
-	if (mce_sys.rx_prefetch_bytes_before_poll) {
+	if (safe_mce_sys().rx_prefetch_bytes_before_poll) {
 		/*for debug:
 		if (m_p_next_rx_desc_poll && m_p_next_rx_desc_poll != p_mem_buf_desc) {
 			cq_logerr("prefetched wrong buffer");
@@ -590,7 +590,7 @@ mem_buf_desc_t* cq_mgr::process_cq_element_rx(vma_ibv_wc* p_wce)
 		VALGRIND_MAKE_MEM_DEFINED(p_mem_buf_desc->p_buffer, p_mem_buf_desc->sz_data);
 
 		prefetch_range((uint8_t*)p_mem_buf_desc->p_buffer + m_sz_transport_header, 
-				min(p_mem_buf_desc->sz_data - m_sz_transport_header, (size_t)mce_sys.rx_prefetch_bytes));
+				min(p_mem_buf_desc->sz_data - m_sz_transport_header, (size_t)safe_mce_sys().rx_prefetch_bytes));
 		//prefetch((uint8_t*)p_mem_buf_desc->p_buffer + m_sz_transport_header);
 	}
 
@@ -603,7 +603,7 @@ bool cq_mgr::compensate_qp_poll_success(mem_buf_desc_t* buff_cur)
 	// Compensate QP for all completions that we found
 	if (likely(m_qp_rec.qp)) {
 		++m_qp_rec.debth;
-		if (likely(m_qp_rec.debth < (int)mce_sys.rx_num_wr_to_post_recv)) {
+		if (likely(m_qp_rec.debth < (int)safe_mce_sys().rx_num_wr_to_post_recv)) {
 			return false;
 		}
 		if (m_rx_pool.size() || request_more_buffers()) {
@@ -614,7 +614,7 @@ bool cq_mgr::compensate_qp_poll_success(mem_buf_desc_t* buff_cur)
 			} while (--m_qp_rec.debth > 0 && m_rx_pool.size());
 			m_p_cq_stat->n_buffer_pool_len = m_rx_pool.size();
 		}
-		else if (mce_sys.cq_keep_qp_full ||
+		else if (safe_mce_sys().cq_keep_qp_full ||
 				m_qp_rec.debth + MCE_MAX_CQ_POLL_BATCH > (int)m_qp_rec.qp->get_rx_max_wr_num()) {
 			m_p_cq_stat->n_rx_pkt_drop++;
 			post_recv_qp(&m_qp_rec, buff_cur);
@@ -704,19 +704,19 @@ int cq_mgr::poll_and_process_helper_rx(uint64_t* p_cq_poll_sn, void* pv_fd_ready
 
 	int ret;
 	uint32_t ret_rx_processed = process_recv_queue(pv_fd_ready_array);
-	if (unlikely(ret_rx_processed >= mce_sys.cq_poll_batch_max)) {
+	if (unlikely(ret_rx_processed >= safe_mce_sys().cq_poll_batch_max)) {
 		m_p_ring->m_gro_mgr.flush_all(pv_fd_ready_array);
 		return ret_rx_processed;
 	}
 
 	if (m_p_next_rx_desc_poll) {
-		prefetch_range((uint8_t*)m_p_next_rx_desc_poll->p_buffer,mce_sys.rx_prefetch_bytes_before_poll);
+		prefetch_range((uint8_t*)m_p_next_rx_desc_poll->p_buffer,safe_mce_sys().rx_prefetch_bytes_before_poll);
 	}
 
-	ret = poll(wce, mce_sys.cq_poll_batch_max, p_cq_poll_sn);
+	ret = poll(wce, safe_mce_sys().cq_poll_batch_max, p_cq_poll_sn);
 	if (ret > 0) {
 		m_n_wce_counter += ret;
-		if (ret < (int)mce_sys.cq_poll_batch_max)
+		if (ret < (int)safe_mce_sys().cq_poll_batch_max)
 			m_b_was_drained = true;
 
 		for (int i = 0; i < ret; i++) {
@@ -743,10 +743,10 @@ int cq_mgr::poll_and_process_helper_tx(uint64_t* p_cq_poll_sn)
 	// Assume locked!!!
 	cq_logfuncall("");
 	vma_ibv_wc wce[MCE_MAX_CQ_POLL_BATCH];
-	int ret = poll(wce, mce_sys.cq_poll_batch_max, p_cq_poll_sn);
+	int ret = poll(wce, safe_mce_sys().cq_poll_batch_max, p_cq_poll_sn);
 	if (ret > 0) {
 		m_n_wce_counter += ret;
-		if (ret < (int)mce_sys.cq_poll_batch_max)
+		if (ret < (int)safe_mce_sys().cq_poll_batch_max)
 			m_b_was_drained = true;
 
 		for (int i = 0; i < ret; i++) {
@@ -827,7 +827,7 @@ int cq_mgr::drain_and_proccess(bool b_recycle_buffers /*=false*/)
 	if (b_recycle_buffers)
 		m_b_was_drained = false;
 
-	while ((mce_sys.progress_engine_wce_max && (mce_sys.progress_engine_wce_max > m_n_wce_counter)) && 
+	while ((safe_mce_sys().progress_engine_wce_max && (safe_mce_sys().progress_engine_wce_max > m_n_wce_counter)) && 
 		!m_b_was_drained) {
 
 		vma_ibv_wc wce[MCE_MAX_CQ_POLL_BATCH];

--- a/src/vma/dev/cq_mgr.h
+++ b/src/vma/dev/cq_mgr.h
@@ -237,10 +237,10 @@ private:
 	//returns list of buffers to the owner.
 	void		process_tx_buffer_list(mem_buf_desc_t* p_mem_buf_desc);
 
-	// requests mce_sys.qp_compensation_level buffers from global pool
+	// requests safe_mce_sys().qp_compensation_level buffers from global pool
 	bool 		request_more_buffers() __attribute__((noinline));
 
-	// returns mce_sys.qp_compensation_level buffers to global pool
+	// returns safe_mce_sys().qp_compensation_level buffers to global pool
 	void 		return_extra_buffers() __attribute__((noinline));
 
 	// post-recv to a qp

--- a/src/vma/dev/ib_ctx_handler.cpp
+++ b/src/vma/dev/ib_ctx_handler.cpp
@@ -154,15 +154,15 @@ ibv_port_attr ib_ctx_handler::get_ibv_port_attr(int port_num)
 void ib_ctx_handler::set_dev_configuration()
 {
 	ibch_logdbg("Setting configuration for the MLX card %s", m_p_ibv_device->name);
-	m_conf_attr_rx_num_wre                  = mce_sys.rx_num_wr;
+	m_conf_attr_rx_num_wre                  = safe_mce_sys().rx_num_wr;
 	m_conf_attr_tx_num_post_send_notify     = NUM_TX_POST_SEND_NOTIFY;
-	m_conf_attr_tx_max_inline               = mce_sys.tx_max_inline;
-	m_conf_attr_tx_num_wre                  = mce_sys.tx_num_wr;
+	m_conf_attr_tx_max_inline               = safe_mce_sys().tx_max_inline;
+	m_conf_attr_tx_num_wre                  = safe_mce_sys().tx_num_wr;
 
 	if (m_conf_attr_tx_num_wre < (m_conf_attr_tx_num_post_send_notify * 2)) {
 		m_conf_attr_tx_num_wre = m_conf_attr_tx_num_post_send_notify * 2;
 		ibch_loginfo("%s Setting the %s to %d according to the device specific configuration:",
-			   m_p_ibv_device->name, SYS_VAR_TX_NUM_WRE, mce_sys.tx_num_wr);
+			   m_p_ibv_device->name, SYS_VAR_TX_NUM_WRE, safe_mce_sys().tx_num_wr);
 	}
 }
 

--- a/src/vma/dev/ib_ctx_time_converter.cpp
+++ b/src/vma/dev/ib_ctx_time_converter.cpp
@@ -251,7 +251,7 @@ ts_conversion_mode_t ib_ctx_time_converter::get_devices_convertor_status(struct 
 			"status for all devices [%d], ibv_context_list = %p\n", num_devices, ibv_context_list);
 	uint32_t devs_status = 0;
 #ifdef DEFINED_IBV_EXP_CQ_TIMESTAMP
-	if (mce_sys.rx_udp_hw_ts_conversion != TS_CONVERSION_MODE_DISABLE){
+	if (safe_mce_sys().rx_udp_hw_ts_conversion != TS_CONVERSION_MODE_DISABLE){
 		devs_status = IBV_EXP_QUERY_DEVICE_SUPPORTED | IBV_EXP_QUERY_VALUES_SUPPORTED;
 		for (int i = 0; i < num_devices; i++) {
 			devs_status &= get_device_convertor_status(ibv_context_list[i]);
@@ -259,7 +259,7 @@ ts_conversion_mode_t ib_ctx_time_converter::get_devices_convertor_status(struct 
 	}
 #endif
 
-	switch (mce_sys.rx_udp_hw_ts_conversion) {
+	switch (safe_mce_sys().rx_udp_hw_ts_conversion) {
 	case TS_CONVERSION_MODE_RAW:
 		ctx_time_conversion_mode = devs_status & IBV_EXP_QUERY_DEVICE_SUPPORTED ? TS_CONVERSION_MODE_RAW : TS_CONVERSION_MODE_DISABLE;
 		break;

--- a/src/vma/dev/net_device_table_mgr.cpp
+++ b/src/vma/dev/net_device_table_mgr.cpp
@@ -106,14 +106,14 @@ net_device_table_mgr::net_device_table_mgr() : cache_table_mgr<ip_address,net_de
 		throw_vma_exception_no_msg();
 	}
 
-	if (mce_sys.progress_engine_interval_msec != MCE_CQ_DRAIN_INTERVAL_DISABLED && mce_sys.progress_engine_wce_max != 0) {
-		ndtm_logdbg("registering timer for ring draining with %d msec intervales", mce_sys.progress_engine_interval_msec);
-		g_p_event_handler_manager->register_timer_event(mce_sys.progress_engine_interval_msec, this, PERIODIC_TIMER, (void*)RING_PROGRESS_ENGINE_TIMER);
+	if (safe_mce_sys().progress_engine_interval_msec != MCE_CQ_DRAIN_INTERVAL_DISABLED && safe_mce_sys().progress_engine_wce_max != 0) {
+		ndtm_logdbg("registering timer for ring draining with %d msec intervales", safe_mce_sys().progress_engine_interval_msec);
+		g_p_event_handler_manager->register_timer_event(safe_mce_sys().progress_engine_interval_msec, this, PERIODIC_TIMER, (void*)RING_PROGRESS_ENGINE_TIMER);
 	}
 
-	if (mce_sys.cq_aim_interval_msec != MCE_CQ_ADAPTIVE_MODERATION_DISABLED) {
-		ndtm_logdbg("registering timer for cq adaptive moderation with %d msec intervales", mce_sys.cq_aim_interval_msec);
-		g_p_event_handler_manager->register_timer_event(mce_sys.cq_aim_interval_msec, this, PERIODIC_TIMER, (void*)RING_ADAPT_CQ_MODERATION_TIMER);
+	if (safe_mce_sys().cq_aim_interval_msec != MCE_CQ_ADAPTIVE_MODERATION_DISABLED) {
+		ndtm_logdbg("registering timer for cq adaptive moderation with %d msec intervales", safe_mce_sys().cq_aim_interval_msec);
+		g_p_event_handler_manager->register_timer_event(safe_mce_sys().cq_aim_interval_msec, this, PERIODIC_TIMER, (void*)RING_ADAPT_CQ_MODERATION_TIMER);
 	}
 }
 
@@ -243,7 +243,7 @@ int net_device_table_mgr::map_net_devices()
 			continue;
 		}
 
-		if ((!mce_sys.enable_ipoib) && (get_iftype_from_ifname(ifa->ifa_name) == ARPHRD_INFINIBAND)) {
+		if ((!safe_mce_sys().enable_ipoib) && (get_iftype_from_ifname(ifa->ifa_name) == ARPHRD_INFINIBAND)) {
 			ndtm_logdbg("Blocking offload: IPoIB interfaces ('%s')", ifa->ifa_name);
 
 			// Close the cma_id which will not be offload

--- a/src/vma/dev/net_device_val.cpp
+++ b/src/vma/dev/net_device_val.cpp
@@ -138,8 +138,8 @@ void net_device_val::configure(struct ifaddrs* ifa, struct rdma_cm_id* cma_id)
 
 	m_if_idx        = if_nametoindex(m_name.c_str());
 	m_mtu           = get_if_mtu_from_ifname(m_name.c_str());
-	if (mce_sys.mtu != 0 && (int)mce_sys.mtu != m_mtu) {
-		nd_logwarn("Mismatch between interface %s MTU=%d and VMA_MTU=%d. Make sure VMA_MTU and all offloaded interfaces MTUs match.", m_name.c_str(), m_mtu, mce_sys.mtu);
+	if (safe_mce_sys().mtu != 0 && (int)safe_mce_sys().mtu != m_mtu) {
+		nd_logwarn("Mismatch between interface %s MTU=%d and VMA_MTU=%d. Make sure VMA_MTU and all offloaded interfaces MTUs match.", m_name.c_str(), m_mtu, safe_mce_sys().mtu);
 	}
 	m_local_addr    = ((struct sockaddr_in *)ifa->ifa_addr)->sin_addr.s_addr;
 	m_netmask       = ((struct sockaddr_in *)ifa->ifa_netmask)->sin_addr.s_addr;
@@ -560,7 +560,7 @@ bool net_device_val::release_ring(IN resource_allocation_key key)
 
 resource_allocation_key net_device_val::ring_key_redirection_reserve(IN resource_allocation_key key)
 {
-	if (!mce_sys.ring_limit_per_interface) return key;
+	if (!safe_mce_sys().ring_limit_per_interface) return key;
 
 	if (m_h_ring_key_redirection_map.find(key) != m_h_ring_key_redirection_map.end()) {
 		m_h_ring_key_redirection_map[key].second++;
@@ -570,7 +570,7 @@ resource_allocation_key net_device_val::ring_key_redirection_reserve(IN resource
 	}
 
 	int ring_map_size = (int)m_h_ring_map.size();
-	if (mce_sys.ring_limit_per_interface > ring_map_size) {
+	if (safe_mce_sys().ring_limit_per_interface > ring_map_size) {
 		m_h_ring_key_redirection_map[key] = std::make_pair(ring_map_size, 1);
 		nd_logdbg("redirecting key=%lu (ref-count:1) to key=%lu", key, ring_map_size);
 		return ring_map_size;
@@ -595,7 +595,7 @@ resource_allocation_key net_device_val::ring_key_redirection_release(IN resource
 {
 	resource_allocation_key ret_key = key;
 
-	if (!mce_sys.ring_limit_per_interface) return ret_key;
+	if (!safe_mce_sys().ring_limit_per_interface) return ret_key;
 
 	if (m_h_ring_key_redirection_map.find(key) == m_h_ring_key_redirection_map.end()) {
 		nd_logdbg("key = %lu is not found in the redirection map", key);

--- a/src/vma/dev/qp_mgr.cpp
+++ b/src/vma/dev/qp_mgr.cpp
@@ -65,7 +65,7 @@
 qp_mgr::qp_mgr(const ring_simple* p_ring, const ib_ctx_handler* p_context, const uint8_t port_num, const uint32_t tx_num_wr):
 	m_qp(NULL), m_p_ring((ring_simple*)p_ring), m_port_num((uint8_t)port_num), m_p_ib_ctx_handler((ib_ctx_handler*)p_context),
 	m_p_ahc_head(NULL), m_p_ahc_tail(NULL), m_max_inline_data(0), m_max_qp_wr(0), m_p_cq_mgr_rx(NULL), m_p_cq_mgr_tx(NULL),
-	m_rx_num_wr(mce_sys.rx_num_wr), m_tx_num_wr(tx_num_wr), m_rx_num_wr_to_post_recv(mce_sys.rx_num_wr_to_post_recv), 
+	m_rx_num_wr(safe_mce_sys().rx_num_wr), m_tx_num_wr(tx_num_wr), m_rx_num_wr_to_post_recv(safe_mce_sys().rx_num_wr_to_post_recv), 
 	m_curr_rx_wr(0), m_n_unsignaled_count(0), m_n_tx_count(0), m_p_last_tx_mem_buf_desc(NULL), m_p_prev_rx_desc_pushed(NULL),
 	m_n_ip_id_base(0), m_n_ip_id_offset(0)
 {
@@ -147,7 +147,7 @@ int qp_mgr::configure(struct ibv_comp_channel* p_rx_comp_event_channel)
 	memset(&qp_init_attr, 0, sizeof(qp_init_attr));
 
 	// Check device capabilities for max SG elements
-	uint32_t tx_max_inline = mce_sys.tx_max_inline;;
+	uint32_t tx_max_inline = safe_mce_sys().tx_max_inline;;
 	uint32_t rx_num_sge = MCE_DEFAULT_RX_NUM_SGE;
 
 	qp_init_attr.cap.max_send_wr = m_tx_num_wr;
@@ -447,7 +447,7 @@ int qp_mgr::post_recv(mem_buf_desc_t* p_mem_buf_desc)
 		next = p_mem_buf_desc->p_next_desc;
 		p_mem_buf_desc->p_next_desc = NULL;
 
-		if (mce_sys.rx_prefetch_bytes_before_poll) {
+		if (safe_mce_sys().rx_prefetch_bytes_before_poll) {
 			if (m_p_prev_rx_desc_pushed)
 				m_p_prev_rx_desc_pushed->p_prev_desc = p_mem_buf_desc;
 			m_p_prev_rx_desc_pushed = p_mem_buf_desc;

--- a/src/vma/dev/rfs_mc.cpp
+++ b/src/vma/dev/rfs_mc.cpp
@@ -92,7 +92,7 @@ void rfs_mc::prepare_flow_spec()
 						dst_mac,
 							htons(m_p_ring->m_p_qp_mgr->get_partiton()));
 
-			if (mce_sys.eth_mc_l2_only_rules) {
+			if (safe_mce_sys().eth_mc_l2_only_rules) {
 				ibv_flow_spec_ipv4_set(&(attach_flow_data_eth->ibv_flow_attr.ipv4), 0, 0);
 				ibv_flow_spec_tcp_udp_set(&(attach_flow_data_eth->ibv_flow_attr.tcp_udp), 0, 0, 0);
 				p_attach_flow_data = (attach_flow_data_t*)attach_flow_data_eth;

--- a/src/vma/dev/ring_allocation_logic.cpp
+++ b/src/vma/dev/ring_allocation_logic.cpp
@@ -64,7 +64,7 @@ resource_allocation_key ring_allocation_logic::get_res_key_by_logic()
 	switch (m_ring_allocation_logic) {
 	case RING_LOGIC_PER_INTERFACE:
 		key = 0;
-		if (mce_sys.tcp_ctl_thread > CTL_THREAD_DISABLE)
+		if (safe_mce_sys().tcp_ctl_thread > CTL_THREAD_DISABLE)
 			key = 1;
 		break;
 	case RING_LOGIC_PER_SOCKET:

--- a/src/vma/dev/ring_allocation_logic.h
+++ b/src/vma/dev/ring_allocation_logic.h
@@ -83,8 +83,8 @@ class ring_allocation_logic_rx : public ring_allocation_logic
 {
 public:
 	ring_allocation_logic_rx(int fd, const void* owner = NULL):
-		ring_allocation_logic(mce_sys.ring_allocation_logic_rx,
-				mce_sys.ring_migration_ratio_rx,
+		ring_allocation_logic(safe_mce_sys().ring_allocation_logic_rx,
+				safe_mce_sys().ring_migration_ratio_rx,
 				fd) { RAL_TOSTR(m_tostr, "Rx",owner); }
 };
 
@@ -92,8 +92,8 @@ class ring_allocation_logic_tx : public ring_allocation_logic
 {
 public:
 	ring_allocation_logic_tx(int fd, const void* owner = NULL):
-		ring_allocation_logic(mce_sys.ring_allocation_logic_tx,
-				mce_sys.ring_migration_ratio_tx,
+		ring_allocation_logic(safe_mce_sys().ring_allocation_logic_tx,
+				safe_mce_sys().ring_migration_ratio_tx,
 				fd) { RAL_TOSTR(m_tostr, "Tx",owner); }
 };
 

--- a/src/vma/dev/ring_bond.cpp
+++ b/src/vma/dev/ring_bond.cpp
@@ -142,10 +142,10 @@ void ring_bond::restart(ring_resource_creation_info_t* p_ring_info) {
 
 	if (m_type == net_device_val::ACTIVE_BACKUP) {
 		ring_simple* currently_active = m_active_rings[0];;
-		if (mce_sys.cq_moderation_enable) {
+		if (safe_mce_sys().cq_moderation_enable) {
 			currently_active->m_cq_moderation_info.period = previously_active->m_cq_moderation_info.period;
 			currently_active->m_cq_moderation_info.count = previously_active->m_cq_moderation_info.count;
-			currently_active->modify_cq_moderation(mce_sys.cq_moderation_period_usec, mce_sys.cq_moderation_count);
+			currently_active->modify_cq_moderation(safe_mce_sys().cq_moderation_period_usec, safe_mce_sys().cq_moderation_count);
 		}
 	}
 

--- a/src/vma/dev/ring_simple.cpp
+++ b/src/vma/dev/ring_simple.cpp
@@ -96,7 +96,7 @@ ring_simple::ring_simple(in_addr_t local_if, uint16_t partition_sn, int count, t
 	m_p_qp_mgr(NULL), m_p_cq_mgr_rx(NULL), m_p_cq_mgr_tx(NULL),
 	m_lock_ring_tx_buf_wait("ring:lock_tx_buf_wait"), m_tx_num_bufs(0), m_tx_num_wr(0), m_tx_num_wr_free(0),
 	m_b_qp_tx_first_flushed_completion_handled(false), m_missing_buf_ref_count(0),
-	m_tx_lkey(0), m_partition(partition_sn), m_gro_mgr(mce_sys.gro_streams_max, MAX_GRO_BUFS), m_up(false),
+	m_tx_lkey(0), m_partition(partition_sn), m_gro_mgr(safe_mce_sys().gro_streams_max, MAX_GRO_BUFS), m_up(false),
 	m_p_rx_comp_event_channel(NULL), m_p_tx_comp_event_channel(NULL), m_p_l2_addr(NULL), m_p_ring_stat(NULL),
 	m_local_if(local_if), m_transport_type(transport_type) {
 
@@ -209,7 +209,7 @@ void ring_simple::create_resources(ring_resource_creation_info_t* p_ring_info, b
 	// Check device capabilities for max QP work requests
 	vma_ibv_device_attr& r_ibv_dev_attr = p_ring_info->p_ib_ctx->get_ibv_device_attr();
 	uint32_t max_qp_wr = ALIGN_WR_DOWN(r_ibv_dev_attr.max_qp_wr - 1);
-	m_tx_num_wr = mce_sys.tx_num_wr;
+	m_tx_num_wr = safe_mce_sys().tx_num_wr;
 	if (m_tx_num_wr > max_qp_wr) {
 		ring_logwarn("Allocating only %d Tx QP work requests while user requested %s=%d for QP on interface %d.%d.%d.%d",
 			max_qp_wr, SYS_VAR_TX_NUM_WRE, m_tx_num_wr);
@@ -267,8 +267,8 @@ void ring_simple::create_resources(ring_resource_creation_info_t* p_ring_info, b
 	if (m_parent != this) {
 		m_ring_stat_static.p_ring_master = m_parent;
 	}
-	if (mce_sys.cq_moderation_enable) {
-		modify_cq_moderation(mce_sys.cq_moderation_period_usec, mce_sys.cq_moderation_count);
+	if (safe_mce_sys().cq_moderation_enable) {
+		modify_cq_moderation(safe_mce_sys().cq_moderation_period_usec, safe_mce_sys().cq_moderation_count);
 	}
 
 	vma_stats_instance_create_ring_block(m_p_ring_stat);
@@ -327,7 +327,7 @@ bool ring_simple::attach_flow(flow_tuple& flow_spec_5t, pkt_rcvr_sink *sink)
 		// It means that for every MC group, even if we have sockets with different ports - only one rule in the HW.
 		// So the hash map below keeps track of the number of sockets per rule so we know when to call ibv_attach and ibv_detach
 		rfs_rule_filter* l2_mc_ip_filter = NULL;
-		if (m_transport_type == VMA_TRANSPORT_IB || mce_sys.eth_mc_l2_only_rules) {
+		if (m_transport_type == VMA_TRANSPORT_IB || safe_mce_sys().eth_mc_l2_only_rules) {
 			rule_filter_map_t::iterator l2_mc_iter = m_l2_mc_ip_attach_map.find(key_udp_mc.dst_ip);
 			if (l2_mc_iter == m_l2_mc_ip_attach_map.end()) { // It means that this is the first time attach called with this MC ip
 				m_l2_mc_ip_attach_map[key_udp_mc.dst_ip].counter = 1;
@@ -338,7 +338,7 @@ bool ring_simple::attach_flow(flow_tuple& flow_spec_5t, pkt_rcvr_sink *sink)
 		p_rfs = m_flow_udp_mc_map.get(key_udp_mc, NULL);
 		if (p_rfs == NULL) {		// It means that no rfs object exists so I need to create a new one and insert it to the flow map
 			m_lock_ring_rx.unlock();
-			if (m_transport_type == VMA_TRANSPORT_IB || mce_sys.eth_mc_l2_only_rules) {
+			if (m_transport_type == VMA_TRANSPORT_IB || safe_mce_sys().eth_mc_l2_only_rules) {
 				l2_mc_ip_filter = new rfs_rule_filter(m_l2_mc_ip_attach_map, key_udp_mc.dst_ip, flow_spec_5t);
 			}
 			p_tmp_rfs = new rfs_mc(&flow_spec_5t, this, l2_mc_ip_filter);
@@ -360,7 +360,7 @@ bool ring_simple::attach_flow(flow_tuple& flow_spec_5t, pkt_rcvr_sink *sink)
 	} else if (flow_spec_5t.is_tcp()) {
 		flow_spec_tcp_key_t key_tcp = {flow_spec_5t.get_src_ip(), flow_spec_5t.get_dst_port(), flow_spec_5t.get_src_port()};
 		rfs_rule_filter* tcp_dst_port_filter = NULL;
-		if (mce_sys.tcp_3t_rules) {
+		if (safe_mce_sys().tcp_3t_rules) {
 			rule_filter_map_t::iterator tcp_dst_port_iter = m_tcp_dst_port_attach_map.find(key_tcp.dst_port);
 			if (tcp_dst_port_iter == m_tcp_dst_port_attach_map.end()) {
 				m_tcp_dst_port_attach_map[key_tcp.dst_port].counter = 1;
@@ -372,11 +372,11 @@ bool ring_simple::attach_flow(flow_tuple& flow_spec_5t, pkt_rcvr_sink *sink)
 		p_rfs = m_flow_tcp_map.get(key_tcp, NULL);
 		if (p_rfs == NULL) {		// It means that no rfs object exists so I need to create a new one and insert it to the flow map
 			m_lock_ring_rx.unlock();
-			if (mce_sys.tcp_3t_rules) {
+			if (safe_mce_sys().tcp_3t_rules) {
 				flow_tuple tcp_3t_only(flow_spec_5t.get_dst_ip(), flow_spec_5t.get_dst_port(), 0, 0, flow_spec_5t.get_protocol());
 				tcp_dst_port_filter = new rfs_rule_filter(m_tcp_dst_port_attach_map, key_tcp.dst_port, tcp_3t_only);
 			}
-			if(mce_sys.gro_streams_max && flow_spec_5t.is_5_tuple()) {
+			if(safe_mce_sys().gro_streams_max && flow_spec_5t.is_5_tuple()) {
 				p_tmp_rfs = new rfs_uc_tcp_gro(&flow_spec_5t, this, tcp_dst_port_filter);
 			} else {
 				p_tmp_rfs = new rfs_uc(&flow_spec_5t, this, tcp_dst_port_filter);
@@ -439,7 +439,7 @@ bool ring_simple::detach_flow(flow_tuple& flow_spec_5t, pkt_rcvr_sink* sink)
 	} else if (flow_spec_5t.is_udp_mc()) {
 		int keep_in_map = 1;
 		flow_spec_udp_mc_key_t key_udp_mc = {flow_spec_5t.get_dst_ip(), flow_spec_5t.get_dst_port()};
-		if (m_transport_type == VMA_TRANSPORT_IB || mce_sys.eth_mc_l2_only_rules) {
+		if (m_transport_type == VMA_TRANSPORT_IB || safe_mce_sys().eth_mc_l2_only_rules) {
 			rule_filter_map_t::iterator l2_mc_iter = m_l2_mc_ip_attach_map.find(key_udp_mc.dst_ip);
 			BULLSEYE_EXCLUDE_BLOCK_START
 			if (l2_mc_iter == m_l2_mc_ip_attach_map.end()) {
@@ -471,7 +471,7 @@ bool ring_simple::detach_flow(flow_tuple& flow_spec_5t, pkt_rcvr_sink* sink)
 	} else if (flow_spec_5t.is_tcp()) {
 		int keep_in_map = 1;
 		flow_spec_tcp_key_t key_tcp = {flow_spec_5t.get_src_ip(), flow_spec_5t.get_dst_port(), flow_spec_5t.get_src_port()};
-		if (mce_sys.tcp_3t_rules) {
+		if (safe_mce_sys().tcp_3t_rules) {
 			rule_filter_map_t::iterator tcp_dst_port_iter = m_tcp_dst_port_attach_map.find(key_tcp.dst_port);
 			BULLSEYE_EXCLUDE_BLOCK_START
 			if (tcp_dst_port_iter == m_tcp_dst_port_attach_map.end()) {
@@ -872,7 +872,7 @@ bool ring_simple::rx_process_buffer(mem_buf_desc_t* p_rx_wc_buf_desc, transport_
 		ring_logdbg("Rx IGMP packet info: type=%s (%d), group=%d.%d.%d.%d, code=%d",
 				priv_igmp_type_tostr(p_igmp_h->igmp_type), p_igmp_h->igmp_type,
 				NIPQUAD(p_igmp_h->igmp_group.s_addr), p_igmp_h->igmp_code);
-		if (transport_type == VMA_TRANSPORT_IB  || mce_sys.eth_mc_l2_only_rules) {
+		if (transport_type == VMA_TRANSPORT_IB  || safe_mce_sys().eth_mc_l2_only_rules) {
 			ring_logdbg("Transport type is IB (or eth_mc_l2_only_rules), passing igmp packet to igmp_manager to process");
 			if(g_p_igmp_mgr) {
 				(g_p_igmp_mgr->process_igmp_packet(p_ip_h, m_local_if));
@@ -1483,18 +1483,18 @@ void ring_simple::adapt_cq_moderation()
 
 	if (interval_packets == 0) {
 		// todo if no traffic, set moderation to default?
-		modify_cq_moderation(mce_sys.cq_moderation_period_usec, mce_sys.cq_moderation_count);
+		modify_cq_moderation(safe_mce_sys().cq_moderation_period_usec, safe_mce_sys().cq_moderation_count);
 		m_lock_ring_rx.unlock();
 		return;
 	}
 
 	uint32_t avg_packet_size = interval_bytes / interval_packets;
-	uint32_t avg_packet_rate = (interval_packets * 1000) / (mce_sys.cq_aim_interval_msec * (1 + missed_rounds));
+	uint32_t avg_packet_rate = (interval_packets * 1000) / (safe_mce_sys().cq_aim_interval_msec * (1 + missed_rounds));
 
-	uint32_t ir_rate = mce_sys.cq_aim_interrupts_rate_per_sec;
+	uint32_t ir_rate = safe_mce_sys().cq_aim_interrupts_rate_per_sec;
 
-	int count = MIN(avg_packet_rate / ir_rate, mce_sys.cq_aim_max_count);
-	int period = MIN(mce_sys.cq_aim_max_period_usec, ((1000000 / ir_rate) - (1000000 / MAX(avg_packet_rate, ir_rate))));
+	int count = MIN(avg_packet_rate / ir_rate, safe_mce_sys().cq_aim_max_count);
+	int period = MIN(safe_mce_sys().cq_aim_max_period_usec, ((1000000 / ir_rate) - (1000000 / MAX(avg_packet_rate, ir_rate))));
 
 	if (avg_packet_size < 1024 && avg_packet_rate < 450000) {
 		modify_cq_moderation(0, 0); //latency mode

--- a/src/vma/event/event_handler_manager.cpp
+++ b/src/vma/event/event_handler_manager.cpp
@@ -270,8 +270,8 @@ void* event_handler_thread(void *_p_tgtObject)
 	g_n_internal_thread_id = pthread_self();
 	evh_logdbg("Entering internal thread, id = %lu", g_n_internal_thread_id);
 
-	if (strcmp(mce_sys.internal_thread_cpuset, MCE_DEFAULT_INTERNAL_THREAD_CPUSET)) {
-		std::string tasks_file(mce_sys.internal_thread_cpuset);
+	if (strcmp(safe_mce_sys().internal_thread_cpuset, MCE_DEFAULT_INTERNAL_THREAD_CPUSET)) {
+		std::string tasks_file(safe_mce_sys().internal_thread_cpuset);
 		tasks_file += "/tasks";
 		FILE *fp = fopen(tasks_file.c_str(), "w");
 		BULLSEYE_EXCLUDE_BLOCK_START
@@ -283,11 +283,11 @@ void* event_handler_thread(void *_p_tgtObject)
 		}
 		BULLSEYE_EXCLUDE_BLOCK_END
 		fclose(fp);
-		evh_logdbg("VMA Internal thread added to cpuset %s.", mce_sys.internal_thread_cpuset);
+		evh_logdbg("VMA Internal thread added to cpuset %s.", safe_mce_sys().internal_thread_cpuset);
 
 		// do set affinity now that we are on correct cpuset
-		cpu_set_t cpu_set = mce_sys.internal_thread_affinity;
-		if ( strcmp(mce_sys.internal_thread_affinity_str, "-1")) {
+		cpu_set_t cpu_set = safe_mce_sys().internal_thread_affinity;
+		if ( strcmp(safe_mce_sys().internal_thread_affinity_str, "-1")) {
 			if (pthread_setaffinity_np(g_n_internal_thread_id, sizeof(cpu_set), &cpu_set)) {
 				evh_logdbg("VMA Internal thread affinity failed. Did you try to set affinity outside of cpuset?");
 			} else {
@@ -322,8 +322,8 @@ int event_handler_manager::start_thread()
 	}
 	BULLSEYE_EXCLUDE_BLOCK_END
 
-	cpu_set = mce_sys.internal_thread_affinity;
-	if ( strcmp(mce_sys.internal_thread_affinity_str, "-1") && !strcmp(mce_sys.internal_thread_cpuset, MCE_DEFAULT_INTERNAL_THREAD_CPUSET)) { // no affinity
+	cpu_set = safe_mce_sys().internal_thread_affinity;
+	if ( strcmp(safe_mce_sys().internal_thread_affinity_str, "-1") && !strcmp(safe_mce_sys().internal_thread_cpuset, MCE_DEFAULT_INTERNAL_THREAD_CPUSET)) { // no affinity
 		BULLSEYE_EXCLUDE_BLOCK_START
 		if (pthread_attr_setaffinity_np(&tattr, sizeof(cpu_set), &cpu_set)) {
 			evh_logpanic("Failed to set CPU affinity");
@@ -829,8 +829,8 @@ void* event_handler_manager::thread_loop()
 	poll_fd.revents = 0;
 	while (m_b_continue_running) {
 #ifdef VMA_TIME_MEASURE
-		if (g_inst_cnt >= mce_sys.vma_time_measure_num_samples)
-			finit_instrumentation(mce_sys.vma_time_measure_filename);
+		if (g_inst_cnt >= safe_mce_sys().vma_time_measure_num_samples)
+			finit_instrumentation(safe_mce_sys().vma_time_measure_filename);
 #endif
 
 		// update timer and get timeout
@@ -842,7 +842,7 @@ void* event_handler_manager::thread_loop()
 		}
 
 
-		if( mce_sys.internal_thread_arm_cq_enabled && m_cq_epfd == 0 && g_p_net_device_table_mgr) {
+		if( safe_mce_sys().internal_thread_arm_cq_enabled && m_cq_epfd == 0 && g_p_net_device_table_mgr) {
 			m_cq_epfd = g_p_net_device_table_mgr->global_ring_epfd_get();
 			if( m_cq_epfd > 0 ) {
 				epoll_event evt;
@@ -853,7 +853,7 @@ void* event_handler_manager::thread_loop()
 		}
 
 		uint64_t poll_sn = 0;
-		if( mce_sys.internal_thread_arm_cq_enabled && m_cq_epfd > 0 && g_p_net_device_table_mgr) {
+		if( safe_mce_sys().internal_thread_arm_cq_enabled && m_cq_epfd > 0 && g_p_net_device_table_mgr) {
 			g_p_net_device_table_mgr->global_ring_poll_and_process_element(&poll_sn, NULL);
 			int ret = g_p_net_device_table_mgr->global_ring_request_notification(poll_sn);
 			if (ret > 0) {
@@ -863,8 +863,8 @@ void* event_handler_manager::thread_loop()
 
 		// Make sure we sleep for a minimum of X milli seconds
 		if (timeout_msec > 0) {
-			if ((int)mce_sys.timer_resolution_msec > timeout_msec) {
-				timeout_msec = mce_sys.timer_resolution_msec;
+			if ((int)safe_mce_sys().timer_resolution_msec > timeout_msec) {
+				timeout_msec = safe_mce_sys().timer_resolution_msec;
 			}
 		}
 
@@ -878,7 +878,7 @@ void* event_handler_manager::thread_loop()
 
 		// check pipe
 		for (int idx = 0; idx < ret ; ++idx) {
-			if(mce_sys.internal_thread_arm_cq_enabled && p_events[idx].data.fd == m_cq_epfd && g_p_net_device_table_mgr){
+			if(safe_mce_sys().internal_thread_arm_cq_enabled && p_events[idx].data.fd == m_cq_epfd && g_p_net_device_table_mgr){
 				g_p_net_device_table_mgr->global_ring_wait_for_notification_and_process_element(&poll_sn, NULL);
 			}
 			else if (is_wakeup_fd(p_events[idx].data.fd)) {
@@ -915,7 +915,7 @@ void* event_handler_manager::thread_loop()
 
 			int fd = p_events[idx].data.fd;
 
-			if(mce_sys.internal_thread_arm_cq_enabled && fd == m_cq_epfd) continue;
+			if(safe_mce_sys().internal_thread_arm_cq_enabled && fd == m_cq_epfd) continue;
 
 			evh_logfunc("Processing fd %d", fd);
 

--- a/src/vma/iomux/epfd_info.cpp
+++ b/src/vma/iomux/epfd_info.cpp
@@ -650,7 +650,7 @@ int epfd_info::ring_poll_and_process_element(uint64_t *p_poll_sn, void* pv_fd_re
 
 	m_ring_map_lock.unlock();
 
-	if (mce_sys.thread_mode == THREAD_MODE_PLENTY && ret_total == 0 && errno == EBUSY) pthread_yield();
+	if (safe_mce_sys().thread_mode == THREAD_MODE_PLENTY && ret_total == 0 && errno == EBUSY) pthread_yield();
 
 	if (ret_total)
 		__log_func("ret_total=%d", ret_total);

--- a/src/vma/iomux/io_mux_call.cpp
+++ b/src/vma/iomux/io_mux_call.cpp
@@ -266,23 +266,23 @@ void io_mux_call::polling_loops()
 	 * In all other times, OS is never polled first (even if ratio is 1).
 	 */
 	if (--m_n_skip_os_count <= 0) {
-		m_n_skip_os_count = mce_sys.select_skip_os_fd_check;
+		m_n_skip_os_count = safe_mce_sys().select_skip_os_fd_check;
 		poll_os_countdown = 0;
 	} else {
-		poll_os_countdown = mce_sys.select_poll_os_ratio;
+		poll_os_countdown = safe_mce_sys().select_poll_os_ratio;
 	}
 
 	poll_counter = 0;
-	finite_polling = mce_sys.select_poll_num != -1;
-	multiple_polling_loops = mce_sys.select_poll_num != 0;
+	finite_polling = safe_mce_sys().select_poll_num != -1;
+	multiple_polling_loops = safe_mce_sys().select_poll_num != 0;
 
 	timeval poll_duration;
 	tv_clear(&poll_duration);
-	poll_duration.tv_usec = mce_sys.select_poll_num;
+	poll_duration.tv_usec = safe_mce_sys().select_poll_num;
 
 	__if_dbg("2nd scenario start");
 
-	if (mce_sys.select_handle_cpu_usage_stats) {
+	if (safe_mce_sys().select_handle_cpu_usage_stats) {
 		// handle polling cpu statistics
 		if (!tv_isset(&g_last_zero_polling_time)) {
 			// after first loop - set
@@ -300,14 +300,14 @@ void io_mux_call::polling_loops()
 		__log_funcall("2nd scenario loop %d", poll_counter);
 		__log_funcall("poll_os_countdown=%d, select_poll_os_ratio=%d, check_timer_countdown=%d, m_num_offloaded_rfds=%d,"
 		              "  m_n_all_ready_fds=%d, m_n_ready_rfds=%d, m_n_ready_wfds=%d, m_n_ready_efds=%d, multiple_polling_loops=%d",
-		              poll_os_countdown, mce_sys.select_poll_os_ratio, check_timer_countdown, *m_p_num_all_offloaded_fds,
+		              poll_os_countdown, safe_mce_sys().select_poll_os_ratio, check_timer_countdown, *m_p_num_all_offloaded_fds,
 		              m_n_all_ready_fds, m_n_ready_rfds, m_n_ready_wfds, m_n_ready_efds, multiple_polling_loops);
 
 		/*
 		* Poll OS when count down reaches zero. This honors CQ-OS ratio.
 		* This also handles the 0 ratio case - do not poll OS at all.
 		*/
-		if (poll_os_countdown-- == 0 && mce_sys.select_poll_os_ratio > 0) {
+		if (poll_os_countdown-- == 0 && safe_mce_sys().select_poll_os_ratio > 0) {
 			bool cq_ready = wait_os(true);
 			if (cq_ready) {
 				// This will empty the cqepfd
@@ -327,7 +327,7 @@ void io_mux_call::polling_loops()
 				check_all_offloaded_sockets(&m_poll_sn);
 				break;
 			}
-			poll_os_countdown = mce_sys.select_poll_os_ratio - 1;
+			poll_os_countdown = safe_mce_sys().select_poll_os_ratio - 1;
 		}
 
 		/*
@@ -374,7 +374,7 @@ void io_mux_call::polling_loops()
 		}
 	} while (m_n_all_ready_fds == 0 && multiple_polling_loops);
 
-	if (mce_sys.select_handle_cpu_usage_stats) {
+	if (safe_mce_sys().select_handle_cpu_usage_stats) {
         	// handle polling cpu statistics
 		gettime(&after_polling_timer);
 
@@ -474,7 +474,7 @@ int io_mux_call::call()
 
 	__log_funcall("");
 
-	if (!mce_sys.select_poll_os_force  // TODO: evaluate/consider this logic
+	if (!safe_mce_sys().select_poll_os_force  // TODO: evaluate/consider this logic
 			&& (*m_p_num_all_offloaded_fds == 0))
 	{
 		// 1st scenario

--- a/src/vma/iomux/select_call.cpp
+++ b/src/vma/iomux/select_call.cpp
@@ -156,7 +156,7 @@ select_call::select_call(int *off_fds_buffer, offloaded_mode_t *off_modes_buffer
 				}
 			}
 		}
-		if (! mce_sys.rx_offload_enabled) {
+		if (! safe_mce_sys().rx_offload_enabled) {
 			// reset counter once after the loop instead of 'if'ing N times in the loop
 			m_num_all_offloaded_fds = 0;
 		}
@@ -177,7 +177,7 @@ select_call::select_call(int *off_fds_buffer, offloaded_mode_t *off_modes_buffer
 				}
 			}
 		}
-		if (! mce_sys.tx_offload_enabled) {
+		if (! safe_mce_sys().tx_offload_enabled) {
 			// reset counter once after the loop instead of 'if'ing N times in the loop
 			m_num_offloaded_wfds = 0;
 		}

--- a/src/vma/proto/dst_entry_tcp.cpp
+++ b/src/vma/proto/dst_entry_tcp.cpp
@@ -183,7 +183,7 @@ ssize_t dst_entry_tcp::fast_send(const struct iovec* p_iov, const ssize_t sz_iov
 #endif
 
 	if (unlikely(m_p_tx_mem_buf_desc_list == NULL)) {
-		m_p_tx_mem_buf_desc_list = m_p_ring->mem_buf_tx_get(m_id, b_blocked, mce_sys.tx_bufs_batch_tcp);
+		m_p_tx_mem_buf_desc_list = m_p_ring->mem_buf_tx_get(m_id, b_blocked, safe_mce_sys().tx_bufs_batch_tcp);
 	}
 
 	return 0;
@@ -267,7 +267,7 @@ mem_buf_desc_t* dst_entry_tcp::get_buffer(bool b_blocked /*=false*/)
 
 	// Get a bunch of tx buf descriptor and data buffers
 	if (unlikely(m_p_tx_mem_buf_desc_list == NULL)) {
-		m_p_tx_mem_buf_desc_list = m_p_ring->mem_buf_tx_get(m_id, b_blocked, mce_sys.tx_bufs_batch_tcp);
+		m_p_tx_mem_buf_desc_list = m_p_ring->mem_buf_tx_get(m_id, b_blocked, safe_mce_sys().tx_bufs_batch_tcp);
 	}
 
 	mem_buf_desc_t* p_mem_buf_desc = m_p_tx_mem_buf_desc_list;

--- a/src/vma/proto/neighbour.cpp
+++ b/src/vma/proto/neighbour.cpp
@@ -344,7 +344,7 @@ void neigh_entry::handle_timer_expired(void* ctx)
 	if (state != NUD_REACHABLE) {
 		neigh_logdbg("State is different from NUD_REACHABLE and L2 address wasn't changed. Sending ARP");
 		send_arp();
-		m_timer_handle = priv_register_timer_event(mce_sys.neigh_wait_till_send_arp_msec, this, ONE_SHOT_TIMER, NULL);
+		m_timer_handle = priv_register_timer_event(safe_mce_sys().neigh_wait_till_send_arp_msec, this, ONE_SHOT_TIMER, NULL);
 	}
 	else {
 		neigh_logdbg("State is NUD_REACHABLE and L2 address wasn't changed. Stop sending ARP");
@@ -355,7 +355,7 @@ void neigh_entry::send_arp()
 {
 	// In case we already sent the quota number of unicast ARPs, start sending broadcast ARPs
 	// or we want to send broadcast ARP for the first time
-	bool is_broadcast = (m_arp_counter >= mce_sys.neigh_uc_arp_quata) || m_is_first_send_arp;
+	bool is_broadcast = (m_arp_counter >= safe_mce_sys().neigh_uc_arp_quata) || m_is_first_send_arp;
 	if (post_send_arp(is_broadcast)) {
 		m_is_first_send_arp = false;
 		m_arp_counter++;
@@ -688,7 +688,7 @@ void neigh_entry::handle_neigh_event(neigh_nl_event* nl_ev)
 		if(! ret ) {
 			//If L2 address wasn't changed we need to send ARP
 			send_arp();
-			m_timer_handle = priv_register_timer_event(mce_sys.neigh_wait_till_send_arp_msec, this, ONE_SHOT_TIMER, NULL);
+			m_timer_handle = priv_register_timer_event(safe_mce_sys().neigh_wait_till_send_arp_msec, this, ONE_SHOT_TIMER, NULL);
 		}
 		break;
 	}
@@ -1016,7 +1016,7 @@ int neigh_entry::priv_enter_addr_resolved()
 	if (!priv_get_neigh_state(state) || state != NUD_REACHABLE) {
 		neigh_logdbg("got addr_resolved but state=%d", state);
 		send_arp();
-		m_timer_handle = priv_register_timer_event(mce_sys.neigh_wait_till_send_arp_msec, this, ONE_SHOT_TIMER, NULL);
+		m_timer_handle = priv_register_timer_event(safe_mce_sys().neigh_wait_till_send_arp_msec, this, ONE_SHOT_TIMER, NULL);
 		m_lock.unlock();
 		return 0;
 	} else {
@@ -1088,7 +1088,7 @@ void neigh_entry::priv_enter_error()
 
 	m_lock.lock();
 	//If unsent queue is not empty we will try to KICK START the connection, but only once
-	if (!m_unsent_queue.empty() && (m_err_counter < mce_sys.neigh_num_err_retries)) {
+	if (!m_unsent_queue.empty() && (m_err_counter < safe_mce_sys().neigh_num_err_retries)) {
 		neigh_logdbg("unsent_queue is not empty calling KICK_START");
 		m_err_counter++;
 		event_handler(EV_KICK_START);
@@ -1118,7 +1118,7 @@ int neigh_entry::priv_enter_ready()
 	if (m_type == UC && ! m_is_loopback) {
 		if (priv_get_neigh_state(state) && (state != NUD_REACHABLE)) {
 			send_arp();
-			m_timer_handle = priv_register_timer_event(mce_sys.neigh_wait_till_send_arp_msec, this, ONE_SHOT_TIMER, NULL);
+			m_timer_handle = priv_register_timer_event(safe_mce_sys().neigh_wait_till_send_arp_msec, this, ONE_SHOT_TIMER, NULL);
 		}
 	}
 	m_lock.unlock();
@@ -1903,7 +1903,7 @@ int neigh_ib::build_mc_neigh_val(struct rdma_cm_event* event_data,
 	/*neigh_logerr("flow_label = %#x, sgid_index=%#x, hop_limit=%#x, traffic_class=%#x", ((neigh_ib_val *) m_val)->m_ah_attr.grh.flow_label, ((neigh_ib_val *) m_val)->m_ah_attr.grh.sgid_index,
 				((neigh_ib_val *) m_val)->m_ah_attr.grh.hop_limit, ((neigh_ib_val *) m_val)->m_ah_attr.grh.traffic_class);
 	*/
-	wait_after_join_msec = mce_sys.wait_after_join_msec;
+	wait_after_join_msec = safe_mce_sys().wait_after_join_msec;
 
 	return 0;
 }

--- a/src/vma/proto/vma_lwip.cpp
+++ b/src/vma/proto/vma_lwip.cpp
@@ -98,7 +98,7 @@ u32_t vma_lwip::sys_now(void)
 
 u8_t vma_lwip::read_tcp_timestamp_option(void)
 {
-	u8_t res = (mce_sys.tcp_ts_opt == TCP_TS_OPTION_FOLLOW_OS) ? mce_sys.sysctl_reader.get_net_ipv4_tcp_timestamps() : (mce_sys.tcp_ts_opt == TCP_TS_OPTION_ENABLE ? 1 : 0);
+	u8_t res = (safe_mce_sys().tcp_ts_opt == TCP_TS_OPTION_FOLLOW_OS) ? safe_mce_sys().sysctl_reader.get_net_ipv4_tcp_timestamps() : (safe_mce_sys().tcp_ts_opt == TCP_TS_OPTION_ENABLE ? 1 : 0);
 	if (res) {
 #if LWIP_TCP_TIMESTAMPS
 		lwip_logdbg("TCP timestamp option has been enabled");
@@ -125,16 +125,16 @@ vma_lwip::vma_lwip() : lock_spin_recursive("vma_lwip")
 
 	lwip_logdbg("");
 
-	lwip_cc_algo_module = (enum cc_algo_mod)mce_sys.lwip_cc_algo_mod;
+	lwip_cc_algo_module = (enum cc_algo_mod)safe_mce_sys().lwip_cc_algo_mod;
 
-	lwip_tcp_mss = get_lwip_tcp_mss(mce_sys.mtu, mce_sys.lwip_mss);
+	lwip_tcp_mss = get_lwip_tcp_mss(safe_mce_sys().mtu, safe_mce_sys().lwip_mss);
 	BULLSEYE_EXCLUDE_BLOCK_END
 
 	enable_ts_option = read_tcp_timestamp_option();
-	int is_window_scaling_enabled = mce_sys.sysctl_reader.get_tcp_window_scaling();
+	int is_window_scaling_enabled = safe_mce_sys().sysctl_reader.get_tcp_window_scaling();
 	if(is_window_scaling_enabled) {
-		int rmem_max_value = mce_sys.sysctl_reader.get_tcp_rmem()->max_value;
-		int core_rmem_max = mce_sys.sysctl_reader.get_net_core_rmem_max();
+		int rmem_max_value = safe_mce_sys().sysctl_reader.get_tcp_rmem()->max_value;
+		int core_rmem_max = safe_mce_sys().sysctl_reader.get_net_core_rmem_max();
 		enable_wnd_scale = 1;
 		rcv_wnd_scale = get_window_scaling_factor(rmem_max_value, core_rmem_max);
 	} else {
@@ -156,7 +156,7 @@ vma_lwip::vma_lwip() : lock_spin_recursive("vma_lwip")
 	register_sys_now(sys_now);
 
 	//tcp_ticks increases in the rate of tcp slow_timer
-	void *node = g_p_event_handler_manager->register_timer_event(mce_sys.tcp_timer_resolution_msec * 2, this, PERIODIC_TIMER, 0);
+	void *node = g_p_event_handler_manager->register_timer_event(safe_mce_sys().tcp_timer_resolution_msec * 2, this, PERIODIC_TIMER, 0);
 	if (!node) {
 		lwip_logdbg("LWIP: failed to register timer event");
 		free_lwip_resources();
@@ -229,10 +229,10 @@ uint32_t get_lwip_tcp_mss(uint32_t mtu, uint32_t lwip_mss)
 
 	/*	
 	 * lwip_tcp_mss calculation
-	 * 1. mce_sys.mtu==0 && mce_sys.lwip_mss==0 ==> lwip_tcp_mss = 0 (namelyl-must be calculated per interface)
-	 * 2. mce_sys.mtu==0 && mce_sys.lwip_mss!=0 ==> lwip_tcp_mss = mce_sys.lwip_mss
-	 * 3. mce_sys.mtu!=0 && mce_sys.lwip_mss==0 ==> lwip_tcp_mss = mce_sys.mtu - IP header len - TCP header len (must be positive)
-	 * 4. mce_sys.mtu!=0 && mce_sys.lwip_mss!=0 ==> lwip_tcp_mss = mce_sys.lwip_mss
+	 * 1. safe_mce_sys().mtu==0 && safe_mce_sys().lwip_mss==0 ==> lwip_tcp_mss = 0 (namelyl-must be calculated per interface)
+	 * 2. safe_mce_sys().mtu==0 && safe_mce_sys().lwip_mss!=0 ==> lwip_tcp_mss = safe_mce_sys().lwip_mss
+	 * 3. safe_mce_sys().mtu!=0 && safe_mce_sys().lwip_mss==0 ==> lwip_tcp_mss = safe_mce_sys().mtu - IP header len - TCP header len (must be positive)
+	 * 4. safe_mce_sys().mtu!=0 && safe_mce_sys().lwip_mss!=0 ==> lwip_tcp_mss = safe_mce_sys().lwip_mss
 	 */
 	switch (lwip_mss) {
 	case MSS_FOLLOW_MTU: /* 0 */

--- a/src/vma/sock/fd_collection.cpp
+++ b/src/vma/sock/fd_collection.cpp
@@ -255,7 +255,7 @@ int fd_collection::addsocket(int fd, int domain, int type, bool check_offload /*
 	try {
 		switch (sock_type) {
 			case SOCK_DGRAM:
-			{	transport = __vma_match_by_program(PROTO_UDP, mce_sys.app_id);
+			{	transport = __vma_match_by_program(PROTO_UDP, safe_mce_sys().app_id);
 				if (transport == TRANS_OS) {
 					fdcoll_logdbg("All UDP rules are consistent and instructing to use OS. TRANSPORT: OS");
 					return -1;
@@ -266,7 +266,7 @@ int fd_collection::addsocket(int fd, int domain, int type, bool check_offload /*
 			}
 			case SOCK_STREAM:
 			{
-				transport = __vma_match_by_program(PROTO_TCP, mce_sys.app_id);
+				transport = __vma_match_by_program(PROTO_TCP, safe_mce_sys().app_id);
 				if (transport == TRANS_OS) {
 					fdcoll_logdbg("All TCP rules are consistent and instructing to use OS.transport == USE_OS");
 					return -1;
@@ -307,7 +307,7 @@ int fd_collection::addsocket(int fd, int domain, int type, bool check_offload /*
 
 bool fd_collection::create_offloaded_sockets()
 {
-	bool ret = mce_sys.offloaded_sockets;
+	bool ret = safe_mce_sys().offloaded_sockets;
 
 	lock();
 	if (m_offload_thread_rule.find(pthread_self()) == m_offload_thread_rule.end()) {
@@ -328,7 +328,7 @@ void fd_collection::offloading_rule_change_thread(bool offloaded, pthread_t tid)
 	fdcoll_logdbg("tid=%ul, offloaded=%d", tid, offloaded);
 
 	lock();
-	if (offloaded == mce_sys.offloaded_sockets) {
+	if (offloaded == safe_mce_sys().offloaded_sockets) {
 		m_offload_thread_rule.erase(tid);
 	} else {
 		m_offload_thread_rule[tid] = 1;

--- a/src/vma/sock/fd_collection.h
+++ b/src/vma/sock/fd_collection.h
@@ -169,7 +169,7 @@ private:
 	rdma_event_channel* 		m_p_cma_event_channel;
 	void*				m_timer_handle;
 
-	//if (mce_sys.offloaded_sockets is true) contain all threads that need not be offloaded.
+	//if (safe_mce_sys().offloaded_sockets is true) contain all threads that need not be offloaded.
 	//else contain all threads that need to be offloaded.
 	offload_thread_rule_t		m_offload_thread_rule;
 

--- a/src/vma/sock/pipeinfo.cpp
+++ b/src/vma/sock/pipeinfo.cpp
@@ -219,19 +219,19 @@ ssize_t pipeinfo::tx(const tx_call_t call_type, const iovec* p_iov, const ssize_
 	switch (call_type) {
 	case  TX_WRITE:
 
-		if ((mce_sys.mce_spec == MCE_SPEC_29WEST_LBM_29 || mce_sys.mce_spec == MCE_SPEC_WOMBAT_FH_LBM_554) && 
+		if ((safe_mce_sys().mce_spec == MCE_SPEC_29WEST_LBM_29 || safe_mce_sys().mce_spec == MCE_SPEC_WOMBAT_FH_LBM_554) && 
 		    (p_iov[0].iov_len == 1) && (((char*)p_iov[0].iov_base)[0] == '\0')) {
 
 			// We will pass one pipe write in every T usec
 			//
 			// 1) First signaling pipe write will go through, and triger timer logic
-			// 2) Then we'll send a single pipe writes every T usec (mce_sys.mce_spec_param1)
+			// 2) Then we'll send a single pipe writes every T usec (safe_mce_sys().mce_spec_param1)
 			// 3) We'll stop the timer once we have N cycles with no pipe write
 			//
 
 			m_write_count++;
 			if (m_b_lbm_event_q_pipe_timer_on == false) {
-				m_timer_handle = g_p_event_handler_manager->register_timer_event(mce_sys.mce_spec_param1/1000, this, PERIODIC_TIMER, 0);
+				m_timer_handle = g_p_event_handler_manager->register_timer_event(safe_mce_sys().mce_spec_param1/1000, this, PERIODIC_TIMER, 0);
 				m_b_lbm_event_q_pipe_timer_on = true;
 				m_write_count_on_last_timer = 0;
 				m_write_count_no_change_count = 0;
@@ -241,7 +241,7 @@ ssize_t pipeinfo::tx(const tx_call_t call_type, const iovec* p_iov, const ssize_
 				// simulate a pipe_write
 				write_lbm_pipe_enhance();
 			}
-			else if ((int)m_write_count > (int)(m_write_count_on_last_timer + mce_sys.mce_spec_param2)) {
+			else if ((int)m_write_count > (int)(m_write_count_on_last_timer + safe_mce_sys().mce_spec_param2)) {
 				// simulate a pipe_write
 				write_lbm_pipe_enhance();
 			}

--- a/src/vma/sock/sock-redirect.cpp
+++ b/src/vma/sock/sock-redirect.cpp
@@ -1704,8 +1704,8 @@ int pipe(int __filedes[2])
 	if (!orig_os_api.pipe)	get_orig_funcs();
 	BULLSEYE_EXCLUDE_BLOCK_END
 
-	bool offload_pipe = mce_sys.mce_spec == MCE_SPEC_29WEST_LBM_29 ||
-			    mce_sys.mce_spec == MCE_SPEC_WOMBAT_FH_LBM_554;
+	bool offload_pipe = safe_mce_sys().mce_spec == MCE_SPEC_29WEST_LBM_29 ||
+			    safe_mce_sys().mce_spec == MCE_SPEC_WOMBAT_FH_LBM_554;
 	if (offload_pipe)
 		do_global_ctors();
 
@@ -1791,7 +1791,7 @@ int dup2(int __fd, int __fd2)
 	if (!orig_os_api.dup2) get_orig_funcs();
 	BULLSEYE_EXCLUDE_BLOCK_END
 
-	if (mce_sys.close_on_dup2 && __fd != __fd2) {
+	if (safe_mce_sys().close_on_dup2 && __fd != __fd2) {
 		srdr_logdbg("oldfd=%d, newfd=%d. Closing %d in VMA.\n", __fd, __fd2, __fd2);
 		handle_close(__fd2);
 	}
@@ -1851,7 +1851,7 @@ pid_t fork(void)
 		sock_redirect_exit();
 
 		get_env_params();
-		vlog_start("VMA", mce_sys.log_level, mce_sys.log_filename, mce_sys.log_details, mce_sys.log_colors);
+		vlog_start("VMA", safe_mce_sys().log_level, safe_mce_sys().log_filename, safe_mce_sys().log_details, safe_mce_sys().log_colors);
 		srdr_logdbg_exit("Child Process: starting with %d", getpid());
 		g_is_forked_child = false;
 		sock_redirect_main();
@@ -1904,7 +1904,7 @@ int daemon(int __nochdir, int __noclose)
 		sock_redirect_exit();
 
 		get_env_params();
-		vlog_start("VMA", mce_sys.log_level, mce_sys.log_filename, mce_sys.log_details, mce_sys.log_colors);
+		vlog_start("VMA", safe_mce_sys().log_level, safe_mce_sys().log_filename, safe_mce_sys().log_details, safe_mce_sys().log_colors);
 		srdr_logdbg_exit("Child Process: starting with %d", getpid());
 		g_is_forked_child = false;
 		sock_redirect_main();
@@ -1938,7 +1938,7 @@ int sigaction(int signum, const struct sigaction *act, struct sigaction *oldact)
 
 	if (!orig_os_api.sigaction) get_orig_funcs();
 
-	if (mce_sys.handle_sigintr) {
+	if (safe_mce_sys().handle_sigintr) {
 		srdr_logdbg_entry("signum=%d, act=%p, oldact=%p", signum, act, oldact);
 
 		switch (signum) {
@@ -1974,7 +1974,7 @@ int sigaction(int signum, const struct sigaction *act, struct sigaction *oldact)
 	}
 	ret = orig_os_api.sigaction(signum, act, oldact);
 
-	if (mce_sys.handle_sigintr) {
+	if (safe_mce_sys().handle_sigintr) {
 		if (ret >= 0)
 			srdr_logdbg_exit("returned with %d", ret);
 		else

--- a/src/vma/sock/socket_fd_api.h
+++ b/src/vma/sock/socket_fd_api.h
@@ -173,8 +173,8 @@ public:
 	virtual int get_fd( ) const { return m_fd; };
 
 	// true if fd must be skipped from OS select()
-	// If mce_sys.rx_udp_poll_os_ratio == 0, it means that user configured VMA not to poll os (i.e. TRUE...)
-	virtual bool skip_os_select() { return (!(mce_sys.select_poll_os_ratio)); };
+	// If safe_mce_sys().rx_udp_poll_os_ratio == 0, it means that user configured VMA not to poll os (i.e. TRUE...)
+	virtual bool skip_os_select() { return (!(safe_mce_sys().select_poll_os_ratio)); };
 
 #if _BullseyeCoverage
     #pragma BullseyeCoverage off

--- a/src/vma/sock/sockinfo.cpp
+++ b/src/vma/sock/sockinfo.cpp
@@ -73,7 +73,7 @@ sockinfo::sockinfo(int fd) throw (vma_exception):
 		m_rx_ring_map_lock(MODULE_NAME "::m_rx_ring_map_lock"),
 		m_ring_alloc_logic(fd, this),
 		m_n_rx_pkt_ready_list_count(0), m_rx_pkt_ready_offset(0), m_rx_ready_byte_count(0),
-		m_rx_num_buffs_reuse(mce_sys.rx_bufs_batch),
+		m_rx_num_buffs_reuse(safe_mce_sys().rx_bufs_batch),
 		m_rx_callback(NULL),
 		m_rx_callback_context(NULL)
 {
@@ -146,7 +146,7 @@ int sockinfo::fcntl(int __cmd, unsigned long int __arg) throw (vma_error)
 		snprintf(buf, sizeof(buf), "unimplemented fcntl cmd=%#x, arg=%#x", (unsigned)__cmd, (unsigned)__arg);
 		buf[ sizeof(buf)-1 ] = '\0';
 
-		VLOG_PRINTF_INFO(mce_sys.exception_handling.get_log_severity(), "%s", buf);
+		VLOG_PRINTF_INFO(safe_mce_sys().exception_handling.get_log_severity(), "%s", buf);
 		int rc = handle_exception_flow();
 		switch (rc) {
 		case -1:
@@ -181,7 +181,7 @@ int sockinfo::ioctl(unsigned long int __request, unsigned long int __arg) throw 
 		snprintf(buf, sizeof(buf), "unimplemented ioctl request=%#x, flags=%#x", (unsigned)__request, (unsigned)__arg);
 		buf[ sizeof(buf)-1 ] = '\0';
 
-		VLOG_PRINTF_INFO(mce_sys.exception_handling.get_log_severity(), "%s", buf);
+		VLOG_PRINTF_INFO(safe_mce_sys().exception_handling.get_log_severity(), "%s", buf);
 		int rc = handle_exception_flow();
 		switch (rc) {
 		case -1:
@@ -256,7 +256,7 @@ int sockinfo::rx_wait_helper(int &poll_count, bool is_blocking)
 		}
 	}
 
-	if (poll_count < mce_sys.rx_poll_num || mce_sys.rx_poll_num == -1) {
+	if (poll_count < safe_mce_sys().rx_poll_num || safe_mce_sys().rx_poll_num == -1) {
 		return 0;
 	}
 
@@ -909,19 +909,19 @@ transport_t sockinfo::find_target_family(role_t role, struct sockaddr* sock_addr
 	transport_t target_family = TRANS_DEFAULT;
 	switch (role) {
 	case ROLE_TCP_SERVER:
-		target_family = __vma_match_tcp_server(TRANS_VMA, mce_sys.app_id, sock_addr_first, sizeof(struct sockaddr));
+		target_family = __vma_match_tcp_server(TRANS_VMA, safe_mce_sys().app_id, sock_addr_first, sizeof(struct sockaddr));
 		break;
 	case ROLE_TCP_CLIENT:
-		target_family = __vma_match_tcp_client(TRANS_VMA, mce_sys.app_id, sock_addr_first, sizeof(struct sockaddr), sock_addr_second, sizeof(struct sockaddr));
+		target_family = __vma_match_tcp_client(TRANS_VMA, safe_mce_sys().app_id, sock_addr_first, sizeof(struct sockaddr), sock_addr_second, sizeof(struct sockaddr));
 		break;
 	case ROLE_UDP_RECEIVER:
-		target_family = __vma_match_udp_receiver(TRANS_VMA, mce_sys.app_id, sock_addr_first, sizeof(struct sockaddr));
+		target_family = __vma_match_udp_receiver(TRANS_VMA, safe_mce_sys().app_id, sock_addr_first, sizeof(struct sockaddr));
 		break;
 	case ROLE_UDP_SENDER:
-		target_family = __vma_match_udp_sender(TRANS_VMA, mce_sys.app_id, sock_addr_first, sizeof(struct sockaddr));
+		target_family = __vma_match_udp_sender(TRANS_VMA, safe_mce_sys().app_id, sock_addr_first, sizeof(struct sockaddr));
 		break;
 	case ROLE_UDP_CONNECT:
-		target_family = __vma_match_udp_connect(TRANS_VMA, mce_sys.app_id, sock_addr_first, sizeof(struct sockaddr), sock_addr_second, sizeof(struct sockaddr));
+		target_family = __vma_match_udp_connect(TRANS_VMA, safe_mce_sys().app_id, sock_addr_first, sizeof(struct sockaddr), sock_addr_second, sizeof(struct sockaddr));
 		break;
 	BULLSEYE_EXCLUDE_BLOCK_START
 	default:

--- a/src/vma/sock/sockinfo.h
+++ b/src/vma/sock/sockinfo.h
@@ -424,14 +424,14 @@ protected:
 
     //////////////////////////////////////////////////////////////////
     int handle_exception_flow(){
-		if (mce_sys.exception_handling.is_suit_un_offloading()) {
+		if (safe_mce_sys().exception_handling.is_suit_un_offloading()) {
 			try_un_offloading();
 		}
-		if (mce_sys.exception_handling == vma_exception_handling::MODE_RETURN_ERROR) {
+		if (safe_mce_sys().exception_handling == vma_exception_handling::MODE_RETURN_ERROR) {
 			errno = EINVAL;
 			return -1;
 		}
-		if (mce_sys.exception_handling == vma_exception_handling::MODE_ABORT) {
+		if (safe_mce_sys().exception_handling == vma_exception_handling::MODE_ABORT) {
 			return -2;
 		}
 		return 0;

--- a/src/vma/sock/sockinfo_udp.h
+++ b/src/vma/sock/sockinfo_udp.h
@@ -107,7 +107,7 @@ public:
 	int	getsockopt(int __level, int __optname, void *__optval, socklen_t *__optlen) throw (vma_error);
 
 	/**
-	* Sampling the OS immediately by matching the rx_skip_os counter (m_rx_udp_poll_os_ratio_counter) to the limit (mce_sys.rx_udp_poll_os_ratio)
+	* Sampling the OS immediately by matching the rx_skip_os counter (m_rx_udp_poll_os_ratio_counter) to the limit (safe_mce_sys().rx_udp_poll_os_ratio)
 	*/
 	void	set_immediate_os_sample();
 	/**

--- a/src/vma/util/sys_vars.h
+++ b/src/vma/util/sys_vars.h
@@ -400,6 +400,8 @@ private:
 	mce_sys_var & operator= (const mce_sys_var &);
 
 };
+ 
+extern mce_sys_var & safe_mce_sys();
 
 #define SYS_VAR_LOG_LEVEL				"VMA_TRACELEVEL"
 #define SYS_VAR_LOG_DETAILS				"VMA_LOG_DETAILS"
@@ -673,7 +675,7 @@ private:
 /**
  * Macros for single/multi thread support
  */
-#define MULTI_THREAD_ONLY(x) 	{ if (mce_sys.thread_mode > THREAD_MODE_SINGLE) x; }
+#define MULTI_THREAD_ONLY(x) 	{ if (safe_mce_sys().thread_mode > THREAD_MODE_SINGLE) x; }
 
 
 extern struct mce_sys_var & mce_sys;


### PR DESCRIPTION
Use of mce_sys parameter directly may cause to unpredictable behavior.

Signed-off-by: Daniel Libenson <danielli@r-aa-bolt4.mtr.labs.mlnx>