### PR TITLE
issue: 778287 Fix using safe_mce_sys() calls instead of direct usage of mce_sys struct

### DIFF
--- a/src/vma/sock/sockinfo_tcp.cpp
+++ b/src/vma/sock/sockinfo_tcp.cpp
@@ -1135,7 +1135,7 @@ void sockinfo_tcp::handle_timer_expired(void* user_data)
 	if (safe_mce_sys().tcp_ctl_thread > CTL_THREAD_DISABLE)
 		process_rx_ctl_packets();
 
-	if (mce_sys.internal_thread_tcp_timer_handling == INTERNAL_THREAD_TCP_TIMER_HANDLING_DEFERRED) {
+	if (safe_mce_sys().internal_thread_tcp_timer_handling == INTERNAL_THREAD_TCP_TIMER_HANDLING_DEFERRED) {
 		// DEFERRED. if Internal thread is here first and m_timer_pending is false it jsut 
 		// sets it as true for its next iteration (within 100ms), letting 
 		// application threads have a chance of running tcp_timer()

--- a/src/vma/util/sys_vars.h
+++ b/src/vma/util/sys_vars.h
@@ -662,7 +662,6 @@ extern mce_sys_var & safe_mce_sys();
 #define MULTI_THREAD_ONLY(x) 	{ if (safe_mce_sys().thread_mode > THREAD_MODE_SINGLE) x; }
 
 
-extern struct mce_sys_var & mce_sys;
 extern bool g_b_exit;
 extern bool g_is_forked_child;
 extern bool g_init_global_ctors_done;


### PR DESCRIPTION
Signed-off-by: Ophir Munk <ophirmu@mellanox.com>