### PR TITLE
issue: 784317: Implement optimized free_vma_buff()

### DIFF
--- a/src/vma/dev/cq_mgr.cpp
+++ b/src/vma/dev/cq_mgr.cpp
@@ -692,7 +692,7 @@ void cq_mgr::vma_poll_reclaim_recv_buffer_helper(mem_buf_desc_t* buff)
 				vlog_printf(VLOG_WARNING, "cq_mgr::reclaim_recv_buffer_helper - buff is already a member in a list , id = %s\n", buff->node.list_id());
 			}
 		#endif
-			if(buff->lwip_pbuf_dec_ref_count() <= 0) { //TBD: assert if buff was already 0
+			if(buff->lwip_pbuf_dec_ref_count() <= 0) {
 				temp = buff;
 				buff = temp->p_next_desc;
 				temp->p_next_desc = NULL;
@@ -712,17 +712,18 @@ void cq_mgr::vma_poll_reclaim_recv_buffer_helper(mem_buf_desc_t* buff)
 
 			}
 			else {
+				buff->reset_ref_count();
 				buff = buff->p_next_desc;
 			}
 		}
+		return_extra_buffers();
 		m_p_cq_stat->n_buffer_pool_len = m_rx_pool.size();
 	}
-
 }
 
 int cq_mgr::vma_poll_reclaim_single_recv_buffer_helper(mem_buf_desc_t* buff)
 {
-	int ref_cnt = buff->lwip_pbuf_dec_ref_count(); //TBD: assert if buff was already 0
+	int ref_cnt = buff->lwip_pbuf_dec_ref_count();
 	if (ref_cnt <= 0) {
 		#if _VMA_LIST_DEBUG
 			if (buff->node.is_list_member()) {

--- a/src/vma/dev/ring.h
+++ b/src/vma/dev/ring.h
@@ -250,8 +250,8 @@ public:
 	virtual int		vma_poll(vma_completion_t *vma_completions, unsigned int ncompletions, int flags) = 0;
 	virtual bool		reclaim_recv_buffers_no_lock(mem_buf_desc_t* rx_reuse_lst) {NOT_IN_USE(rx_reuse_lst); return false;}
 
-	virtual int		vma_poll_reclaim_single_recv_buffer_no_lock(mem_buf_desc_t* rx_reuse_lst) {NOT_IN_USE(rx_reuse_lst); return -1;}
-	virtual void		vma_poll_reclaim_recv_buffers_no_lock(mem_buf_desc_t* rx_reuse_lst) {NOT_IN_USE(rx_reuse_lst); return;}
+	virtual int		vma_poll_reclaim_single_recv_buffer(mem_buf_desc_t* rx_reuse_lst) {NOT_IN_USE(rx_reuse_lst); return -1;}
+	virtual void		vma_poll_reclaim_recv_buffers(mem_buf_desc_t* rx_reuse_lst) {NOT_IN_USE(rx_reuse_lst); return;}
 
 protected:
 	uint32_t		m_n_num_resources;

--- a/src/vma/dev/ring_simple.h
+++ b/src/vma/dev/ring_simple.h
@@ -129,7 +129,8 @@ private:
 	flow_spec_tcp_map_t	m_flow_tcp_map;
 	flow_spec_udp_mc_map_t	m_flow_udp_mc_map;
 	flow_spec_udp_uc_map_t	m_flow_udp_uc_map;
-
+	mem_buf_desc_t*		m_rx_buffs_rdy_for_free_head;
+	mem_buf_desc_t*		m_rx_buffs_rdy_for_free_tail;
 };
 
 class ring_eth : public ring_simple

--- a/src/vma/dev/ring_simple.h
+++ b/src/vma/dev/ring_simple.h
@@ -30,8 +30,8 @@ public:
 	virtual void		adapt_cq_moderation();
 	bool			reclaim_recv_buffers_no_lock(descq_t *rx_reuse); // No locks
 	virtual bool		reclaim_recv_buffers_no_lock(mem_buf_desc_t* rx_reuse_lst); // No locks
-	virtual int		vma_poll_reclaim_single_recv_buffer_no_lock(mem_buf_desc_t* rx_reuse_lst); // No locks
-	virtual void		vma_poll_reclaim_recv_buffers_no_lock(mem_buf_desc_t* rx_reuse_lst); // No locks
+	virtual int		vma_poll_reclaim_single_recv_buffer(mem_buf_desc_t* rx_reuse_lst); // No locks
+	virtual void		vma_poll_reclaim_recv_buffers(mem_buf_desc_t* rx_reuse_lst); // No locks
 	virtual bool		reclaim_recv_buffers(descq_t *rx_reuse);
 	virtual int		drain_and_proccess(cq_type_t cq_type);
 	virtual int		wait_for_notification_and_process_element(cq_type_t cq_type, int cq_channel_fd, uint64_t* p_cq_poll_sn, void* pv_fd_ready_array = NULL);

--- a/src/vma/proto/mem_buf_desc.h
+++ b/src/vma/proto/mem_buf_desc.h
@@ -72,9 +72,9 @@ public:
 	inline int inc_ref_count() {return atomic_fetch_and_inc(&n_ref_count);}
 	inline int dec_ref_count() {return atomic_fetch_and_dec(&n_ref_count);}
 
-	inline int lwip_pbuf_inc_ref_count() {return ++lwip_pbuf.pbuf.ref;}
-	inline int lwip_pbuf_dec_ref_count() {return --lwip_pbuf.pbuf.ref;}
-	inline int lwip_pbuf_get_ref_count() const {return lwip_pbuf.pbuf.ref;}
+	inline unsigned int lwip_pbuf_inc_ref_count() {return ++lwip_pbuf.pbuf.ref;}
+	inline unsigned int lwip_pbuf_dec_ref_count() {if (likely(lwip_pbuf.pbuf.ref)) --lwip_pbuf.pbuf.ref; return lwip_pbuf.pbuf.ref;}
+	inline unsigned int lwip_pbuf_get_ref_count() const {return lwip_pbuf.pbuf.ref;}
 
 	bool		b_is_tx_mc_loop_dis; // if the mc loop on the tx side is disabled (the loop is per interface)
 	int8_t		n_frags;	//number of fragments

--- a/src/vma/sock/sock-redirect.cpp
+++ b/src/vma/sock/sock-redirect.cpp
@@ -381,7 +381,7 @@ int vma_free_vma_packets(struct vma_packet_desc_t *packets, int num)
 			p_socket_object = (socket_fd_api*)desc->path.rx.context;
 			ring* rng = (ring*)desc->p_desc_owner;
 			p_socket_object->free_buffs(packets[i].total_len);
-			rng->vma_poll_reclaim_recv_buffers_no_lock(desc);
+			rng->vma_poll_reclaim_recv_buffers(desc);
 		}
 	}
 	else {
@@ -417,7 +417,7 @@ int vma_buff_free(vma_buff_t *buff)
 	if (likely(buff)) {
 		desc = (mem_buf_desc_t*)buff;
 		ring* rng = (ring*)desc->p_desc_owner;
-		ret_val = rng->vma_poll_reclaim_single_recv_buffer_no_lock(desc);
+		ret_val = rng->vma_poll_reclaim_single_recv_buffer(desc);
 	}
 	else {
 		errno = EINVAL;


### PR DESCRIPTION
In order to reduce free_vma_buff() overhead vma_buff is not returned
by free_vma_buff() to CQ's rx buffer pool or to rx global buffer pool
but just inserted into pending for remove ring's list that is handled
on free_vma_packets() or on ring destruction.