### PR TITLE
issue: 828809 control the number of post sends until requesting SIGNAL

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -121,6 +121,7 @@ Example:
  VMA DETAILS: Tx Mem Segs TCP                1000000                    [VMA_TX_SEGS_TCP]
  VMA DETAILS: Tx Mem Bufs                    200000                     [VMA_TX_BUFS]
  VMA DETAILS: Tx QP WRE                      3000                       [VMA_TX_WRE]
+ VMA DETAILS: Tx QP WRE Batching             64                         [VMA_TX_WRE_BATCHING]
  VMA DETAILS: Tx Max QP INLINE               220                        [VMA_TX_MAX_INLINE]
  VMA DETAILS: Tx MC Loopback                 Enabled                    [VMA_TX_MC_LOOPBACK]
  VMA DETAILS: Tx non-blocked eagains         Disabled                   [VMA_TX_NONBLOCKED_EAGAINS]
@@ -303,6 +304,14 @@ Number of Work Request Elements allocated in all transmit QP's.
 The number of QP's can change according to the number of network offloaded
 interfaces.
 Default value is 3000
+
+VMA_TX_WRE_BATCHING
+Number of Tx Work Request Elements until requesting a completion signal. 
+This allows better control the jitter encountered from the Tx CQE handling.
+Higher batching value means high PPS and lower avarge latency.
+Lower batching value means lower latency std-dev.
+Value range is 1-64
+Default value is 64
 
 VMA_TX_MAX_INLINE
 Max send inline data set for QP. 

--- a/README.txt
+++ b/README.txt
@@ -306,10 +306,10 @@ interfaces.
 Default value is 3000
 
 VMA_TX_WRE_BATCHING
-Number of Tx Work Request Elements until requesting a completion signal. 
-This allows better control the jitter encountered from the Tx CQE handling.
-Higher batching value means high PPS and lower avarge latency.
-Lower batching value means lower latency std-dev.
+The number of Tx Work Request Elements used until a completion signal is requested.
+Tuning this parameter allows a better control of the jitter encountered from the 
+Tx CQE handling. Setting a high batching value results in high PPS and lower 
+avarge latency. Setting a low batching value results in lower latency std-dev.
 Value range is 1-64
 Default value is 64
 

--- a/src/vma/dev/ib_ctx_handler.cpp
+++ b/src/vma/dev/ib_ctx_handler.cpp
@@ -55,7 +55,7 @@
 
 
 ib_ctx_handler::ib_ctx_handler(struct ibv_context* ctx, ts_conversion_mode_t ctx_time_converter_mode) :
-	m_channel(0), m_removed(false), m_conf_attr_rx_num_wre(0), m_conf_attr_tx_num_post_send_notify(0),
+	m_channel(0), m_removed(false), m_conf_attr_rx_num_wre(0), m_conf_attr_tx_num_to_signal(0),
 	m_conf_attr_tx_max_inline(0), m_conf_attr_tx_num_wre(0), ctx_time_converter(ctx, ctx_time_converter_mode)
 {
 	memset(&m_ibv_port_attr, 0, sizeof(m_ibv_port_attr));
@@ -155,12 +155,12 @@ void ib_ctx_handler::set_dev_configuration()
 {
 	ibch_logdbg("Setting configuration for the MLX card %s", m_p_ibv_device->name);
 	m_conf_attr_rx_num_wre                  = safe_mce_sys().rx_num_wr;
-	m_conf_attr_tx_num_post_send_notify     = NUM_TX_POST_SEND_NOTIFY;
+	m_conf_attr_tx_num_to_signal            = safe_mce_sys().tx_num_wr_to_signal;
 	m_conf_attr_tx_max_inline               = safe_mce_sys().tx_max_inline;
 	m_conf_attr_tx_num_wre                  = safe_mce_sys().tx_num_wr;
 
-	if (m_conf_attr_tx_num_wre < (m_conf_attr_tx_num_post_send_notify * 2)) {
-		m_conf_attr_tx_num_wre = m_conf_attr_tx_num_post_send_notify * 2;
+	if (m_conf_attr_tx_num_wre < (m_conf_attr_tx_num_to_signal * 2)) {
+		m_conf_attr_tx_num_wre = m_conf_attr_tx_num_to_signal * 2;
 		ibch_loginfo("%s Setting the %s to %d according to the device specific configuration:",
 			   m_p_ibv_device->name, SYS_VAR_TX_NUM_WRE, safe_mce_sys().tx_num_wr);
 	}

--- a/src/vma/dev/ib_ctx_handler.h
+++ b/src/vma/dev/ib_ctx_handler.h
@@ -82,7 +82,7 @@ private:
 	//
 	//conf params
 	uint32_t                m_conf_attr_rx_num_wre;
-	uint32_t                m_conf_attr_tx_num_post_send_notify;
+	uint32_t                m_conf_attr_tx_num_to_signal;
 	uint32_t                m_conf_attr_tx_max_inline;
 	uint32_t                m_conf_attr_tx_num_wre;
 

--- a/src/vma/dev/qp_mgr.cpp
+++ b/src/vma/dev/qp_mgr.cpp
@@ -65,8 +65,11 @@
 qp_mgr::qp_mgr(const ring_simple* p_ring, const ib_ctx_handler* p_context, const uint8_t port_num, const uint32_t tx_num_wr):
 	m_qp(NULL), m_p_ring((ring_simple*)p_ring), m_port_num((uint8_t)port_num), m_p_ib_ctx_handler((ib_ctx_handler*)p_context),
 	m_p_ahc_head(NULL), m_p_ahc_tail(NULL), m_max_inline_data(0), m_max_qp_wr(0), m_p_cq_mgr_rx(NULL), m_p_cq_mgr_tx(NULL),
-	m_rx_num_wr(safe_mce_sys().rx_num_wr), m_tx_num_wr(tx_num_wr), m_rx_num_wr_to_post_recv(safe_mce_sys().rx_num_wr_to_post_recv), 
-	m_curr_rx_wr(0), m_last_posted_rx_wr_id(0), m_n_unsignaled_count(0), m_n_tx_count(0), m_p_last_tx_mem_buf_desc(NULL), m_p_prev_rx_desc_pushed(NULL),
+	m_rx_num_wr(safe_mce_sys().rx_num_wr), m_tx_num_wr(tx_num_wr),
+	m_rx_num_wr_to_post_recv(safe_mce_sys().rx_num_wr_to_post_recv),
+	m_tx_num_wr_to_signal(safe_mce_sys().tx_num_wr_to_signal),
+	m_curr_rx_wr(0), m_last_posted_rx_wr_id(0), m_n_unsignaled_count(0), m_n_tx_count(0),
+	m_p_last_tx_mem_buf_desc(NULL), m_p_prev_rx_desc_pushed(NULL),
 	m_n_ip_id_base(0), m_n_ip_id_offset(0)
 {
 	m_ibv_rx_sg_array = new ibv_sge[m_rx_num_wr_to_post_recv];
@@ -513,7 +516,7 @@ int qp_mgr::send(vma_ibv_send_wr* p_send_wqe)
 
 	qp_logfunc("");
 
-	is_signaled = ++m_n_unsignaled_count >= NUM_TX_POST_SEND_NOTIFY;
+	is_signaled = ++m_n_unsignaled_count >= m_tx_num_wr_to_signal;
 
 	// Link this new mem_buf_desc to the previous one sent
 	p_mem_buf_desc->p_next_desc = m_p_last_tx_mem_buf_desc;

--- a/src/vma/dev/qp_mgr.h
+++ b/src/vma/dev/qp_mgr.h
@@ -149,6 +149,7 @@ protected:
 	uint32_t 		m_tx_num_wr;
 
 	uint32_t 		m_rx_num_wr_to_post_recv;
+	uint32_t 		m_tx_num_wr_to_signal;
 
 	// recv_wr
 	ibv_sge*		m_ibv_rx_sg_array;

--- a/src/vma/main.cpp
+++ b/src/vma/main.cpp
@@ -434,19 +434,20 @@ void print_vma_global_settings()
 
 	if (safe_mce_sys().ring_limit_per_interface) {
 		VLOG_PARAM_NUMBER("Ring limit per interface", safe_mce_sys().ring_limit_per_interface, MCE_DEFAULT_RING_LIMIT_PER_INTERFACE, SYS_VAR_RING_LIMIT_PER_INTERFACE);
-	}else {
+	} else {
 		VLOG_PARAM_NUMSTR("Ring limit per interface", safe_mce_sys().ring_limit_per_interface, MCE_DEFAULT_RING_LIMIT_PER_INTERFACE, SYS_VAR_RING_LIMIT_PER_INTERFACE, "(no limit)");
 	}
 
 	if (safe_mce_sys().tcp_max_syn_rate) {
 		VLOG_PARAM_NUMSTR("TCP max syn rate", safe_mce_sys().tcp_max_syn_rate, MCE_DEFAULT_TCP_MAX_SYN_RATE, SYS_VAR_TCP_MAX_SYN_RATE, "(per sec)");
-	}else {
+	} else {
 		VLOG_PARAM_NUMSTR("TCP max syn rate", safe_mce_sys().tcp_max_syn_rate, MCE_DEFAULT_TCP_MAX_SYN_RATE, SYS_VAR_TCP_MAX_SYN_RATE, "(no limit)");
 	}
 
 	VLOG_PARAM_NUMBER("Tx Mem Segs TCP", safe_mce_sys().tx_num_segs_tcp, MCE_DEFAULT_TX_NUM_SEGS_TCP, SYS_VAR_TX_NUM_SEGS_TCP);
 	VLOG_PARAM_NUMBER("Tx Mem Bufs", safe_mce_sys().tx_num_bufs, MCE_DEFAULT_TX_NUM_BUFS, SYS_VAR_TX_NUM_BUFS);
 	VLOG_PARAM_NUMBER("Tx QP WRE", safe_mce_sys().tx_num_wr, MCE_DEFAULT_TX_NUM_WRE, SYS_VAR_TX_NUM_WRE);
+	VLOG_PARAM_NUMBER("Tx QP WRE Batching", safe_mce_sys().tx_num_wr_to_signal, MCE_DEFAULT_TX_NUM_WRE_TO_SIGNAL, SYS_VAR_TX_NUM_WRE_TO_SIGNAL);
 	VLOG_PARAM_NUMBER("Tx Max QP INLINE", safe_mce_sys().tx_max_inline, MCE_DEFAULT_TX_MAX_INLINE, SYS_VAR_TX_MAX_INLINE);
 	VLOG_PARAM_STRING("Tx MC Loopback", safe_mce_sys().tx_mc_loopback_default, MCE_DEFAULT_TX_MC_LOOPBACK, SYS_VAR_TX_MC_LOOPBACK, safe_mce_sys().tx_mc_loopback_default ? "Enabled " : "Disabled");
 	VLOG_PARAM_STRING("Tx non-blocked eagains", safe_mce_sys().tx_nonblocked_eagains, MCE_DEFAULT_TX_NONBLOCKED_EAGAINS, SYS_VAR_TX_NONBLOCKED_EAGAINS, safe_mce_sys().tx_nonblocked_eagains ? "Enabled " : "Disabled");
@@ -454,14 +455,13 @@ void print_vma_global_settings()
 
 	VLOG_PARAM_NUMBER("Rx Mem Bufs", safe_mce_sys().rx_num_bufs, MCE_DEFAULT_RX_NUM_BUFS, SYS_VAR_RX_NUM_BUFS);
 	VLOG_PARAM_NUMBER("Rx QP WRE", safe_mce_sys().rx_num_wr, MCE_DEFAULT_RX_NUM_WRE, SYS_VAR_RX_NUM_WRE);
-	VLOG_PARAM_NUMBER("Rx QP WRE BATCHING", safe_mce_sys().rx_num_wr_to_post_recv, MCE_DEFAULT_RX_NUM_WRE_TO_POST_RECV, SYS_VAR_RX_NUM_WRE_TO_POST_RECV);
+	VLOG_PARAM_NUMBER("Rx QP WRE Batching", safe_mce_sys().rx_num_wr_to_post_recv, MCE_DEFAULT_RX_NUM_WRE_TO_POST_RECV, SYS_VAR_RX_NUM_WRE_TO_POST_RECV);
 	VLOG_PARAM_NUMBER("Rx Byte Min Limit", safe_mce_sys().rx_ready_byte_min_limit, MCE_DEFAULT_RX_BYTE_MIN_LIMIT, SYS_VAR_RX_BYTE_MIN_LIMIT);
 	VLOG_PARAM_NUMBER("Rx Poll Loops", safe_mce_sys().rx_poll_num, MCE_DEFAULT_RX_NUM_POLLS, SYS_VAR_RX_NUM_POLLS);
 	VLOG_PARAM_NUMBER("Rx Poll Init Loops", safe_mce_sys().rx_poll_num_init, MCE_DEFAULT_RX_NUM_POLLS_INIT, SYS_VAR_RX_NUM_POLLS_INIT);
 	if (safe_mce_sys().rx_udp_poll_os_ratio) {
 		VLOG_PARAM_NUMBER("Rx UDP Poll OS Ratio", safe_mce_sys().rx_udp_poll_os_ratio, MCE_DEFAULT_RX_UDP_POLL_OS_RATIO, SYS_VAR_RX_UDP_POLL_OS_RATIO);
-	}
-	else {
+	} else {
 		VLOG_PARAM_STRING("Rx UDP Poll OS Ratio", safe_mce_sys().rx_udp_poll_os_ratio, MCE_DEFAULT_RX_UDP_POLL_OS_RATIO, SYS_VAR_RX_UDP_POLL_OS_RATIO, "Disabled");
 	}
 

--- a/src/vma/util/sys_vars.cpp
+++ b/src/vma/util/sys_vars.cpp
@@ -339,6 +339,7 @@ void mce_sys_var::get_env_params()
 	tx_num_segs_tcp         = MCE_DEFAULT_TX_NUM_SEGS_TCP;
 	tx_num_bufs             = MCE_DEFAULT_TX_NUM_BUFS;
 	tx_num_wr               = MCE_DEFAULT_TX_NUM_WRE;
+	tx_num_wr_to_signal     = MCE_DEFAULT_TX_NUM_WRE_TO_SIGNAL;
 	tx_max_inline		= MCE_DEFAULT_TX_MAX_INLINE;
 	tx_mc_loopback_default  = MCE_DEFAULT_TX_MC_LOOPBACK;
 	tx_nonblocked_eagains   = MCE_DEFAULT_TX_NONBLOCKED_EAGAINS;
@@ -532,6 +533,11 @@ void mce_sys_var::get_env_params()
 
 	if ((env_ptr = getenv(SYS_VAR_TX_NUM_WRE)) != NULL)
 		tx_num_wr = (uint32_t)atoi(env_ptr);
+
+	if ((env_ptr = getenv(SYS_VAR_TX_NUM_WRE_TO_SIGNAL)) != NULL)
+		tx_num_wr_to_signal = MIN(NUM_TX_WRE_TO_SIGNAL_MAX, MAX(1, (uint32_t)atoi(env_ptr)));
+	if (tx_num_wr <= (tx_num_wr_to_signal * 2))
+		tx_num_wr = tx_num_wr_to_signal * 2;
 
 	if ((env_ptr = getenv(SYS_VAR_TX_MAX_INLINE)) != NULL)
 		tx_max_inline = (uint32_t)atoi(env_ptr);

--- a/src/vma/util/sys_vars.h
+++ b/src/vma/util/sys_vars.h
@@ -302,6 +302,7 @@ struct mce_sys_var {
 	uint32_t 	tx_num_segs_tcp;
 	uint32_t 	tx_num_bufs;
 	uint32_t 	tx_num_wr;
+	uint32_t	tx_num_wr_to_signal;
 	uint32_t 	tx_max_inline;
 	bool 		tx_mc_loopback_default;
 	bool		tx_nonblocked_eagains;
@@ -433,6 +434,7 @@ extern mce_sys_var & safe_mce_sys();
 #define SYS_VAR_TX_NUM_SEGS_TCP				"VMA_TX_SEGS_TCP"
 #define SYS_VAR_TX_NUM_BUFS				"VMA_TX_BUFS"
 #define SYS_VAR_TX_NUM_WRE				"VMA_TX_WRE"
+#define SYS_VAR_TX_NUM_WRE_TO_SIGNAL			"VMA_TX_WRE_BATCHING"
 #define SYS_VAR_TX_MAX_INLINE				"VMA_TX_MAX_INLINE"
 #define SYS_VAR_TX_MC_LOOPBACK				"VMA_TX_MC_LOOPBACK"
 #define SYS_VAR_TX_NONBLOCKED_EAGAINS			"VMA_TX_NONBLOCKED_EAGAINS"
@@ -495,7 +497,7 @@ extern mce_sys_var & safe_mce_sys();
 #define SYS_VAR_MTU					"VMA_MTU"
 #define SYS_VAR_TCP_MAX_SYN_RATE			"VMA_TCP_MAX_SYN_RATE"
 #define SYS_VAR_MSS					"VMA_MSS"
-#define SYS_VAR_TCP_CC_ALGO					"VMA_TCP_CC_ALGO"
+#define SYS_VAR_TCP_CC_ALGO				"VMA_TCP_CC_ALGO"
 #define SYS_VAR_SPEC					"VMA_SPEC"
 #define SYS_VAR_SPEC_PARAM1				"VMA_SPEC_PARAM1"
 #define SYS_VAR_SPEC_PARAM2				"VMA_SPEC_PARAM2"
@@ -538,6 +540,7 @@ extern mce_sys_var & safe_mce_sys();
 #define MCE_DEFAULT_TX_NUM_SEGS_TCP			(1000000)
 #define MCE_DEFAULT_TX_NUM_BUFS				(200000)
 #define MCE_DEFAULT_TX_NUM_WRE				(3000)
+#define MCE_DEFAULT_TX_NUM_WRE_TO_SIGNAL		(64)
 #define MCE_DEFAULT_TX_MAX_INLINE			(220) //224
 #define MCE_DEFAULT_TX_BUILD_IP_CHKSUM			(true)
 #define MCE_DEFAULT_TX_MC_LOOPBACK			(true)
@@ -641,7 +644,7 @@ extern mce_sys_var & safe_mce_sys();
 #define MCE_ALIGNMENT					((unsigned long)63)
 #define RX_BUF_SIZE(mtu)				(mtu + IPOIB_HDR_LEN + GRH_HDR_LEN) // RX buffers are larger in IB
 #define TX_BUF_SIZE(mtu)				(mtu + ETH_HDR_LEN) // Tx buffers are larger in Ethernet (they include L2 for RAW QP)
-#define NUM_TX_POST_SEND_NOTIFY				64
+#define NUM_TX_WRE_TO_SIGNAL_MAX			64
 #define NUM_RX_WRE_TO_POST_RECV_MAX			1024
 #define TCP_MAX_SYN_RATE_TOP_LIMIT			100000
 #define DEFAULT_MC_TTL					64


### PR DESCRIPTION
Replace the hardcoded NUM_TX_POST_SEND_NOTIFY (64) with a load time
VMA configuration parameter: VMA_TX_WRE_BATCHING

By controlling the size of Tx list collected until request a completion
signal we can better control the jitter encountered from the Tx CQE handling.
Valid value range: 1-64
Default: 64 (like the hardcoded value before the chaneg)

Signed-off-by: Alex Rosenbaum <Alexr@mellanox.com>