### PR TITLE
issue 777416: Add SO_VMA_USER_DATA option for setsockopt()

### DIFF
--- a/src/vma/sock/sockinfo.h
+++ b/src/vma/sock/sockinfo.h
@@ -150,10 +150,13 @@ protected:
 	// Callback function pointer to support VMA extra API (vma_extra.h)
 	vma_recv_callback_t	m_rx_callback;
 	void*			m_rx_callback_context; // user context
+	void*			m_fd_context;
 
 	virtual void 		set_blocking(bool is_blocked);
 	virtual int 		fcntl(int __cmd, unsigned long int __arg) throw (vma_error);
 	virtual int 		ioctl(unsigned long int __request, unsigned long int __arg) throw (vma_error);
+	virtual int setsockopt(int __level, int __optname, const void *__optval, socklen_t __optlen) throw (vma_error);
+	virtual int getsockopt(int __level, int __optname, void *__optval, socklen_t *__optlen) throw (vma_error);
 
 	virtual	mem_buf_desc_t* get_front_m_rx_pkt_ready_list() = 0;
 	virtual	size_t get_size_m_rx_pkt_ready_list() = 0;


### PR DESCRIPTION
New VMA specific option allows to provide user defined data
in vma_completion_t as result of vma_poll().
By default socket descriptor is returned.
SO_VMA_USER_DATA option associated with SOL_SOCKET level.

Signed-off-by: Igor Ivanov <igor.ivanov.va@gmail.com>