### PR TITLE
issue: 775233 Add control for logging

### DIFF
--- a/config/m4/opt.m4
+++ b/config/m4/opt.m4
@@ -1,0 +1,23 @@
+# opt.m4 - Macros to control optimization
+# 
+# Copyright (C) Mellanox Technologies Ltd. 2016.  ALL RIGHTS RESERVED.
+# See file LICENSE for terms.
+#
+
+##########################
+# Logging control
+#
+AC_ARG_ENABLE(
+    [opt-log],
+    AC_HELP_STRING(
+        [--enable-opt-log],
+        [Optimize logging output (default=no)]))
+AC_MSG_CHECKING(
+    [checking for logging optimization])
+if test "x$enable_opt_log" = "xyes"; then
+    CPPFLAGS="$CPPFLAGS -DVMA_OPTIMIZE_LOG -DNDEBUG"
+    AC_MSG_RESULT([yes])
+else
+    AC_MSG_RESULT([no])
+fi
+

--- a/configure.ac
+++ b/configure.ac
@@ -51,6 +51,7 @@ AC_SUBST(LIBALIC_FLAG)
 AC_SUBST([BUILD_DATE], [$(date +'%b/%d/%Y')])
 AC_SUBST([BUILD_TIME], [$(date +'%H:%M:%S')])
 
+m4_include([config/m4/opt.m4])
 m4_include([config/m4/pkg.m4])
 PKG_PROG_PKG_CONFIG
 

--- a/src/vlogger/vlogger.h
+++ b/src/vlogger/vlogger.h
@@ -80,20 +80,45 @@
 #define __log_err(log_fmt, log_args...)          do { VLOG_PRINTF(VLOG_ERROR, log_fmt, ##log_args); } while (0)
 #define __log_warn(log_fmt, log_args...)         do { VLOG_PRINTF(VLOG_WARNING, log_fmt, ##log_args); } while (0)
 #define __log_info(log_fmt, log_args...)         do { VLOG_PRINTF(VLOG_INFO, log_fmt, ##log_args); } while (0)
+
+#if defined(VMA_OPTIMIZE_LOG)
+#define __log_details(log_fmt, log_args...)      ((void)0)
+#define __log_dbg(log_fmt, log_args...)          ((void)0)
+#define __log_fine(log_fmt, log_args...)         ((void)0)
+#define __log_finer(log_fmt, log_args...)        ((void)0)
+#else
 #define __log_details(log_fmt, log_args...)      do { if (g_vlogger_level >= VLOG_DETAILS) 	VLOG_PRINTF(VLOG_DETAILS, log_fmt, ##log_args); } while (0)
 #define __log_dbg(log_fmt, log_args...)          do { if (g_vlogger_level >= VLOG_DEBUG) 	VLOG_PRINTF(VLOG_DEBUG, log_fmt, ##log_args); } while (0)
 #define __log_fine(log_fmt, log_args...)         do { if (g_vlogger_level >= VLOG_FINE) 		VLOG_PRINTF(VLOG_FINE, log_fmt, ##log_args); } while (0)
 #define __log_finer(log_fmt, log_args...)        do { if (g_vlogger_level >= VLOG_FINER) 	VLOG_PRINTF(VLOG_FINER, log_fmt, ##log_args); } while (0)
+#endif /* VMA_OPTIMIZE_LOG */
 
 #define __log_info_panic(log_fmt, log_args...)   do { VLOG_PRINTF_INFO(VLOG_PANIC, log_fmt, ##log_args); throw; } while (0)
 #define __log_info_err(log_fmt, log_args...)     do { VLOG_PRINTF_INFO(VLOG_ERROR, log_fmt, ##log_args); } while (0)
 #define __log_info_warn(log_fmt, log_args...)    do { VLOG_PRINTF_INFO(VLOG_WARNING, log_fmt, ##log_args); } while (0)
 #define __log_info_info(log_fmt, log_args...)    do { VLOG_PRINTF_INFO(VLOG_INFO, log_fmt, ##log_args); } while (0)
+
+#if defined(VMA_OPTIMIZE_LOG)
+#define __log_info_details(log_fmt, log_args...) ((void)0)
+#define __log_info_dbg(log_fmt, log_args...)     ((void)0)
+#define __log_info_fine(log_fmt, log_args...)    ((void)0)
+#define __log_info_finer(log_fmt, log_args...)   ((void)0)
+#else
 #define __log_info_details(log_fmt, log_args...) do { if (g_vlogger_level >= VLOG_DETAILS) 	VLOG_PRINTF_INFO(VLOG_DETAILS, log_fmt, ##log_args); } while (0)
 #define __log_info_dbg(log_fmt, log_args...)     do { if (g_vlogger_level >= VLOG_DEBUG) 	VLOG_PRINTF_INFO(VLOG_DEBUG, log_fmt, ##log_args); } while (0)
 #define __log_info_fine(log_fmt, log_args...)    do { if (g_vlogger_level >= VLOG_FINE) 		VLOG_PRINTF_INFO(VLOG_FINE, log_fmt, ##log_args); } while (0)
 #define __log_info_finer(log_fmt, log_args...)   do { if (g_vlogger_level >= VLOG_FINER) 	VLOG_PRINTF_INFO(VLOG_FINER, log_fmt, ##log_args); } while (0)
+#endif /* VMA_OPTIMIZE_LOG */
 
+#if defined(VMA_OPTIMIZE_LOG)
+#define __log_entry_dbg(log_fmt, log_args...)    ((void)0)
+#define __log_entry_fine(log_fmt, log_args...)   ((void)0)
+#define __log_entry_finer(log_fmt, log_args...)  ((void)0)
+
+#define __log_exit_dbg(log_fmt, log_args...)     ((void)0)
+#define __log_exit_fine(log_fmt, log_args...)    ((void)0)
+#define __log_exit_finer(log_fmt, log_args...)   ((void)0)
+#else
 #define __log_entry_dbg(log_fmt, log_args...)    do { if (g_vlogger_level >= VLOG_DEBUG) 	VLOG_PRINTF_ENTRY(VLOG_DEBUG, log_fmt, ##log_args); } while (0)
 #define __log_entry_fine(log_fmt, log_args...)   do { if (g_vlogger_level >= VLOG_FINE)		VLOG_PRINTF_ENTRY(VLOG_FINE, log_fmt, ##log_args); } while (0)
 #define __log_entry_finer(log_fmt, log_args...)  do { if (g_vlogger_level >= VLOG_FINER) 	VLOG_PRINTF_ENTRY(VLOG_FINER, log_fmt, ##log_args); } while (0)
@@ -101,6 +126,7 @@
 #define __log_exit_dbg(log_fmt, log_args...)     do { if (g_vlogger_level >= VLOG_DEBUG) 	VLOG_PRINTF_EXIT(VLOG_DEBUG, log_fmt, ##log_args); } while (0)
 #define __log_exit_fine(log_fmt, log_args...)    do { if (g_vlogger_level >= VLOG_FINE)		VLOG_PRINTF_EXIT(VLOG_FINE, log_fmt, ##log_args); } while (0)
 #define __log_exit_finer(log_fmt, log_args...)   do { if (g_vlogger_level >= VLOG_FINER) 	VLOG_PRINTF_EXIT(VLOG_FINER, log_fmt, ##log_args); } while (0)
+#endif /* VMA_OPTIMIZE_LOG */
 
 // deprecated functions - only exist for Backward Compatibility.  Please avoid using them!
 #define __log_func(...)          __log_fine(__VA_ARGS__)

--- a/src/vma/dev/net_device_table_mgr.cpp
+++ b/src/vma/dev/net_device_table_mgr.cpp
@@ -279,9 +279,8 @@ int net_device_table_mgr::map_net_devices()
 		m_if_indx_to_nd_val_lst[p_net_device_val->get_if_idx()].push_back(p_net_device_val);
 		m_lock.unlock();
 
-		ibv_device* ibvdevice = ib_ctx->get_ibv_device();
 		ndtm_logdbg("Offload interface '%s': Mapped to ibv device '%s' [%p] on port %d",
-				ifa->ifa_name, ibvdevice->name, ibvdevice, cma_id->port_num);
+				ifa->ifa_name, ib_ctx->get_ibv_device()->name, ib_ctx->get_ibv_device(), cma_id->port_num);
 
 		IF_RDMACM_FAILURE(rdma_destroy_id(cma_id)) {
 			ndtm_logerr("Failed in rdma_destroy_id (errno=%d %m)", errno);

--- a/src/vma/dev/net_device_val.cpp
+++ b/src/vma/dev/net_device_val.cpp
@@ -349,9 +349,8 @@ bool net_device_val::update_active_backup_slaves()
 		if (strstr(active_slave, m_slaves[i]->if_name) != NULL) {
 			m_slaves[i]->is_active_slave = true;
 			found_active_slave = true;
-			struct ibv_device* p_ibv_device = p_ring_info[i].p_ib_ctx->get_ibv_device();
 			nd_logdbg("Offload interface '%s': Re-mapped to ibv device '%s' [%p] on port %d",
-					m_name.c_str(), p_ibv_device->name, p_ibv_device, p_ring_info[i].port_num);
+					m_name.c_str(), p_ring_info[i].p_ib_ctx->get_ibv_device()->name, p_ring_info[i].p_ib_ctx->get_ibv_device(), p_ring_info[i].port_num);
 		} else {
 			m_slaves[i]->is_active_slave = false;
 		}

--- a/src/vma/dev/qp_mgr.cpp
+++ b/src/vma/dev/qp_mgr.cpp
@@ -106,11 +106,9 @@ qp_mgr::~qp_mgr()
 
 int qp_mgr::configure(struct ibv_comp_channel* p_rx_comp_event_channel)
 {
-	transport_type_t transport_type = m_p_ring->get_transport_type();
-	struct ibv_device* p_ibv_device = m_p_ib_ctx_handler->get_ibv_device();
 	qp_logdbg("Creating QP of transport type '%s' on ibv device '%s' [%p] on port %d",
-			priv_vma_transport_type_str(transport_type),
-			p_ibv_device->name, p_ibv_device, m_port_num);
+			priv_vma_transport_type_str(m_p_ring->get_transport_type()),
+			m_p_ib_ctx_handler->get_ibv_device()->name, m_p_ib_ctx_handler->get_ibv_device(), m_port_num);
 
 	// Check device capabilities for max QP work requests
 	vma_ibv_device_attr& r_ibv_dev_attr = m_p_ib_ctx_handler->get_ibv_device_attr();

--- a/src/vma/dev/ring_simple.cpp
+++ b/src/vma/dev/ring_simple.cpp
@@ -152,10 +152,11 @@ ring_simple::~ring_simple()
 
 	delete[] m_p_n_rx_channel_fds;
 
-	int buffer_accounting = m_tx_num_bufs - m_tx_pool.size() - m_missing_buf_ref_count;
 	ring_logdbg("Tx buffer poll: free count = %u, sender_has = %d, total = %d, %s (%d)",
 			m_tx_pool.size(), m_missing_buf_ref_count, m_tx_num_bufs,
-			(buffer_accounting?"bad accounting!!":"good accounting"), buffer_accounting);
+			((m_tx_num_bufs - m_tx_pool.size() - m_missing_buf_ref_count) ?
+					"bad accounting!!" : "good accounting"),
+					(m_tx_num_bufs - m_tx_pool.size() - m_missing_buf_ref_count));
 	ring_logdbg("Tx WR num: free count = %d, total = %d, %s (%d)",
 			m_tx_num_wr_free, m_tx_num_wr,
 			((m_tx_num_wr - m_tx_num_wr_free) ? "bad accounting!!":"good accounting"), (m_tx_num_wr - m_tx_num_wr_free));
@@ -622,7 +623,6 @@ bool ring_simple::rx_process_buffer(mem_buf_desc_t* p_rx_wc_buf_desc, transport_
 	uint16_t n_frag_offset = 0;
 	struct iphdr* p_ip_h = NULL;
 	struct udphdr* p_udp_h = NULL;
-	in_addr_t local_addr = p_rx_wc_buf_desc->path.rx.dst.sin_addr.s_addr;
 
 	// This is an internal function (within ring and 'friends'). No need for lock mechanism.
 
@@ -736,7 +736,7 @@ bool ring_simple::rx_process_buffer(mem_buf_desc_t* p_rx_wc_buf_desc, transport_
 			NIPQUAD(p_ip_h->daddr), NIPQUAD(p_ip_h->saddr),
 			sz_data, n_frag_offset, ntohs(p_ip_h->id),
 			iphdr_protocol_type_to_str(p_ip_h->protocol), p_ip_h->protocol,
-			NIPQUAD(local_addr));
+			NIPQUAD(p_rx_wc_buf_desc->path.rx.dst.sin_addr.s_addr));
 
 	// Check that the ip datagram has at least the udp header size for the first ip fragment (besides the ip header)
 	ip_hdr_len = (int)(p_ip_h->ihl)*4;
@@ -869,6 +869,7 @@ bool ring_simple::rx_process_buffer(mem_buf_desc_t* p_rx_wc_buf_desc, transport_
 	case IPPROTO_IGMP:
 	{
 		struct igmp* p_igmp_h= (struct igmp*)((uint8_t*)p_ip_h + ip_hdr_len);
+		NOT_IN_USE(p_igmp_h); /* to supress warning in case VMA_OPTIMIZE_LOG */
 		ring_logdbg("Rx IGMP packet info: type=%s (%d), group=%d.%d.%d.%d, code=%d",
 				priv_igmp_type_tostr(p_igmp_h->igmp_type), p_igmp_h->igmp_type,
 				NIPQUAD(p_igmp_h->igmp_group.s_addr), p_igmp_h->igmp_code);

--- a/src/vma/proto/dst_entry_tcp.cpp
+++ b/src/vma/proto/dst_entry_tcp.cpp
@@ -174,6 +174,7 @@ ssize_t dst_entry_tcp::fast_send(const struct iovec* p_iov, const ssize_t sz_iov
 
 #ifndef __COVERITY__
         struct tcphdr* p_tcp_h = (struct tcphdr*)(((uint8_t*)(&(p_pkt->hdr.m_ip_hdr))+sizeof(p_pkt->hdr.m_ip_hdr)));
+        NOT_IN_USE(p_tcp_h); /* to supress warning in case VMA_OPTIMIZE_LOG */
         dst_tcp_logfunc("Tx TCP segment info: src_port=%d, dst_port=%d, flags='%s%s%s%s%s%s' seq=%u, ack=%u, win=%u, payload_sz=%u",
                         ntohs(p_tcp_h->source), ntohs(p_tcp_h->dest),
                         p_tcp_h->urg?"U":"", p_tcp_h->ack?"A":"", p_tcp_h->psh?"P":"",

--- a/src/vma/proto/neighbour.cpp
+++ b/src/vma/proto/neighbour.cpp
@@ -568,6 +568,7 @@ bool neigh_entry::post_send_tcp(iovec *iov, header *h)
 	m_p_ring->send_ring_buffer(m_id, &m_send_wqe, false);
 #ifndef __COVERITY__
 	struct tcphdr* p_tcp_h = (struct tcphdr*)(((uint8_t*)(&(p_pkt->hdr.m_ip_hdr))+sizeof(p_pkt->hdr.m_ip_hdr)));
+	NOT_IN_USE(p_tcp_h); /* to supress warning in case VMA_OPTIMIZE_LOG */
 	neigh_logdbg("Tx TCP segment info: src_port=%d, dst_port=%d, flags='%s%s%s%s%s%s' seq=%u, ack=%u, win=%u, payload_sz=%u",
 			ntohs(p_tcp_h->source), ntohs(p_tcp_h->dest),
 			p_tcp_h->urg?"U":"", p_tcp_h->ack?"A":"", p_tcp_h->psh?"P":"",
@@ -936,6 +937,7 @@ void neigh_entry::dofunc_enter_ready(const sm_info_t& func_info)
 
 void neigh_entry::priv_general_st_entry(const sm_info_t& func_info)
 {
+	NOT_IN_USE(func_info); /* to supress warning in case VMA_OPTIMIZE_LOG */
 	neigh_logdbg("State change: %s (%d) => %s (%d) with event %s (%d)",
 		state_to_str((state_t) func_info.old_state), func_info.old_state,
 		state_to_str((state_t) func_info.new_state), func_info.new_state,
@@ -949,6 +951,8 @@ void neigh_entry::priv_general_st_leave(const sm_info_t& func_info)
 
 void neigh_entry::priv_print_event_info(state_t state, event_t event)
 {
+	NOT_IN_USE(state); /* to supress warning in case VMA_OPTIMIZE_LOG */
+	NOT_IN_USE(event); /* to supress warning in case VMA_OPTIMIZE_LOG */
 	neigh_logdbg("Got event '%s' (%d) in state '%s' (%d)",
 		event_to_str(event), event, state_to_str(state), state);
 }

--- a/src/vma/sock/sock-redirect.cpp
+++ b/src/vma/sock/sock-redirect.cpp
@@ -556,6 +556,7 @@ int bind(int __fd, const struct sockaddr *__addr, socklen_t __addrlen)
 	BULLSEYE_EXCLUDE_BLOCK_END
 
 	char buf[256];
+	NOT_IN_USE(buf); /* to suppress warning in case VMA_OPTIMIZE_LOG */
 	srdr_logdbg_entry("fd=%d, %s", __fd, sprintf_sockaddr(buf, 256, __addr, __addrlen));
 
 	int ret = 0;
@@ -596,6 +597,7 @@ int connect(int __fd, const struct sockaddr *__to, socklen_t __tolen)
 	BULLSEYE_EXCLUDE_BLOCK_END
 
 	char buf[256];
+	NOT_IN_USE(buf); /* to suppress warning in case VMA_OPTIMIZE_LOG */
 	srdr_logdbg_entry("fd=%d, %s", __fd, sprintf_sockaddr(buf, 256, __to, __tolen));
 
 	int ret = 0;
@@ -1384,6 +1386,9 @@ int select_helper(int __nfds,
 	if (g_vlogger_level >= VLOG_FUNC) {
 		const int tmpbufsize = 256;
 		char tmpbuf[tmpbufsize], tmpbuf2[tmpbufsize];
+		NOT_IN_USE(tmpbufsize); /* to suppress warning in case VMA_OPTIMIZE_LOG */
+		NOT_IN_USE(tmpbuf); /* to suppress warning in case VMA_OPTIMIZE_LOG */
+		NOT_IN_USE(tmpbuf2); /* to suppress warning in case VMA_OPTIMIZE_LOG */
 		srdr_logfunc("readfds: %s, writefds: %s",
 			   sprintf_fdset(tmpbuf, tmpbufsize, __nfds, __readfds), 
 			   sprintf_fdset(tmpbuf2, tmpbufsize, __nfds, __writefds));
@@ -1397,6 +1402,9 @@ int select_helper(int __nfds,
 		if (g_vlogger_level >= VLOG_FUNC) {
 			const int tmpbufsize = 256;
 			char tmpbuf[tmpbufsize], tmpbuf2[tmpbufsize];
+			NOT_IN_USE(tmpbufsize); /* to suppress warning in case VMA_OPTIMIZE_LOG */
+			NOT_IN_USE(tmpbuf); /* to suppress warning in case VMA_OPTIMIZE_LOG */
+			NOT_IN_USE(tmpbuf2); /* to suppress warning in case VMA_OPTIMIZE_LOG */
 			srdr_logfunc_exit("readfds: %s, writefds: %s",
 				   sprintf_fdset(tmpbuf, tmpbufsize, __nfds, __readfds),
 				   sprintf_fdset(tmpbuf2, tmpbufsize, __nfds, __writefds));
@@ -1601,6 +1609,7 @@ int epoll_ctl(int __epfd, int __op, int __fd, struct epoll_event *__event)
 	     "DEL",
 	     "MOD"
 	};
+	NOT_IN_USE(op_names); /* to suppress warning in case VMA_OPTIMIZE_LOG */
 	if (__event) {
 		srdr_logfunc_entry("epfd=%d, op=%s, fd=%d, events=%#x, data=%x", 
 			__epfd, op_names[__op], __fd, __event->events, __event->data.u64);

--- a/src/vma/sock/sockinfo_tcp.cpp
+++ b/src/vma/sock/sockinfo_tcp.cpp
@@ -1229,6 +1229,7 @@ err_t sockinfo_tcp::ack_recvd_lwip_cb(void *arg, struct tcp_pcb *tpcb, u16_t ack
 {
 	sockinfo_tcp *conn = (sockinfo_tcp *)arg;
 
+	NOT_IN_USE(tpcb); /* to suppress warning in case VMA_OPTIMIZE_LOG */
 	assert((uintptr_t)tpcb->my_container == (uintptr_t)arg);
 
 	vlog_func_enter();


### PR DESCRIPTION
These changes allow to exclude debug level logging from
binary. It does not impact panic, err, warn and info output.
In addition it disable/enable assert() calls.
It is controlled by --enable-opt-log configuration option (default off).

Signed-off-by: Igor Ivanov <igor.ivanov.va@gmail.com>

Motivation:
 - this change is able to improve performance (for example: sockperf pp -m202 --tcp reports ~100-150ns benefit)

Note:
 - if we need to ON this by default keeping in mind that it cuts off debug output more than INFO level.