### PR TITLE
issue: 804206 DNS server (UDP,port 53) to be handled by OS by default

### DIFF
--- a/src/vma/util/libvma.conf
+++ b/src/vma/util/libvma.conf
@@ -25,6 +25,10 @@
 application-id * *
 
 #
+# By default DNS server-side protocol (UDP, port 53) is handled by OS
+use os udp_connect *:53
+
+#
 ##############################################################################
 #
 # SPECIFICATION OF THE TARGET PROCCESS


### PR DESCRIPTION
Add to libvma.conf file: by default use OS for handling DNS server side
UDP port 53

Signed-off-by: Ophir Munk <ophirmu@mellanox.com>