### PR TITLE
issue: 817046 Fix for flow steering option check

### DIFF
--- a/src/vma/main.cpp
+++ b/src/vma/main.cpp
@@ -268,8 +268,8 @@ void check_debug()
 
 void check_flow_steering_log_num_mgm_entry_size()
 {
-	char flow_steering_val[2] = {0};
-	if (priv_try_read_file((const char*)FLOW_STEERING_MGM_ENTRY_SIZE_PARAM_FILE, flow_steering_val, 2) == -1) {
+	char flow_steering_val[4] = {0};
+	if (priv_try_read_file((const char*)FLOW_STEERING_MGM_ENTRY_SIZE_PARAM_FILE, flow_steering_val, sizeof(flow_steering_val)) == -1) {
 		vlog_printf(VLOG_DEBUG, "Flow steering option for mlx4 driver does not exist in current OFED version");
 	}
 	else if (flow_steering_val[0] != '-' || flow_steering_val[1] != '1') {


### PR DESCRIPTION
Buffer for option value was not enough as a result incorrect warning is appeared.

@OphirMunk could you look at