### PR TITLE
issue: 822441 Support receive SW checksum

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -641,13 +641,12 @@ Disabled by default (enabling causing a slight performance
 degradation of ~50-100 nano sec per half round trip)
 
 VMA_RX_SW_CSUM
-Enable/Disable software checksum validation for receive IP and TCP/UDP packets.
-Software checksum validation will be compute (if enabled) only if HW checksum
-validation failed.
-Use value of 0 to disable.
-Use value of 1 for enable.
-Enabled by default (should cause a performance degradation if HW checksum
-validation is not supported)
+This parameter enables/disables software checksum validation for received IP packets (TCP and UDP packets).
+When this parameter is enabled, software checksum validation will be calculated only if hardware checksum
+validation was not performed (in which case a performance degradation might occur).
+Use value of 0 to disable the parameter.
+Use value of 1 to enable the parameter.
+Default value is 1.
 
 VMA_EXCEPTION_HANDLING
 Mode for handling missing support or error cases in Socket API or functionality by VMA.

--- a/README.txt
+++ b/README.txt
@@ -640,6 +640,15 @@ Use value of 2 for OS follow up.
 Disabled by default (enabling causing a slight performance
 degradation of ~50-100 nano sec per half round trip)
 
+VMA_RX_SW_CSUM
+Enable/Disable software checksum validation for receive IP and TCP/UDP packets.
+Software checksum validation will be compute (if enabled) only if HW checksum
+validation failed.
+Use value of 0 to disable.
+Use value of 1 for enable.
+Enabled by default (should cause a performance degradation if HW checksum
+validation is not supported)
+
 VMA_EXCEPTION_HANDLING
 Mode for handling missing support or error cases in Socket API or functionality by VMA.
 Useful for quickly identifying VMA unsupported Socket API or features

--- a/README.txt
+++ b/README.txt
@@ -641,12 +641,21 @@ Disabled by default (enabling causing a slight performance
 degradation of ~50-100 nano sec per half round trip)
 
 VMA_RX_SW_CSUM
-This parameter enables/disables software checksum validation for received IP packets (TCP and UDP packets).
-When this parameter is enabled, software checksum validation will be calculated only if hardware checksum
-validation was not performed (in which case a performance degradation might occur).
-Use value of 0 to disable the parameter.
-Use value of 1 to enable the parameter.
-Default value is 1.
+This parameter enables/disables software checksum validation for ingress TCP/UDP IP packets.
+Most Mellanox HCAs support hardware offload checksum validation. If the hardware does not
+support checksum validation offload, software checksum validation is required.
+When this parameter is enabled, software checksum validation is calculated only if hardware
+offload checksum validation is not performed.
+Performance degradation might occur if hardware offload fails to validate checksum and
+software calculation is used.
+Note that disabling software calculation might cause corrupt packets to be
+processed by VMA and the application, when the hardware does not perform this action.
+For further details on which adapter card supports hardware offload checksum validation,
+please refer to the VMA Release Notes.
+Valid Values are:
+Use value of 0 to disable.
+Use value of 1 for enable.
+Default value is Enabled.
 
 VMA_EXCEPTION_HANDLING
 Mode for handling missing support or error cases in Socket API or functionality by VMA.

--- a/src/vma/dev/cq_mgr.cpp
+++ b/src/vma/dev/cq_mgr.cpp
@@ -236,10 +236,10 @@ cq_mgr::cq_mgr(ring_simple* p_ring, ib_ctx_handler* p_ib_ctx_handler, int cq_siz
 	if (m_b_is_rx)
 		vma_stats_instance_create_cq_block(m_p_cq_stat);
 
-	m_b_is_rx_csum_on = false;
+	m_b_is_rx_hw_csum_on = false;
 	if (m_b_is_rx) {
-		m_b_is_rx_csum_on = vma_is_rx_csum_supported(m_p_ib_ctx_handler->get_ibv_device_attr());
-		cq_logdbg("RX CSUM support = %d", m_b_is_rx_csum_on);
+		m_b_is_rx_hw_csum_on = vma_is_rx_hw_csum_supported(m_p_ib_ctx_handler->get_ibv_device_attr());
+		cq_logdbg("RX CSUM support = %d", m_b_is_rx_hw_csum_on);
 	}
 
 	cq_logdbg("Created CQ as %s with fd[%d] and of size %d elements (ibv_cq_hndl=%p)", (m_b_is_rx?"Rx":"Tx"), get_channel_fd(), cq_size, m_p_ibv_cq);
@@ -466,7 +466,7 @@ void cq_mgr::process_cq_element_log_helper(mem_buf_desc_t* p_mem_buf_desc, vma_i
 	// wce with bad status value
 	if (p_wce->status == IBV_WC_SUCCESS) {
 		cq_logdbg("wce: wr_id=%#x, status=%#x, vendor_err=%#x, qp_num=%#x", p_wce->wr_id, p_wce->status, p_wce->vendor_err, p_wce->qp_num);
-		if (m_b_is_rx_csum_on && ! vma_wc_rx_csum_ok(*p_wce))
+		if (m_b_is_rx_hw_csum_on && ! vma_wc_rx_hw_csum_ok(*p_wce))
 			cq_logdbg("wce: bad rx_csum");
 		cq_logdbg("wce: opcode=%#x, byte_len=%#d, src_qp=%#x, wc_flags=%#x", vma_wc_opcode(*p_wce), p_wce->byte_len, p_wce->src_qp, vma_wc_flags(*p_wce));
 		cq_logdbg("wce: pkey_index=%#x, slid=%#x, sl=%#x, dlid_path_bits=%#x, imm_data=%#x", p_wce->pkey_index, p_wce->slid, p_wce->sl, p_wce->dlid_path_bits, p_wce->imm_data);
@@ -527,6 +527,9 @@ mem_buf_desc_t* cq_mgr::process_cq_element_rx(vma_ibv_wc* p_wce)
 	mem_buf_desc_t* p_mem_buf_desc = (mem_buf_desc_t*)(uintptr_t)p_wce->wr_id;
 
 	bool bad_wce = p_wce->status != IBV_WC_SUCCESS;
+	if  (!safe_mce_sys().rx_sw_csum) {
+		bad_wce |= m_b_is_rx_hw_csum_on && !vma_wc_rx_hw_csum_ok(*p_wce);
+	}
 
 	if (unlikely(bad_wce || p_mem_buf_desc == NULL)) {
 		if (p_mem_buf_desc == NULL) {
@@ -562,7 +565,7 @@ mem_buf_desc_t* cq_mgr::process_cq_element_rx(vma_ibv_wc* p_wce)
 		p_mem_buf_desc->p_prev_desc = NULL;
 	}
 
-	p_mem_buf_desc->hw_csum_validation = m_b_is_rx_csum_on && vma_wc_rx_csum_ok(*p_wce);
+	p_mem_buf_desc->is_rx_sw_csum_need = safe_mce_sys().rx_sw_csum ? !(m_b_is_rx_hw_csum_on && vma_wc_rx_hw_csum_ok(*p_wce)) : false;
 
 	if (likely(vma_wc_opcode(*p_wce) & VMA_IBV_WC_RECV)) {
 		p_mem_buf_desc->path.rx.qpn = p_wce->qp_num; //todo not used

--- a/src/vma/dev/cq_mgr.cpp
+++ b/src/vma/dev/cq_mgr.cpp
@@ -168,7 +168,8 @@ inline uint32_t cq_mgr::process_recv_queue(void* pv_fd_ready_array)
 }
 
 cq_mgr::cq_mgr(ring_simple* p_ring, ib_ctx_handler* p_ib_ctx_handler, int cq_size, struct ibv_comp_channel* p_comp_event_channel, bool is_rx) :
-		m_p_ring(p_ring), m_p_ib_ctx_handler(p_ib_ctx_handler), m_b_is_rx(is_rx), m_comp_event_channel(p_comp_event_channel), m_p_next_rx_desc_poll(NULL)
+		m_p_ring(p_ring), m_p_ib_ctx_handler(p_ib_ctx_handler), m_b_is_rx(is_rx), m_b_is_rx_sw_csum_on(safe_mce_sys().rx_sw_csum),
+		m_comp_event_channel(p_comp_event_channel), m_p_next_rx_desc_poll(NULL)
 {
 	cq_logfunc("");
 
@@ -527,8 +528,14 @@ mem_buf_desc_t* cq_mgr::process_cq_element_rx(vma_ibv_wc* p_wce)
 	mem_buf_desc_t* p_mem_buf_desc = (mem_buf_desc_t*)(uintptr_t)p_wce->wr_id;
 
 	bool bad_wce = p_wce->status != IBV_WC_SUCCESS;
-	if  (!safe_mce_sys().rx_sw_csum) {
-		bad_wce |= m_b_is_rx_hw_csum_on && !vma_wc_rx_hw_csum_ok(*p_wce);
+	bool is_rx_sw_csum_need;
+
+	if  (m_b_is_rx_sw_csum_on) {
+		// no changes in bad_wce
+		is_rx_sw_csum_need = !(m_b_is_rx_hw_csum_on && vma_wc_rx_hw_csum_ok(*p_wce));
+	} else {
+		bad_wce =  bad_wce || (m_b_is_rx_hw_csum_on && !vma_wc_rx_hw_csum_ok(*p_wce));
+		is_rx_sw_csum_need = false;
 	}
 
 	if (unlikely(bad_wce || p_mem_buf_desc == NULL)) {
@@ -565,7 +572,7 @@ mem_buf_desc_t* cq_mgr::process_cq_element_rx(vma_ibv_wc* p_wce)
 		p_mem_buf_desc->p_prev_desc = NULL;
 	}
 
-	p_mem_buf_desc->is_rx_sw_csum_need = safe_mce_sys().rx_sw_csum ? !(m_b_is_rx_hw_csum_on && vma_wc_rx_hw_csum_ok(*p_wce)) : false;
+	p_mem_buf_desc->is_rx_sw_csum_need = is_rx_sw_csum_need;
 
 	if (likely(vma_wc_opcode(*p_wce) & VMA_IBV_WC_RECV)) {
 		p_mem_buf_desc->path.rx.qpn = p_wce->qp_num; //todo not used

--- a/src/vma/dev/cq_mgr.cpp
+++ b/src/vma/dev/cq_mgr.cpp
@@ -526,8 +526,7 @@ mem_buf_desc_t* cq_mgr::process_cq_element_rx(vma_ibv_wc* p_wce)
 	// Get related mem_buf_desc pointer from the wr_id
 	mem_buf_desc_t* p_mem_buf_desc = (mem_buf_desc_t*)(uintptr_t)p_wce->wr_id;
 
-	bool bad_wce = (p_wce->status != IBV_WC_SUCCESS) ||
-			(m_b_is_rx_csum_on && !vma_wc_rx_csum_ok(*p_wce));
+	bool bad_wce = p_wce->status != IBV_WC_SUCCESS;
 
 	if (unlikely(bad_wce || p_mem_buf_desc == NULL)) {
 		if (p_mem_buf_desc == NULL) {
@@ -562,6 +561,8 @@ mem_buf_desc_t* cq_mgr::process_cq_element_rx(vma_ibv_wc* p_wce)
 		m_p_next_rx_desc_poll = p_mem_buf_desc->p_prev_desc;
 		p_mem_buf_desc->p_prev_desc = NULL;
 	}
+
+	p_mem_buf_desc->hw_csum_validation = m_b_is_rx_csum_on && vma_wc_rx_csum_ok(*p_wce);
 
 	if (likely(vma_wc_opcode(*p_wce) & VMA_IBV_WC_RECV)) {
 		p_mem_buf_desc->path.rx.qpn = p_wce->qp_num; //todo not used

--- a/src/vma/dev/cq_mgr.h
+++ b/src/vma/dev/cq_mgr.h
@@ -175,6 +175,7 @@ private:
 	ib_ctx_handler*			m_p_ib_ctx_handler;
 	bool				m_b_is_rx;
 	bool				m_b_is_rx_hw_csum_on;
+	const bool			m_b_is_rx_sw_csum_on;
 	struct ibv_comp_channel*	m_comp_event_channel;
 	struct ibv_cq*			m_p_ibv_cq;
 	bool				m_b_notification_armed;

--- a/src/vma/dev/cq_mgr.h
+++ b/src/vma/dev/cq_mgr.h
@@ -174,7 +174,7 @@ private:
 	ring_simple*		m_p_ring;
 	ib_ctx_handler*			m_p_ib_ctx_handler;
 	bool				m_b_is_rx;
-	bool				m_b_is_rx_csum_on;
+	bool				m_b_is_rx_hw_csum_on;
 	struct ibv_comp_channel*	m_comp_event_channel;
 	struct ibv_cq*			m_p_ibv_cq;
 	bool				m_b_notification_armed;

--- a/src/vma/dev/ring_simple.cpp
+++ b/src/vma/dev/ring_simple.cpp
@@ -785,9 +785,7 @@ bool ring_simple::rx_process_buffer(mem_buf_desc_t* p_rx_wc_buf_desc, transport_
 #endif
 	}
 
-	bool enable_sw_csum = safe_mce_sys().rx_sw_csum && !p_rx_wc_buf_desc->hw_csum_validation;
-
-	if (enable_sw_csum && compute_ip_checksum((unsigned short*)p_ip_h, p_ip_h->ihl * 2)) {
+	if (p_rx_wc_buf_desc->is_rx_sw_csum_need && compute_ip_checksum((unsigned short*)p_ip_h, p_ip_h->ihl * 2)) {
 		return false; // false ip checksum
 	}
 
@@ -814,7 +812,7 @@ bool ring_simple::rx_process_buffer(mem_buf_desc_t* p_rx_wc_buf_desc, transport_
 		// Get the udp header pointer + udp payload size
 		p_udp_h = (struct udphdr*)((uint8_t*)p_ip_h + ip_hdr_len);
 
-		if (enable_sw_csum && !p_udp_h->check && compute_udp_checksum(p_ip_h, (unsigned short*) p_udp_h)) {
+		if (p_rx_wc_buf_desc->is_rx_sw_csum_need && !p_udp_h->check && compute_udp_checksum(p_ip_h, (unsigned short*) p_udp_h)) {
 			return false; // false udp checksum
 		}
 
@@ -846,7 +844,7 @@ bool ring_simple::rx_process_buffer(mem_buf_desc_t* p_rx_wc_buf_desc, transport_
 		// Get the tcp header pointer + tcp payload size
 		struct tcphdr* p_tcp_h = (struct tcphdr*)((uint8_t*)p_ip_h + ip_hdr_len);
 
-		if (enable_sw_csum && compute_tcp_checksum(p_ip_h, (unsigned short*) p_tcp_h)) {
+		if (p_rx_wc_buf_desc->is_rx_sw_csum_need && compute_tcp_checksum(p_ip_h, (unsigned short*) p_tcp_h)) {
 			return false; // false tcp checksum
 		}
 

--- a/src/vma/main.cpp
+++ b/src/vma/main.cpp
@@ -466,6 +466,7 @@ void print_vma_global_settings()
 	}
 
 	VLOG_PARAM_NUMBER("Rx UDP HW TS Conversion", safe_mce_sys().rx_udp_hw_ts_conversion, MCE_DEFAULT_RX_UDP_HW_TS_CONVERSION, SYS_VAR_RX_UDP_HW_TS_CONVERSION);
+	VLOG_PARAM_NUMBER("Rx SW CSUM", safe_mce_sys().rx_sw_csum, MCE_DEFUALT_RX_SW_CSUM, SYS_VAR_RX_SW_CSUM);
 	if (safe_mce_sys().rx_poll_yield_loops) {
 		VLOG_PARAM_NUMBER("Rx Poll Yield", safe_mce_sys().rx_poll_yield_loops, MCE_DEFAULT_RX_POLL_YIELD, SYS_VAR_RX_POLL_YIELD);
 	}
@@ -715,7 +716,7 @@ void igmp_test()
 	p_pkt->m_ip_hdr.tot_len = htons(IPV4_IGMP_HDR_LEN + sizeof(igmphdr));
 	p_pkt->m_ip_hdr_ext = htonl(IGMP_IP_HEADER_EXT);
 	p_pkt->m_ip_hdr.check = 0;
-	p_pkt->m_ip_hdr.check = csum((unsigned short*)&p_pkt->m_ip_hdr, (IPV4_IGMP_HDR_LEN_WORDS) * 2);
+	p_pkt->m_ip_hdr.check = compute_ip_checksum((unsigned short*)&p_pkt->m_ip_hdr, (IPV4_IGMP_HDR_LEN_WORDS) * 2);
 
 	// Create the IGMP header
 	p_pkt->m_igmp_hdr.type = IGMP_QUERY;
@@ -723,7 +724,7 @@ void igmp_test()
 	p_pkt->m_igmp_hdr.group = (in_addr_t)inet_addr("224.4.4.4");
 
 	p_pkt->m_igmp_hdr.csum = 0;
-	p_pkt->m_igmp_hdr.csum = csum((unsigned short*)&p_pkt->m_igmp_hdr, IGMP_HDR_LEN_WORDS * 2);
+	p_pkt->m_igmp_hdr.csum = compute_ip_checksum((unsigned short*)&p_pkt->m_igmp_hdr, IGMP_HDR_LEN_WORDS * 2);
 
 	g_p_igmp_mgr->process_igmp_packet(&p_pkt->m_ip_hdr, (in_addr_t)inet_addr("2.2.2.16"));
 }

--- a/src/vma/proto/dst_entry_tcp.cpp
+++ b/src/vma/proto/dst_entry_tcp.cpp
@@ -120,11 +120,11 @@ ssize_t dst_entry_tcp::fast_send(const struct iovec* p_iov, const ssize_t sz_iov
 
 #ifdef VMA_NO_HW_CSUM
 		p_pkt->hdr.m_ip_hdr.check = 0; // use 0 at csum calculation time
-		p_pkt->hdr.m_ip_hdr.check = csum((unsigned short*)&p_pkt->hdr.m_ip_hdr, p_pkt->hdr.m_ip_hdr.ihl * 2);
+		p_pkt->hdr.m_ip_hdr.check = compute_ip_checksum((unsigned short*)&p_pkt->hdr.m_ip_hdr, p_pkt->hdr.m_ip_hdr.ihl * 2);
 		struct tcphdr* p_tcphdr = (struct tcphdr*)(((uint8_t*)(&(p_pkt->hdr.m_ip_hdr))+sizeof(p_pkt->hdr.m_ip_hdr)));
 		p_tcphdr->check = 0;
 		p_tcphdr->check = compute_tcp_checksum(&p_pkt->hdr.m_ip_hdr, (const uint16_t *)p_tcphdr);
-		dst_tcp_logfine("using SW checksum calculation: p_pkt->hdr.m_ip_hdr.check=%d, p_tcphdr->check=%d", (int)p_tcphdr->check, (int)p_pkt->hdr.m_ip_hdr.check);
+		dst_tcp_logfine("using SW checksum calculation: p_pkt->hdr.m_ip_hdr.check=%d, p_tcphdr->check=%d", (int)p_pkt->hdr.m_ip_hdr.check, (int)p_tcphdr->check);
 #endif
 		m_p_ring->send_lwip_buffer(m_id, m_p_send_wqe, b_blocked);
 	}
@@ -161,11 +161,11 @@ ssize_t dst_entry_tcp::fast_send(const struct iovec* p_iov, const ssize_t sz_iov
 		p_pkt->hdr.m_ip_hdr.tot_len = (htons)(m_sge[0].length - m_header.m_transport_header_len);
 #ifdef VMA_NO_HW_CSUM
 		p_pkt->hdr.m_ip_hdr.check = 0; // use 0 at csum calculation time
-		p_pkt->hdr.m_ip_hdr.check = csum((unsigned short*)&p_pkt->hdr.m_ip_hdr, p_pkt->hdr.m_ip_hdr.ihl * 2);
+		p_pkt->hdr.m_ip_hdr.check = compute_ip_checksum((unsigned short*)&p_pkt->hdr.m_ip_hdr, p_pkt->hdr.m_ip_hdr.ihl * 2);
 		struct tcphdr* p_tcphdr = (struct tcphdr*)(((uint8_t*)(&(p_pkt->hdr.m_ip_hdr))+sizeof(p_pkt->hdr.m_ip_hdr)));
 		p_tcphdr->check = 0;
 		p_tcphdr->check = compute_tcp_checksum(&p_pkt->hdr.m_ip_hdr, (const uint16_t *)p_tcphdr);
-		dst_tcp_logfine("using SW checksum calculation: p_pkt->hdr.m_ip_hdr.check=%d, p_tcphdr->check=%d", (int)p_tcphdr->check, (int)p_pkt->hdr.m_ip_hdr.check);
+		dst_tcp_logfine("using SW checksum calculation: p_pkt->hdr.m_ip_hdr.check=%d, p_tcphdr->check=%d", (int)p_pkt->hdr.m_ip_hdr.check, (int)p_tcphdr->check);
 #endif
 		m_p_send_wqe = &m_not_inline_send_wqe;
 		m_p_send_wqe->wr_id = (uintptr_t)p_mem_buf_desc;

--- a/src/vma/proto/dst_entry_udp.cpp
+++ b/src/vma/proto/dst_entry_udp.cpp
@@ -110,7 +110,7 @@ ssize_t dst_entry_udp::fast_send(const iovec* p_iov, const ssize_t sz_iov, bool 
 #ifdef VMA_NO_HW_CSUM
 		dst_udp_logfunc("using SW checksum calculation");
 		m_header.m_header.hdr.m_ip_hdr.check = 0; // use 0 at csum calculation time
-		m_header.m_header.hdr.m_ip_hdr.check = csum((unsigned short*)&m_header.m_header.hdr.m_ip_hdr, m_header.m_header.hdr.m_ip_hdr.ihl * 2);
+		m_header.m_header.hdr.m_ip_hdr.check = compute_ip_checksum((unsigned short*)&m_header.m_header.hdr.m_ip_hdr, m_header.m_header.hdr.m_ip_hdr.ihl * 2);
 #endif
 		// Get a bunch of tx buf descriptor and data buffers
 		if (unlikely(m_p_tx_mem_buf_desc_list == NULL)) {
@@ -237,7 +237,7 @@ ssize_t dst_entry_udp::fast_send(const iovec* p_iov, const ssize_t sz_iov, bool 
 			if (b_need_sw_csum) {
 				dst_udp_logfunc("ip fragmentation detected, using SW checksum calculation");
 				p_pkt->hdr.m_ip_hdr.check = 0; // use 0 at csum calculation time
-				p_pkt->hdr.m_ip_hdr.check = csum((unsigned short*)&p_pkt->hdr.m_ip_hdr, p_pkt->hdr.m_ip_hdr.ihl * 2);
+				p_pkt->hdr.m_ip_hdr.check = compute_ip_checksum((unsigned short*)&p_pkt->hdr.m_ip_hdr, p_pkt->hdr.m_ip_hdr.ihl * 2);
 				m_p_send_wqe_handler->disable_hw_csum(m_not_inline_send_wqe);
 			} else {
 				dst_udp_logfunc("using HW checksum calculation");

--- a/src/vma/proto/igmp_handler.cpp
+++ b/src/vma/proto/igmp_handler.cpp
@@ -224,12 +224,12 @@ void igmp_handler::set_ip_igmp_hdr(ip_igmp_tx_hdr_template_t* ip_igmp_hdr)
 	ip_igmp_hdr->m_ip_hdr.tot_len = htons(IPV4_IGMP_HDR_LEN + sizeof(igmphdr));
 	ip_igmp_hdr->m_ip_hdr_ext = htonl(IGMP_IP_HEADER_EXT);
 	ip_igmp_hdr->m_ip_hdr.check = 0;
-	ip_igmp_hdr->m_ip_hdr.check = csum((unsigned short*)&ip_igmp_hdr->m_ip_hdr, (IPV4_IGMP_HDR_LEN_WORDS) * 2);
+	ip_igmp_hdr->m_ip_hdr.check = compute_ip_checksum((unsigned short*)&ip_igmp_hdr->m_ip_hdr, (IPV4_IGMP_HDR_LEN_WORDS) * 2);
 
 	// Create the IGMP header
 	ip_igmp_hdr->m_igmp_hdr.type = IGMPV2_HOST_MEMBERSHIP_REPORT;
 	ip_igmp_hdr->m_igmp_hdr.code = 0;
 	ip_igmp_hdr->m_igmp_hdr.group = m_mc_addr.get_in_addr();
 	ip_igmp_hdr->m_igmp_hdr.csum = 0;
-	ip_igmp_hdr->m_igmp_hdr.csum = csum((unsigned short*)&ip_igmp_hdr->m_igmp_hdr, IGMP_HDR_LEN_WORDS * 2);
+	ip_igmp_hdr->m_igmp_hdr.csum = compute_ip_checksum((unsigned short*)&ip_igmp_hdr->m_igmp_hdr, IGMP_HDR_LEN_WORDS * 2);
 }

--- a/src/vma/proto/mem_buf_desc.h
+++ b/src/vma/proto/mem_buf_desc.h
@@ -93,6 +93,7 @@ public:
 	inline int dec_ref_count() {return atomic_fetch_and_dec(&n_ref_count);}
 
 	bool		b_is_tx_mc_loop_dis; // if the mc loop on the tx side is disabled (the loop is per interface)
+	bool		hw_csum_validation;
 	int8_t		n_frags;	//number of fragments
 	size_t		transport_header_len;
 

--- a/src/vma/proto/mem_buf_desc.h
+++ b/src/vma/proto/mem_buf_desc.h
@@ -93,7 +93,7 @@ public:
 	inline int dec_ref_count() {return atomic_fetch_and_dec(&n_ref_count);}
 
 	bool		b_is_tx_mc_loop_dis; // if the mc loop on the tx side is disabled (the loop is per interface)
-	bool		hw_csum_validation;
+	bool		is_rx_sw_csum_need;
 	int8_t		n_frags;	//number of fragments
 	size_t		transport_header_len;
 

--- a/src/vma/proto/neighbour.cpp
+++ b/src/vma/proto/neighbour.cpp
@@ -474,7 +474,7 @@ bool neigh_entry::post_send_udp(iovec * iov, header *h)
 		if (b_need_sw_csum) {
 			neigh_logdbg("ip fragmentation detected, using SW checksum calculation");
 			p_pkt->hdr.m_ip_hdr.check = 0; // use 0 at csum calculation time
-			p_pkt->hdr.m_ip_hdr.check = csum((unsigned short*)&p_pkt->hdr.m_ip_hdr, p_pkt->hdr.m_ip_hdr.ihl * 2);
+			p_pkt->hdr.m_ip_hdr.check = compute_ip_checksum((unsigned short*)&p_pkt->hdr.m_ip_hdr, p_pkt->hdr.m_ip_hdr.ihl * 2);
 			wqe_sh.disable_hw_csum(m_send_wqe);
 		} else {
 			neigh_logdbg("using HW checksum calculation");
@@ -559,7 +559,7 @@ bool neigh_entry::post_send_tcp(iovec *iov, header *h)
 	m_send_wqe.wr_id = (uintptr_t)p_mem_buf_desc;
 #ifdef VMA_NO_HW_CSUM
 		p_pkt->hdr.m_ip_hdr.check = 0; // use 0 at csum calculation time
-		p_pkt->hdr.m_ip_hdr.check = csum((unsigned short*)&p_pkt->hdr.m_ip_hdr, p_pkt->hdr.m_ip_hdr.ihl * 2);
+		p_pkt->hdr.m_ip_hdr.check = compute_ip_checksum((unsigned short*)&p_pkt->hdr.m_ip_hdr, p_pkt->hdr.m_ip_hdr.ihl * 2);
 		struct tcphdr* p_tcphdr = (struct tcphdr*)(((uint8_t*)(&(p_pkt->hdr.m_ip_hdr))+sizeof(p_pkt->hdr.m_ip_hdr)));
 		p_tcphdr->check = 0;
 		p_tcphdr->check = compute_tcp_checksum(&p_pkt->hdr.m_ip_hdr, (const uint16_t *)p_tcphdr);

--- a/src/vma/util/sys_vars.cpp
+++ b/src/vma/util/sys_vars.cpp
@@ -354,6 +354,7 @@ void mce_sys_var::get_env_params()
 	rx_poll_num_init        = MCE_DEFAULT_RX_NUM_POLLS_INIT;
 	rx_udp_poll_os_ratio    = MCE_DEFAULT_RX_UDP_POLL_OS_RATIO;
 	rx_udp_hw_ts_conversion = MCE_DEFAULT_RX_UDP_HW_TS_CONVERSION;
+	rx_sw_csum         	= MCE_DEFUALT_RX_SW_CSUM;
 	rx_poll_yield_loops     = MCE_DEFAULT_RX_POLL_YIELD;
 	select_handle_cpu_usage_stats   = MCE_DEFAULT_SELECT_CPU_USAGE_STATS;
 	rx_ready_byte_min_limit = MCE_DEFAULT_RX_BYTE_MIN_LIMIT;
@@ -628,6 +629,10 @@ void mce_sys_var::get_env_params()
 			vlog_printf(VLOG_WARNING,"Rx UDP HW TS conversion size out of range [%d] (min=%d, max=%d). using default [%d]\n", rx_udp_hw_ts_conversion, TS_CONVERSION_MODE_DISABLE , TS_CONVERSION_MODE_LAST - 1, MCE_DEFAULT_RX_UDP_HW_TS_CONVERSION);
 			rx_udp_hw_ts_conversion = MCE_DEFAULT_RX_UDP_HW_TS_CONVERSION;
 		}
+	}
+
+	if ((env_ptr = getenv(SYS_VAR_RX_SW_CSUM)) != NULL) {
+		rx_sw_csum = atoi(env_ptr) ? true : false;
 	}
 
 	//The following 2 params were replaced by SYS_VAR_RX_UDP_POLL_OS_RATIO

--- a/src/vma/util/sys_vars.h
+++ b/src/vma/util/sys_vars.h
@@ -318,6 +318,7 @@ struct mce_sys_var {
 	int32_t		rx_poll_num_init;
 	uint32_t 	rx_udp_poll_os_ratio;
 	ts_conversion_mode_t	rx_udp_hw_ts_conversion;
+	bool 		rx_sw_csum;
 	uint32_t 	rx_poll_yield_loops;
 	uint32_t 	rx_skip_os_fd_check;
 	uint32_t 	rx_ready_byte_min_limit;
@@ -446,6 +447,7 @@ extern mce_sys_var & safe_mce_sys();
 #define SYS_VAR_RX_NUM_POLLS_INIT			"VMA_RX_POLL_INIT"
 #define SYS_VAR_RX_UDP_POLL_OS_RATIO			"VMA_RX_UDP_POLL_OS_RATIO"
 #define SYS_VAR_RX_UDP_HW_TS_CONVERSION		"VMA_RX_UDP_HW_TS_CONVERSION"
+#define SYS_VAR_RX_SW_CSUM				"VMA_RX_SW_CSUM"
 // The following 2 params were replaced by VMA_RX_UDP_POLL_OS_RATIO
 #define SYS_VAR_RX_POLL_OS_RATIO                       "VMA_RX_POLL_OS_RATIO"
 #define SYS_VAR_RX_SKIP_OS                             "VMA_RX_SKIP_OS"
@@ -555,6 +557,7 @@ extern mce_sys_var & safe_mce_sys();
 #define MCE_DEFAULT_RX_NUM_POLLS_INIT			(0)
 #define MCE_DEFAULT_RX_UDP_POLL_OS_RATIO		(100)
 #define MCE_DEFAULT_RX_UDP_HW_TS_CONVERSION		(TS_CONVERSION_MODE_SYNC)
+#define MCE_DEFUALT_RX_SW_CSUM				(true)
 #define MCE_DEFAULT_RX_POLL_YIELD			(0)
 #define MCE_DEFAULT_RX_BYTE_MIN_LIMIT			(65536)
 #define MCE_DEFAULT_RX_PREFETCH_BYTES			(256)

--- a/src/vma/util/utils.cpp
+++ b/src/vma/util/utils.cpp
@@ -184,11 +184,11 @@ unsigned short compute_tcp_checksum(const struct iphdr *p_iphdr, const uint16_t 
 
     //add the pseudo header
     //the source ip
-    sum += (p_iphdr->saddr>>16)&0xFFFF;
-    sum += (p_iphdr->saddr)&0xFFFF;
+    sum += (p_iphdr->saddr >> 16) & 0xFFFF;
+    sum += (p_iphdr->saddr) & 0xFFFF;
     //the dest ip
-    sum += (p_iphdr->daddr>>16)&0xFFFF;
-    sum += (p_iphdr->daddr)&0xFFFF;
+    sum += (p_iphdr->daddr >> 16) & 0xFFFF;
+    sum += (p_iphdr->daddr) & 0xFFFF;
     //protocol and reserved: 6
     sum += htons(IPPROTO_TCP);
     //the length
@@ -224,11 +224,11 @@ unsigned short compute_udp_checksum(const struct iphdr *p_iphdr, const uint16_t 
     unsigned short udp_len = htons(udphdrp->len);
 
     //add the pseudo header
-    sum += (p_iphdr->saddr>>16)&0xFFFF;
-    sum += (p_iphdr->saddr)&0xFFFF;
+    sum += (p_iphdr->saddr >> 16) & 0xFFFF;
+    sum += (p_iphdr->saddr) & 0xFFFF;
     //the dest ip
-    sum += (p_iphdr->daddr>>16)&0xFFFF;
-    sum += (p_iphdr->daddr)&0xFFFF;
+    sum += (p_iphdr->daddr >> 16) & 0xFFFF;
+    sum += (p_iphdr->daddr) & 0xFFFF;
     //protocol and reserved: 17
     sum += htons(IPPROTO_UDP);
     //the length

--- a/src/vma/util/utils.h
+++ b/src/vma/util/utils.h
@@ -56,15 +56,21 @@ struct iphdr; //forward declaration
 int check_if_regular_file (char *path);
 
 /**
- * Check Sum extensions
+ * IP Header Checksum Calculation
  */
-unsigned short csum(const unsigned short *buf, unsigned int nshort_words);
+unsigned short compute_ip_checksum(const unsigned short *buf, unsigned int nshort_words);
 
 /**
 * get tcp checksum: given IP header and tcp segment (assume checksum field in TCP header contains zero)
 * matches RFC 793
 */
 unsigned short compute_tcp_checksum(const struct iphdr *p_iphdr, const uint16_t *p_ip_payload);
+
+/**
+* get udp checksum: given IP header and UDP datagram (assume checksum field in UDP header contains zero)
+* matches RFC 793
+*/
+unsigned short compute_udp_checksum(const struct iphdr *p_iphdr, const uint16_t *p_ip_payload);
 
 /**
  * get user space max number of open fd's using getrlimit, default parameter equals to 1024

--- a/src/vma/util/verbs_extra.h
+++ b/src/vma/util/verbs_extra.h
@@ -117,11 +117,11 @@ typedef struct ibv_wc				vma_ibv_wc;
 #define VMA_IBV_WC_RECV				IBV_WC_RECV
 //csum offload
 #ifdef DEFINED_IBV_DEVICE_RAW_IP_CSUM
-#define vma_is_rx_csum_supported(attr)		((attr).device_cap_flags & (IBV_DEVICE_RAW_IP_CSUM | IBV_DEVICE_UD_IP_CSUM))
-#define vma_wc_rx_csum_ok(wc)			(vma_wc_flags(wc) & IBV_WC_IP_CSUM_OK)
+#define vma_is_rx_hw_csum_supported(attr)	((attr).device_cap_flags & (IBV_DEVICE_RAW_IP_CSUM | IBV_DEVICE_UD_IP_CSUM))
+#define vma_wc_rx_hw_csum_ok(wc)		(vma_wc_flags(wc) & IBV_WC_IP_CSUM_OK)
 #else
-#define vma_is_rx_csum_supported(attr)		0
-#define vma_wc_rx_csum_ok(wc)			(1)
+#define vma_is_rx_hw_csum_supported(attr)	0
+#define vma_wc_rx_hw_csum_ok(wc)		(1)
 #endif
 
 typedef int            vma_ibv_cq_init_attr;
@@ -174,14 +174,14 @@ typedef struct ibv_flow_spec_tcp_udp		vma_ibv_flow_spec_tcp_udp;
 typedef struct ibv_exp_device_attr		vma_ibv_device_attr;
 #define vma_ibv_device_attr_comp_mask(attr)	(attr).comp_mask = IBV_EXP_DEVICE_ATTR_EXP_CAP_FLAGS
 #ifdef DEFINED_IBV_EXP_DEVICE_RX_CSUM_L4_PKT
-#define vma_is_rx_csum_supported(attr)		(((attr).exp_device_cap_flags & IBV_EXP_DEVICE_RX_CSUM_L3_PKT) \
+#define vma_is_rx_hw_csum_supported(attr)	(((attr).exp_device_cap_flags & IBV_EXP_DEVICE_RX_CSUM_L3_PKT) \
 						&& ((attr).exp_device_cap_flags & IBV_EXP_DEVICE_RX_CSUM_L4_PKT))
 #else
 #ifdef DEFINED_IBV_EXP_DEVICE_RX_CSUM_TCP_UDP_PKT
-#define vma_is_rx_csum_supported(attr)		(((attr).exp_device_cap_flags & IBV_EXP_DEVICE_RX_CSUM_IP_PKT) \
+#define vma_is_rx_hw_csum_supported(attr)	(((attr).exp_device_cap_flags & IBV_EXP_DEVICE_RX_CSUM_IP_PKT) \
 						&& ((attr).exp_device_cap_flags & IBV_EXP_DEVICE_RX_CSUM_TCP_UDP_PKT))
 #else
-#define vma_is_rx_csum_supported(attr)		0
+#define vma_is_rx_hw_csum_supported(attr)	0
 #endif
 #endif
 //ibv_modify_qp
@@ -213,12 +213,12 @@ typedef int            vma_ibv_cq_init_attr;
 #endif
 
 #ifdef DEFINED_IBV_EXP_DEVICE_RX_CSUM_L4_PKT
-#define vma_wc_rx_csum_ok(wc)			((vma_wc_flags(wc) & IBV_EXP_L3_RX_CSUM_OK) && (vma_wc_flags(wc) & IBV_EXP_L4_RX_CSUM_OK))
+#define vma_wc_rx_hw_csum_ok(wc)		((vma_wc_flags(wc) & IBV_EXP_L3_RX_CSUM_OK) && (vma_wc_flags(wc) & IBV_EXP_L4_RX_CSUM_OK))
 #else
 #ifdef DEFINED_IBV_EXP_DEVICE_RX_CSUM_TCP_UDP_PKT
-#define vma_wc_rx_csum_ok(wc)			((vma_wc_flags(wc) & IBV_EXP_WC_RX_IP_CSUM_OK) && (vma_wc_flags(wc) & IBV_EXP_WC_RX_TCP_UDP_CSUM_OK))
+#define vma_wc_rx_hw_csum_ok(wc)		((vma_wc_flags(wc) & IBV_EXP_WC_RX_IP_CSUM_OK) && (vma_wc_flags(wc) & IBV_EXP_WC_RX_TCP_UDP_CSUM_OK))
 #else
-#define vma_wc_rx_csum_ok(wc)			(1)
+#define vma_wc_rx_hw_csum_ok(wc)		(1)
 #endif
 #endif
 


### PR DESCRIPTION
Support software checksum validation for receive IP and TCP/UDP packets.
Software checksum validation will be compute (if enabled) only if HW checksum validation failed.
Enable/Disable using VMA_RX_SW_CSUM parameter.
Enabled by default (should cause a performance degradation if HW checksum
validation is not supported).

Signed-off-by: Liran Oz <lirano@mellanox.com>