### PR TITLE
issue: 825888 small fixes for dump fd statistics

### DIFF
--- a/src/stats/stats_reader.cpp
+++ b/src/stats/stats_reader.cpp
@@ -1384,7 +1384,7 @@ int main (int argc, char **argv)
 			{"version",		0,	NULL,	'V'},
 			{"zero",		0,	NULL,	'z'},
 			{"log_level",		1,	NULL,	'l'},
-			{"fd_statistics",	1,	NULL,	'S'},
+			{"fd_dump",		1,	NULL,	'S'},
 			{"details_level",	1,	NULL,	'D'},
 			{"name",		1,	NULL,	'n'},
 			{"find_pid",		0,	NULL,	'f'},

--- a/src/vma/util/vma_stats.h
+++ b/src/vma/util/vma_stats.h
@@ -300,9 +300,9 @@ typedef struct {
 } version_info_t;
 
 typedef struct sh_mem_t {
-    int                            reader_counter; //only copy to shm upon active reader
+	int				reader_counter; //only copy to shm upon active reader
 	version_info_t			ver_info;
-	char		stats_protocol_ver[32];
+	char				stats_protocol_ver[32];
 	size_t				max_skt_inst_num;
 	vlog_levels_t			log_level;
 	uint8_t 			log_details_level;
@@ -310,10 +310,11 @@ typedef struct sh_mem_t {
 	ring_instance_block_t		ring_inst_arr[NUM_OF_SUPPORTED_RINGS];
 	bpool_instance_block_t		bpool_inst_arr[NUM_OF_SUPPORTED_BPOOLS];
 	mc_grp_info_t			mc_info;
-	iomux_stats_t                   iomux;
+	iomux_stats_t			iomux;
 	int				fd_dump;
 	vlog_levels_t			fd_dump_log_level;
-	int				fd_to_dump;
+
+	// MUST BE LAST ENTRY in struct: [0] is the allocation start point for all fd's
 	socket_instance_block_t  	skt_inst_arr[0]; //sockets statistics array
 } sh_mem_t;
 


### PR DESCRIPTION
1. socket array starts at END OF sturct sh_mem_t. No addition member after it.
2. full key word wrongly used for '--fd_dump'

Signed-off-by: Alex Rosenbaum <Alexr@mellanox.com>