### PR TITLE
issue: 781407: vma_poll: add support for selective vma buffers deallocation API

### DIFF
--- a/src/vma/dev/cq_mgr.h
+++ b/src/vma/dev/cq_mgr.h
@@ -224,6 +224,8 @@ private:
 	//false if the given buffer was not used.
 	bool 		compensate_qp_poll_success(mem_buf_desc_t* buff);
 	void		reclaim_recv_buffer_helper(mem_buf_desc_t* buff);
+	int 		vma_poll_reclaim_single_recv_buffer_helper(mem_buf_desc_t* buff);
+	void		vma_poll_reclaim_recv_buffer_helper(mem_buf_desc_t* buff);
 	inline uint32_t process_recv_queue(void* pv_fd_ready_array = NULL);
 	inline void	process_recv_buffer(mem_buf_desc_t* buff, void* pv_fd_ready_array = NULL);
 

--- a/src/vma/dev/ring.h
+++ b/src/vma/dev/ring.h
@@ -250,6 +250,9 @@ public:
 	virtual int		vma_poll(vma_completion_t *vma_completions, unsigned int ncompletions, int flags) = 0;
 	virtual bool		reclaim_recv_buffers_no_lock(mem_buf_desc_t* rx_reuse_lst) {NOT_IN_USE(rx_reuse_lst); return false;}
 
+	virtual int		vma_poll_reclaim_single_recv_buffer_no_lock(mem_buf_desc_t* rx_reuse_lst) {NOT_IN_USE(rx_reuse_lst); return -1;}
+	virtual void		vma_poll_reclaim_recv_buffers_no_lock(mem_buf_desc_t* rx_reuse_lst) {NOT_IN_USE(rx_reuse_lst); return;}
+
 protected:
 	uint32_t		m_n_num_resources;
 	int*			m_p_n_rx_channel_fds;

--- a/src/vma/dev/ring_simple.cpp
+++ b/src/vma/dev/ring_simple.cpp
@@ -1287,6 +1287,16 @@ bool ring_simple::reclaim_recv_buffers_no_lock(mem_buf_desc_t* rx_reuse_lst)
 	return m_p_cq_mgr_rx->reclaim_recv_buffers(rx_reuse_lst);
 }
 
+int ring_simple::vma_poll_reclaim_single_recv_buffer_no_lock(mem_buf_desc_t* rx_reuse_lst)
+{
+	return m_p_cq_mgr_rx->vma_poll_reclaim_single_recv_buffer_helper(rx_reuse_lst);
+}
+
+void ring_simple::vma_poll_reclaim_recv_buffers_no_lock(mem_buf_desc_t* rx_reuse_lst)
+{
+	return m_p_cq_mgr_rx->vma_poll_reclaim_recv_buffer_helper(rx_reuse_lst);
+}
+
 void ring_simple::mem_buf_desc_completion_with_error_rx(mem_buf_desc_t* p_rx_wc_buf_desc)
 {
 	m_p_cq_mgr_rx->mem_buf_desc_completion_with_error(p_rx_wc_buf_desc);

--- a/src/vma/dev/ring_simple.h
+++ b/src/vma/dev/ring_simple.h
@@ -30,6 +30,8 @@ public:
 	virtual void		adapt_cq_moderation();
 	bool			reclaim_recv_buffers_no_lock(descq_t *rx_reuse); // No locks
 	virtual bool		reclaim_recv_buffers_no_lock(mem_buf_desc_t* rx_reuse_lst); // No locks
+	virtual int		vma_poll_reclaim_single_recv_buffer_no_lock(mem_buf_desc_t* rx_reuse_lst); // No locks
+	virtual void		vma_poll_reclaim_recv_buffers_no_lock(mem_buf_desc_t* rx_reuse_lst); // No locks
 	virtual bool		reclaim_recv_buffers(descq_t *rx_reuse);
 	virtual int		drain_and_proccess(cq_type_t cq_type);
 	virtual int		wait_for_notification_and_process_element(cq_type_t cq_type, int cq_channel_fd, uint64_t* p_cq_poll_sn, void* pv_fd_ready_array = NULL);

--- a/src/vma/proto/mem_buf_desc.h
+++ b/src/vma/proto/mem_buf_desc.h
@@ -72,6 +72,10 @@ public:
 	inline int inc_ref_count() {return atomic_fetch_and_inc(&n_ref_count);}
 	inline int dec_ref_count() {return atomic_fetch_and_dec(&n_ref_count);}
 
+	inline int lwip_pbuf_inc_ref_count() {return ++lwip_pbuf.pbuf.ref;}
+	inline int lwip_pbuf_dec_ref_count() {return --lwip_pbuf.pbuf.ref;}
+	inline int lwip_pbuf_get_ref_count() const {return lwip_pbuf.pbuf.ref;}
+
 	bool		b_is_tx_mc_loop_dis; // if the mc loop on the tx side is disabled (the loop is per interface)
 	int8_t		n_frags;	//number of fragments
 	size_t		transport_header_len;

--- a/src/vma/sock/sock-redirect.cpp
+++ b/src/vma/sock/sock-redirect.cpp
@@ -369,31 +369,60 @@ int vma_free_packets(int __fd, struct vma_packet_t *pkts, size_t count)
 }
 
 extern "C"
-int vma_free_vma_packets(int fd, struct vma_packet_desc_t *packets, int num)
+int vma_free_vma_packets(struct vma_packet_desc_t *packets, int num)
 {
-	int ret_val = 0;
-	int *ring_fd;
-	cq_channel_info* cq_ch_info = NULL;
+	mem_buf_desc_t* desc = NULL;
 	socket_fd_api* p_socket_object = NULL;
+	int ret_val = 0;
 
-	p_socket_object = fd_collection_get_sockfd(fd);
-
-	ring_fd = p_socket_object->get_rings_fds();
-	cq_ch_info = g_p_fd_collection->get_cq_channel_fd(ring_fd[0]);
-
-	if (likely(cq_ch_info)) {
-		ring* p_ring = cq_ch_info->get_ring();
+	if (likely(packets)) {
 		for (int i = 0; i < num; i++) {
+			desc = (mem_buf_desc_t*)packets[i].buff_lst;
+			p_socket_object = (socket_fd_api*)desc->path.rx.context;
+			ring* rng = (ring*)desc->p_desc_owner;
 			p_socket_object->free_buffs(packets[i].total_len);
-			p_ring->reclaim_recv_buffers_no_lock((mem_buf_desc_t*)packets[i].buff_lst);
+			rng->vma_poll_reclaim_recv_buffers_no_lock(desc);
 		}
-
 	}
 	else {
 		errno = EINVAL;
 		ret_val = -1;
 	}
 
+	return ret_val;
+}
+extern "C"
+int vma_buff_ref(vma_buff_t *buff)
+{
+	int ret_val = 0;
+	mem_buf_desc_t* desc = NULL;
+
+	if (likely(buff)) {
+		desc = (mem_buf_desc_t*)buff;
+		ret_val = desc->lwip_pbuf_inc_ref_count();
+	}
+	else {
+		errno = EINVAL;
+		ret_val = -1;
+	}
+	return ret_val;
+}
+
+extern "C"
+int vma_buff_free(vma_buff_t *buff)
+{
+	int ret_val = 0;
+	mem_buf_desc_t* desc = NULL;
+
+	if (likely(buff)) {
+		desc = (mem_buf_desc_t*)buff;
+		ring* rng = (ring*)desc->p_desc_owner;
+		ret_val = rng->vma_poll_reclaim_single_recv_buffer_no_lock(desc);
+	}
+	else {
+		errno = EINVAL;
+		ret_val = -1;
+	}
 	return ret_val;
 }
 
@@ -753,6 +782,8 @@ int getsockopt(int __fd, int __level, int __optname,
 		vma_api->get_socket_rings_fds = vma_get_socket_rings_fds;
 		vma_api->free_vma_packets = vma_free_vma_packets;
 		vma_api->vma_poll = vma_poll;
+		vma_api->ref_vma_buff = vma_buff_ref;
+		vma_api->free_vma_buff = vma_buff_free;
 		*((vma_api_t**)__optval) = vma_api;
 		return 0;
 	}

--- a/src/vma/sock/sockinfo_tcp.cpp
+++ b/src/vma/sock/sockinfo_tcp.cpp
@@ -1325,6 +1325,7 @@ err_t sockinfo_tcp::rx_lwip_cb(void *arg, struct tcp_pcb *pcb,
 		p_first_desc->n_frags++;
 		p_curr_desc->path.rx.frag.iov_base = p_curr_buff->payload;
 		p_curr_desc->path.rx.frag.iov_len = p_curr_buff->len;
+		p_curr_desc->path.rx.context = conn;
 		p_curr_desc->p_next_desc = (mem_buf_desc_t *)p_curr_buff->next;
 		p_curr_buff = p_curr_buff->next;
 		p_curr_desc = p_curr_desc->p_next_desc;


### PR DESCRIPTION
The new API allows:
- Selective deallocation of the buffers provided by vma_poll().
- Decoupling between buffer management and "Transport Credits" (TCP WIN) update.

Signed-off-by: Alex Vainman <alexv@mellanox.com>