### PR TITLE
issue: 816006 In case tcp sndbuf is 0 - poll once CQ for an ACK (non-blocking rx)

### DIFF
--- a/src/vma/sock/sockinfo_tcp.h
+++ b/src/vma/sock/sockinfo_tcp.h
@@ -322,6 +322,9 @@ private:
 	static err_t ack_recvd_lwip_cb(void *arg, struct tcp_pcb *tpcb, u16_t space);
 	static err_t rx_lwip_cb(void *arg, struct tcp_pcb *tpcb, struct pbuf *p, err_t err);
 	static err_t rx_drop_lwip_cb(void *arg, struct tcp_pcb *tpcb, struct pbuf *p, err_t err);
+        
+	// poll once CQ. Motivation: in case sndbuf size is 0 - try polling for a pending ACK in CQ
+	unsigned rx_poll_once_non_blocking(int & err);
 
 	// Be sure that m_pcb is initialized
 	void set_conn_properties_from_pcb();

--- a/src/vma/sock/sockinfo_tcp.h
+++ b/src/vma/sock/sockinfo_tcp.h
@@ -281,6 +281,8 @@ private:
 	peer_map_t      m_rx_peer_packets;
 	vma_desc_list_t m_rx_ctl_reuse_list;
 	ready_pcb_map_t m_ready_pcbs;
+	static const unsigned RX_POLL_NON_BLOCK_THREASHOLD = 10;
+	unsigned m_rx_poll_non_block_counter;
 
 	inline void init_pbuf_custom(mem_buf_desc_t *p_desc);
 
@@ -324,7 +326,7 @@ private:
 	static err_t rx_drop_lwip_cb(void *arg, struct tcp_pcb *tpcb, struct pbuf *p, err_t err);
         
 	// poll once CQ. Motivation: in case sndbuf size is 0 - try polling for a pending ACK in CQ
-	unsigned rx_poll_once_non_blocking(int & err);
+	void rx_poll_once_non_blocking(int & err);
 
 	// Be sure that m_pcb is initialized
 	void set_conn_properties_from_pcb();

--- a/src/vma/sock/sockinfo_tcp.h
+++ b/src/vma/sock/sockinfo_tcp.h
@@ -281,8 +281,8 @@ private:
 	peer_map_t      m_rx_peer_packets;
 	vma_desc_list_t m_rx_ctl_reuse_list;
 	ready_pcb_map_t m_ready_pcbs;
-	static const unsigned RX_POLL_NON_BLOCK_THREASHOLD = 10;
-	unsigned m_rx_poll_non_block_counter;
+	static const unsigned TX_CONSECUTIVE_EAGAIN_THREASHOLD = 10;
+	unsigned m_tx_consecutive_eagain_count;
 
 	inline void init_pbuf_custom(mem_buf_desc_t *p_desc);
 
@@ -325,9 +325,6 @@ private:
 	static err_t rx_lwip_cb(void *arg, struct tcp_pcb *tpcb, struct pbuf *p, err_t err);
 	static err_t rx_drop_lwip_cb(void *arg, struct tcp_pcb *tpcb, struct pbuf *p, err_t err);
         
-	// poll once CQ. Motivation: in case sndbuf size is 0 - try polling for a pending ACK in CQ
-	void rx_poll_once_non_blocking(int & err);
-
 	// Be sure that m_pcb is initialized
 	void set_conn_properties_from_pcb();
 


### PR DESCRIPTION
If TCP sndbuf is 0 we are dependent on incoming ACKs to increase sndbuf. In
non-blocking mode only the internal thread is currently responsible for
draining the CQ and processing this ACK. However, the internal thread
operates by default once every 10ms.
This feature adds the user application as source of polling the CQ
immediately as part of tx() operation.
This feature is only applicable in non-blocking mode

Signed-off-by: Ophir Munk <ophirmu@mellanox.com>