### PR TITLE
issue: 844374 Fix error handling while register socket with plural ep…

### DIFF
--- a/src/vma/iomux/epfd_info.cpp
+++ b/src/vma/iomux/epfd_info.cpp
@@ -295,8 +295,8 @@ int epfd_info::add_fd(int fd, epoll_event *event)
 		__log_dbg("fd=%d must be skipped from os epoll()", fd);
 		// Checking for duplicate fds
 		if (m_fd_info.find(fd) != m_fd_info.end()) {
-			__log_dbg("epoll_ctl: tried to add an existing fd. (%d)", fd);
 			errno = EEXIST;
+			__log_dbg("epoll_ctl: fd=%d is already registered with this epoll instance %d (errno=%d %m)", fd, m_epfd, errno);
 			return -1;
 		}
 	}
@@ -335,10 +335,10 @@ int epfd_info::add_fd(int fd, epoll_event *event)
 		if (ret < 0) {
 			switch (errno) {
 			case EEXIST:
-				__log_dbg("epoll_ctl: fd=%d is already registered with this epoll instance (%d)", fd, m_epfd);
+				__log_dbg("epoll_ctl: fd=%d is already registered with this epoll instance %d (errno=%d %m)", fd, m_epfd, errno);
 				break;
 			case ENOMEM:
-				__log_dbg("epoll_ctl: fd=%d is already registered with another epoll instance (%d), cannot register to epoll (%d)", fd, temp_sock_fd_api->get_epoll_context_fd(), m_epfd);
+				__log_dbg("epoll_ctl: fd=%d is already registered with another epoll instance %d, cannot register to epoll %d (errno=%d %m)", fd, temp_sock_fd_api->get_epoll_context_fd(), m_epfd, errno);
 				break;
 			default:
 				__log_dbg("epoll_ctl: failed to add fd=%d to epoll epfd=%d (errno=%d %m)", fd, m_epfd, errno);

--- a/src/vma/iomux/epfd_info.cpp
+++ b/src/vma/iomux/epfd_info.cpp
@@ -333,10 +333,16 @@ int epfd_info::add_fd(int fd, epoll_event *event)
 		lock();
 
 		if (ret < 0) {
-			if (errno == EEXIST) {
-				__log_dbg("epoll_ctl: fd=%d is already registered with this epoll instance (%d)", fd, this->get_epoll_fd());
-			} else { // errno == ENOMEM
-				__log_dbg("epoll_ctl: fd=%d is already registered with another epoll instance (%d), cannot register to epoll (%d)", fd, temp_sock_fd_api->get_epoll_context_fd(), this->get_epoll_fd());
+			switch (errno) {
+			case EEXIST:
+				__log_dbg("epoll_ctl: fd=%d is already registered with this epoll instance (%d)", fd, m_epfd);
+				break;
+			case ENOMEM:
+				__log_dbg("epoll_ctl: fd=%d is already registered with another epoll instance (%d), cannot register to epoll (%d)", fd, temp_sock_fd_api->get_epoll_context_fd(), m_epfd);
+				break;
+			default:
+				__log_dbg("epoll_ctl: failed to add fd=%d to epoll epfd=%d (errno=%d %m)", fd, m_epfd, errno);
+				break;
 			}
 			return ret;
 		}

--- a/src/vma/sock/socket_fd_api.cpp
+++ b/src/vma/sock/socket_fd_api.cpp
@@ -349,9 +349,17 @@ int socket_fd_api::free_packets(struct vma_packet_t *pkts, size_t count)
     #pragma BullseyeCoverage on
 #endif
 
-void socket_fd_api::add_epoll_context(epfd_info *epfd)
+int socket_fd_api::add_epoll_context(epfd_info *epfd)
 {
-	if(!m_econtext) m_econtext = epfd;
+	if(!m_econtext) {
+		// This socket is not registered to any epfd
+		m_econtext = epfd;
+		return 0;
+	} else {
+		// Currently VMA does not support more then 1 epfd listed
+		errno = (m_econtext == epfd) ? EEXIST : ENOMEM;
+		return -1;
+	}
 }
 
 void socket_fd_api::remove_epoll_context(epfd_info *epfd)

--- a/src/vma/sock/socket_fd_api.h
+++ b/src/vma/sock/socket_fd_api.h
@@ -189,7 +189,7 @@ public:
 
 	virtual void consider_rings_migration() {}
 
-	virtual void add_epoll_context(epfd_info *epfd);
+	virtual int add_epoll_context(epfd_info *epfd);
 	virtual void remove_epoll_context(epfd_info *epfd);
 	int get_epoll_context_fd();
 

--- a/src/vma/sock/socket_fd_api.h
+++ b/src/vma/sock/socket_fd_api.h
@@ -191,6 +191,7 @@ public:
 
 	virtual void add_epoll_context(epfd_info *epfd);
 	virtual void remove_epoll_context(epfd_info *epfd);
+	int get_epoll_context_fd();
 
 #if _BullseyeCoverage
     #pragma BullseyeCoverage off

--- a/src/vma/sock/socket_fd_api.h
+++ b/src/vma/sock/socket_fd_api.h
@@ -223,7 +223,6 @@ protected:
 	void notify_epoll_context_remove_ring(ring* ring);
 	bool notify_epoll_context_verify(epfd_info *epfd);
 	void notify_epoll_context_fd_is_offloaded();
-	int get_epoll_context_fd();
 
 	// identification information <socket fd>
 	int m_fd;

--- a/src/vma/sock/sockinfo.h
+++ b/src/vma/sock/sockinfo.h
@@ -117,7 +117,7 @@ public:
 
 	virtual void consider_rings_migration();
 
-	virtual void add_epoll_context(epfd_info *epfd);
+	virtual int add_epoll_context(epfd_info *epfd);
 	virtual void remove_epoll_context(epfd_info *epfd);
 	virtual void statistics_print(vlog_levels_t log_level = VLOG_DEBUG);
 

--- a/tests/functionality/iomux/1epoll_1socket_twice.c
+++ b/tests/functionality/iomux/1epoll_1socket_twice.c
@@ -1,0 +1,146 @@
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/types.h>
+#include <sys/socket.h>
+#include <netdb.h>
+#include <unistd.h>
+#include <fcntl.h>
+#include <sys/epoll.h>
+#include <errno.h>
+
+#define MAXEVENTS 64
+
+static int
+make_socket_non_blocking (int sfd)
+{
+	int flags, s;
+
+	flags = fcntl (sfd, F_GETFL, 0);
+	if (flags == -1)
+	{
+		perror ("fcntl");
+		return -1;
+	}
+
+	flags |= O_NONBLOCK;
+	s = fcntl (sfd, F_SETFL, flags);
+	if (s == -1)
+	{
+		perror ("fcntl");
+		return -1;
+	}
+
+	return 0;
+}
+
+static int
+create_and_bind (char *port)
+{
+	struct addrinfo hints;
+	struct addrinfo *result, *rp;
+	int s, sfd;
+
+	memset (&hints, 0, sizeof (struct addrinfo));
+	hints.ai_family = AF_UNSPEC;     /* Return IPv4 and IPv6 choices */
+	hints.ai_socktype = SOCK_STREAM; /* We want a TCP socket */
+	hints.ai_flags = AI_PASSIVE;     /* All interfaces */
+
+	s = getaddrinfo (NULL, port, &hints, &result);
+	if (s != 0)
+	{
+		fprintf (stderr, "getaddrinfo: %s\n", gai_strerror (s));
+		return -1;
+	}
+
+	for (rp = result; rp != NULL; rp = rp->ai_next)
+	{
+		sfd = socket (rp->ai_family, rp->ai_socktype, rp->ai_protocol);
+		if (sfd == -1)
+			continue;
+
+		s = bind (sfd, rp->ai_addr, rp->ai_addrlen);
+		if (s == 0)
+		{
+			/* We managed to bind successfully! */
+			break;
+		}
+
+		close (sfd);
+	}
+
+	if (rp == NULL)
+	{
+		fprintf (stderr, "Could not bind\n");
+		return -1;
+	}
+
+	freeaddrinfo (result);
+
+	return sfd;
+}
+
+int
+main (int argc, char *argv[])
+{
+	int sfd, s;
+	int efd;
+	struct epoll_event event;
+	struct epoll_event *events;
+
+	sfd = create_and_bind ("6666");
+	if (sfd == -1)
+		goto failure;
+
+	printf("--> create socket %d\n", sfd);
+
+	s = make_socket_non_blocking (sfd);
+	if (s == -1)
+		goto failure;
+
+	printf("--> set socket %d non blocking\n", sfd);
+
+	s = listen (sfd, SOMAXCONN);
+	if (s == -1)
+	{
+		perror ("--> listen");
+		goto failure;
+	}
+
+	efd = epoll_create1 (0);
+	if (efd == -1)
+	{
+		perror ("--> epoll_create");
+		goto failure;
+	}
+
+	printf("--> create epoll %d\n",efd);
+
+	event.data.fd = sfd;
+	event.events = EPOLLIN | EPOLLET;
+	s = epoll_ctl (efd, EPOLL_CTL_ADD, sfd, &event);
+	if (s == -1)
+	{
+		perror ("--> epoll_ctl");
+		goto failure;
+	}
+
+	printf("--> socket %d was registered to epoll %d\n", sfd, efd);
+
+	s = epoll_ctl(efd, EPOLL_CTL_ADD, sfd, &event);
+	if (s == -1)
+	{
+		if (errno == EEXIST) {
+			printf("--> socket %d was already registered to epoll %d, errno = %d\n", sfd, efd, errno);
+			printf("--> SUCCESS\n");
+			return EXIT_SUCCESS;
+		} else {
+			printf("--> socket %d was already registered to epoll %d, errno should be set to EEXIST, errno = %d\n", sfd, efd, errno);
+			goto failure;
+		}
+	}
+
+failure:
+	printf("--> FAILURE\n");
+	return EXIT_FAILURE;
+}

--- a/tests/functionality/iomux/2epoll_1socket.c
+++ b/tests/functionality/iomux/2epoll_1socket.c
@@ -1,0 +1,182 @@
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/types.h>
+#include <sys/socket.h>
+#include <netdb.h>
+#include <unistd.h>
+#include <fcntl.h>
+#include <sys/epoll.h>
+#include <errno.h>
+
+#define MAXEVENTS 64
+
+static int
+make_socket_non_blocking (int sfd)
+{
+	int flags, s;
+
+	flags = fcntl (sfd, F_GETFL, 0);
+	if (flags == -1)
+	{
+		perror ("fcntl");
+		return -1;
+	}
+
+	flags |= O_NONBLOCK;
+	s = fcntl (sfd, F_SETFL, flags);
+	if (s == -1)
+	{
+		perror ("fcntl");
+		return -1;
+	}
+
+	return 0;
+}
+
+static int
+create_and_bind (char *port)
+{
+	struct addrinfo hints;
+	struct addrinfo *result, *rp;
+	int s, sfd;
+
+	memset (&hints, 0, sizeof (struct addrinfo));
+	hints.ai_family = AF_UNSPEC;     /* Return IPv4 and IPv6 choices */
+	hints.ai_socktype = SOCK_STREAM; /* We want a TCP socket */
+	hints.ai_flags = AI_PASSIVE;     /* All interfaces */
+
+	s = getaddrinfo (NULL, port, &hints, &result);
+	if (s != 0)
+	{
+		fprintf (stderr, "getaddrinfo: %s\n", gai_strerror (s));
+		return -1;
+	}
+
+	for (rp = result; rp != NULL; rp = rp->ai_next)
+	{
+		sfd = socket (rp->ai_family, rp->ai_socktype, rp->ai_protocol);
+		if (sfd == -1)
+			continue;
+
+		s = bind (sfd, rp->ai_addr, rp->ai_addrlen);
+		if (s == 0)
+		{
+			/* We managed to bind successfully! */
+			break;
+		}
+
+		close (sfd);
+	}
+
+	if (rp == NULL)
+	{
+		fprintf (stderr, "Could not bind\n");
+		return -1;
+	}
+
+	freeaddrinfo (result);
+
+	return sfd;
+}
+
+int
+main (int argc, char *argv[])
+{
+	int sfd, s, with_vma;
+	int efd, efd2;
+	struct epoll_event event;
+	struct epoll_event *events;
+
+	if (argc != 2) {
+		printf("--> Usage: ./2epoll_1socket <with_vma>\n");
+		printf("--> With VMA run ./2epoll_1socket 1\n");
+		printf("--> With  OS run ./2epoll_1socket 0\n");
+		return EXIT_FAILURE;
+	}
+
+	with_vma = atoi(argv[1]);
+	if (with_vma)
+		printf("--> running with VMA\n");
+	else
+		printf("--> running with OS\n");
+
+	sfd = create_and_bind ("6666");
+	if (sfd == -1)
+		goto failure;
+
+	printf("--> create socket %d\n", sfd);
+
+	s = make_socket_non_blocking (sfd);
+	if (s == -1)
+		goto failure;
+
+	printf("--> set socket %d non blocking\n", sfd);
+
+	s = listen (sfd, SOMAXCONN);
+	if (s == -1)
+	{
+		perror ("--> listen");
+		goto failure;
+	}
+
+	efd = epoll_create1 (0);
+	if (efd == -1)
+	{
+		perror ("--> epoll_create");
+		goto failure;
+	}
+
+	printf("--> created epoll %d\n",efd);
+
+	efd2 = epoll_create1 (0);
+	if (efd2 == -1)
+	{
+		perror ("--> epoll_create");
+		goto failure;
+	}
+
+	printf("--> created epoll %d\n",efd2);
+
+	event.data.fd = sfd;
+	event.events = EPOLLIN | EPOLLET;
+
+	s = epoll_ctl (efd, EPOLL_CTL_ADD, sfd, &event);
+	if (s == -1)
+	{
+		perror ("--> epoll_ctl 1");
+		goto failure;
+	}
+
+	printf("--> socket %d was registered to epoll %d\n", sfd, efd);
+
+	s = epoll_ctl (efd2, EPOLL_CTL_ADD, sfd, &event);
+	if (with_vma) {
+		if (s == -1) {
+			if (errno == ENOMEM) {
+				printf("--> socket %d was already registered to epoll %d, cant register to another epfd %d, errno = %d\n", sfd, efd, efd2, errno);
+				printf("--> SUCCESS\n");
+				return EXIT_SUCCESS;
+			} else {
+				printf("--> socket %d was already registered to epoll %d, cant register to another epfd %d, errno should be set to ENOMEM, errno = %d\n", sfd, efd, efd2, errno);
+				goto failure;
+			}
+		} else {
+			printf("--> epoll_ctl didnot return with error, VMA support only 1 epfd for each socket\n", sfd, efd, efd2, errno);
+			goto failure;
+		}
+	} else {
+		if (s == -1) {
+			printf("--> epoll_ctl return with error, errno = %d\n", errno);
+			goto failure;
+		}
+	}
+
+	printf("--> socket %d was registered to epoll %d\n", sfd, efd);
+	printf("--> SUCCESS\n");
+	return EXIT_SUCCESS;
+
+failure:
+	printf("--> FAILURE\n");
+	return EXIT_FAILURE;
+}


### PR DESCRIPTION
…oll instances

VMA does not supports registration of socket with plural epoll instances.
In the current situation we simply ignore the request without returning
an error.
errno will be set to EEXIST if the fd is already registered with the same epoll.
errno will be set to ENOMEM if the fd is already registered with another epoll.