### PR TITLE
issue: 781540 Add short (25 msec) delay between RAW QP state change to ERROR and polling CQ for all CQE's

### DIFF
--- a/src/vma/dev/ring_simple.cpp
+++ b/src/vma/dev/ring_simple.cpp
@@ -133,6 +133,9 @@ ring_simple::~ring_simple()
 	if (m_p_qp_mgr) {
 		// 'down' the active QP/CQ
 		m_p_qp_mgr->down();
+
+		// Allow all WEQ's to be FLUSHED
+		usleep(25000);
 	}
 	// Release QP/CQ resources
 	delete m_p_qp_mgr;


### PR DESCRIPTION
In ConnectX-4 we need this additional delay allow all Rx WQE's to
complete FLUSH-ing into CQ before closing the QP and CQ.
This can cause VMA Rx buffer resource leak when closing a RING.