### PR TITLE
Issue: 777420 Add support for auto accept

### DIFF
--- a/src/vma/sock/sockinfo_tcp.h
+++ b/src/vma/sock/sockinfo_tcp.h
@@ -206,7 +206,6 @@ protected:
 
 private:
 	vma_completion_t* m_p_vma_completion;
-	vma_completion_t* m_last_cmp;
 	vma_buff_t* m_last_poll_vma_buff_lst;
 	//lwip specific things
 	struct tcp_pcb m_pcb;
@@ -278,6 +277,9 @@ private:
 
 	//Builds rfs key
 	static void create_flow_tuple_key_from_pcb(flow_tuple &key, struct tcp_pcb *pcb);
+
+	//auto accept function
+	static void auto_accept_connection(sockinfo_tcp *parent, sockinfo_tcp *child);
 
 	// accept cb func
 	static err_t accept_lwip_cb(void *arg, struct tcp_pcb *child_pcb, err_t err);


### PR DESCRIPTION
This commit adds auto accept support for vma_poll():
- When connection on server side enters into established state
  VMA generates VMA_POLL_NEW_CONNECTION_ACCEPTED event.
- EPOLLIN event is not reported for the listen socket.
- No need calling accept() but application can start immediately
  getting packets from the new connection via vma_poll().

Signed-off-by: Alex Vainman <alexv@mellanox.com>