### PR TITLE
issue: 781384 add log details on UDP setsockopt(SO_BINDTODEVICE)

### DIFF
--- a/src/vma/sock/sockinfo_udp.cpp
+++ b/src/vma/sock/sockinfo_udp.cpp
@@ -339,6 +339,7 @@ const char * setsockopt_so_opt_to_str(int opt)
 	case SO_SNDBUF:			return "SO_SNDBUF";
 	case SO_TIMESTAMP:		return "SO_TIMESTAMP";
 	case SO_TIMESTAMPNS:		return "SO_TIMESTAMPNS";
+	case SO_BINDTODEVICE:		return "SO_BINDTODEVICE";
 	default:			break;
 	}
 	return "UNKNOWN SO opt";
@@ -459,6 +460,7 @@ sockinfo_udp::~sockinfo_udp()
 int sockinfo_udp::bind(const struct sockaddr *__addr, socklen_t __addrlen)
 {
 	si_udp_logfunc("");
+
 
 	// We always call the orig_bind which will check sanity of the user socket api
 	// and the OS will also allocate a specific port that we can also use
@@ -740,7 +742,9 @@ int sockinfo_udp::setsockopt(int __level, int __optname, __const void *__optval,
 					else
 						m_loops_timer.set_timeout_msec(-1);
 					si_udp_logdbg("SOL_SOCKET: SO_RCVTIMEO=%d", m_loops_timer.get_timeout_msec());
-
+				}
+				else {
+					si_udp_logdbg("SOL_SOCKET, %s=\"???\" - NOT HANDLED, optval == NULL", setsockopt_so_opt_to_str(__optname));
 				}
 				break;
 
@@ -751,6 +755,9 @@ int sockinfo_udp::setsockopt(int __level, int __optname, __const void *__optval,
 					if (__optname == SO_TIMESTAMPNS)
 						m_b_rcvtstampns = m_b_rcvtstamp;
 					si_udp_logdbg("SOL_SOCKET, %s=%s", setsockopt_so_opt_to_str(__optname), (m_b_rcvtstamp ? "true" : "false"));
+				}
+				else {
+					si_udp_logdbg("SOL_SOCKET, %s=\"???\" - NOT HANDLED, optval == NULL", setsockopt_so_opt_to_str(__optname));
 				}
 				break;
 
@@ -782,6 +789,9 @@ int sockinfo_udp::setsockopt(int __level, int __optname, __const void *__optval,
 					m_n_tsing_flags  = val;
 					si_udp_logdbg("SOL_SOCKET, SO_TIMESTAMPING=%u", m_n_tsing_flags);
 				}
+				else {
+					si_udp_logdbg("SOL_SOCKET, %s=\"???\" - NOT HANDLED, optval == NULL", setsockopt_so_opt_to_str(__optname));
+				}
 				break;
 
 			case SO_BINDTODEVICE:
@@ -795,6 +805,8 @@ int sockinfo_udp::setsockopt(int __level, int __optname, __const void *__optval,
 					} else {
 						m_so_bindtodevice_ip = sockaddr.sin_addr.s_addr;
 					}
+					si_udp_logdbg("SOL_SOCKET, %s='%s' (%d.%d.%d.%d)", setsockopt_so_opt_to_str(__optname), (char*)__optval, NIPQUAD(m_so_bindtodevice_ip));
+
 					// handle TX side
 					if (m_p_connected_dst_entry) {
 						m_p_connected_dst_entry->set_so_bindtodevice_addr(m_so_bindtodevice_ip);
@@ -805,7 +817,8 @@ int sockinfo_udp::setsockopt(int __level, int __optname, __const void *__optval,
 							dst_entry_iter++;
 						}
 					}
-					// TODO handle RX side
+
+					// handle RX side - TODO
 				}
 				else {
 					si_udp_logdbg("SOL_SOCKET, %s=\"???\" - NOT HANDLED, optval == NULL", setsockopt_so_opt_to_str(__optname));

--- a/tests/bindtodevice/client.py
+++ b/tests/bindtodevice/client.py
@@ -1,0 +1,57 @@
+#!/usr/bin/env python
+#
+#
+#@copyright:
+#        Copyright (c) 2001-2016 Mellanox Technologies, Ltd. All rights reserved.
+#
+#        This software is available to you under a choice of one of two
+#        licenses.  You may choose to be licensed under the terms of the GNU
+#        General Public License (GPL) Version 2, available from the file
+#        COPYING in the main directory of this source tree, or the
+#        BSD license below:
+#
+#            Redistribution and use in source and binary forms, with or
+#            without modification, are permitted provided that the following
+#            conditions are met:
+#
+#             - Redistributions of source code must retain the above
+#               copyright notice, this list of conditions and the following
+#               disclaimer.
+#
+#             - Redistributions in binary form must reproduce the above
+#               copyright notice, this list of conditions and the following
+#               disclaimer in the documentation and/or other materials
+#               provided with the distribution.
+#
+#        THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+#        EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+#        MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+#        NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+#        BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+#        ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+#        CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+#        SOFTWARE.
+#
+#@author: Alex Rosenbaum
+
+#@date: 18May2016
+#
+#
+#
+#
+import socket, time, sys
+
+if (len(sys.argv) <3):
+    print "In correct parameter : " + sys.argv[0] + " dst_ip_address dst_port src_ifname" 
+    sys.exit(-1)
+
+
+print "UDP target IP:port=<", sys.argv[1], ":", sys.argv[2], ">"
+print "ifname:", sys.argv[3]
+
+sock=socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+sock.setblocking(0)
+sock.setsockopt(socket.SOL_SOCKET, 25, sys.argv[3]+'\0') # SO_BINDTODEVICE
+sock.sendto("HELLO WORLD", (sys.argv[1], int(sys.argv[2])))
+time.sleep(1)
+sock.close()


### PR DESCRIPTION
commit includes a simple python test code which calls setsockopt(SO_BINDTODEVICE)
to test these changes

Update log example:
VMA DEBUG: ENTER: setsockopt(fd=21, level=1, optname=25)
VMA DEBUG: si_udp[fd=21]:808:setsockopt() SOL_SOCKET, SO_BINDTODEVICE='ens3' (4.4.4.12)
VMA DEBUG: EXIT: setsockopt() returned with 0