### PR TITLE
issue: 842842 Move udp rx hw timestamp conversion from cq_mgr into so…

### DIFF
--- a/src/vma/dev/cq_mgr.h
+++ b/src/vma/dev/cq_mgr.h
@@ -173,6 +173,7 @@ public:
 private:
 	ring_simple*		m_p_ring;
 	ib_ctx_handler*			m_p_ib_ctx_handler;
+	ib_ctx_time_converter*		m_p_ib_ctx_time_converter;
 	bool				m_b_is_rx;
 	bool				m_b_is_rx_hw_csum_on;
 	const bool			m_b_is_rx_sw_csum_on;

--- a/src/vma/dev/ib_ctx_handler.cpp
+++ b/src/vma/dev/ib_ctx_handler.cpp
@@ -101,8 +101,8 @@ ib_ctx_handler::~ib_ctx_handler() {
 	BULLSEYE_EXCLUDE_BLOCK_END
 }
 
-ts_conversion_mode_t ib_ctx_handler::get_ctx_time_converter_status() {
-	return ctx_time_converter.get_converter_status();
+ib_ctx_time_converter* ib_ctx_handler::get_ctx_time_converter() {
+	return &ctx_time_converter;
 }
 
 ibv_mr* ib_ctx_handler::mem_reg(void *addr, size_t length, uint64_t access)

--- a/src/vma/dev/ib_ctx_handler.h
+++ b/src/vma/dev/ib_ctx_handler.h
@@ -61,11 +61,7 @@ public:
 	bool                    is_removed() { return m_removed;}
 	virtual void            handle_event_ibverbs_cb(void *ev_data, void *ctx);
 	void                    handle_event_DEVICE_FATAL();
-	ts_conversion_mode_t    get_ctx_time_converter_status();
-
-	inline void convert_hw_time_to_system_time(uint64_t packet_hw_time, struct timespec* packet_systime) {
-		ctx_time_converter.convert_hw_time_to_system_time(packet_hw_time, packet_systime);
-	}
+	ib_ctx_time_converter*  get_ctx_time_converter();
 
 private:
 	struct ibv_context*     m_p_ibv_context;

--- a/src/vma/proto/mem_buf_desc.h
+++ b/src/vma/proto/mem_buf_desc.h
@@ -34,12 +34,13 @@
 #ifndef MEM_BUF_DESC_H
 #define MEM_BUF_DESC_H
 
-#include "vma/util/vma_list.h"
 #include <netinet/in.h>
-#include "vma/util/vtypes.h" // for unlikely
 
+#include "vma/util/vma_list.h"
+#include "vma/util/vtypes.h" // for unlikely
 #include "vma/lwip/pbuf.h"
 #include "vma/util/atomic.h"
+#include "vma/dev/ib_ctx_time_converter.h"
 
 struct mem_buf_desc_t;
 
@@ -123,7 +124,8 @@ public:
 			size_t		sz_payload;
 
 			struct timespec sw_timestamp;
-			struct timespec	hw_timestamp;
+			uint64_t	hw_raw_timestamp;
+			ib_ctx_time_converter*	p_ib_ctx_time_converter;
 
 			void* 		context;
 		} rx;

--- a/src/vma/sock/sockinfo_udp.cpp
+++ b/src/vma/sock/sockinfo_udp.cpp
@@ -1371,7 +1371,7 @@ void sockinfo_udp::handle_recv_timestamping(struct cmsg_state *cm_state)
 	}
 
 	if (m_n_tsing_flags & SOF_TIMESTAMPING_RAW_HARDWARE) {
-		tsing.hwtimeraw = packet->path.rx.hw_timestamp;
+		packet->path.rx.p_ib_ctx_time_converter->convert_hw_time_to_system_time(packet->path.rx.hw_raw_timestamp, &tsing.hwtimeraw);
 	}
 
 	insert_cmsg(cm_state, SOL_SOCKET, SO_TIMESTAMPING, &tsing, sizeof(tsing));


### PR DESCRIPTION
…ckinfo_udp

Currently, The time conversion for each incoming packet is made in the cq_mgr.
i.e, the conversion is made no only for UDP sockets who didn't enable the option
but also for TCP sockets.
Each conversion includes some mathematical calculations and cache misses
which cause performance degradation.
To improve performance, we should make this conversion only for UDP
sockets which enabled the option.

Signed-off-by: Liran Oz lirano@mellanox.com
