### PR TITLE
issue: 786406 Make coverity check stronger

### DIFF
--- a/contrib/jenkins_tests/cov.sh
+++ b/contrib/jenkins_tests/cov.sh
@@ -29,7 +29,7 @@ for excl in $cov_exclude_file_list; do
     sleep 1
 done
 
-eval "cov-analyze --dir $cov_build --config ${WORKSPACE}/coverity_vma_config.xml"
+eval "cov-analyze --enable-fnptr --fnptr-models --all --paths 20000 --dir $cov_build --config ${WORKSPACE}/coverity_vma_config.xml"
 rc=$(($rc+$?))
 
 set -eE

--- a/contrib/test_jenkins.sh
+++ b/contrib/test_jenkins.sh
@@ -10,7 +10,7 @@ echo
 
 source $(dirname $0)/jenkins_tests/globals.sh
 
-export PATH=/hpc/local/bin::/usr/local/bin:/bin:/usr/bin:/usr/sbin:${PATH}
+export PATH=${PATH}:/hpc/local/bin
 env
 
 rel_path=$(dirname $0)


### PR DESCRIPTION
Added additional option for analyzes:
--enable-fnptr --fnptr-models - follows function pointers (by default it doesn't)
--all - add some checkers
--paths - increases number of paths checked (default is 5k, it increase cov run duration)

Signed-off-by: Igor Ivanov <igor.ivanov.va@gmail.com>

New options enable new issues that should be resolved in separate PR.