### PR TITLE
issue: 569177 use netlink to define alias interface base name

### DIFF
--- a/src/vma/dev/net_device_table_mgr.cpp
+++ b/src/vma/dev/net_device_table_mgr.cpp
@@ -244,6 +244,7 @@ int net_device_table_mgr::map_net_devices()
 		}
 
 		bool valid = false;
+
 		char base_ifname[IFNAMSIZ];
 		get_base_interface_name((const char*)(ifa->ifa_name), base_ifname, sizeof(base_ifname));
 		if (check_device_exist(base_ifname, BOND_DEVICE_FILE)) {

--- a/src/vma/dev/net_device_val.cpp
+++ b/src/vma/dev/net_device_val.cpp
@@ -737,9 +737,7 @@ void net_device_val_eth::configure(struct ifaddrs* ifa, struct rdma_cm_id* cma_i
 		nd_logpanic("m_p_L2_addr allocation error");
 	}
 	BULLSEYE_EXCLUDE_BLOCK_END
-
 	create_br_address(m_name.c_str());
-
 	m_vlan = get_vlan_id_from_ifname(m_name.c_str());
 	if (m_vlan && m_bond != NO_BOND && m_bond_fail_over_mac == 1) {
 		vlog_printf(VLOG_WARNING, " ******************************************************************\n");

--- a/src/vma/util/utils.h
+++ b/src/vma/util/utils.h
@@ -326,6 +326,17 @@ uint16_t get_vlan_id_from_ifname(const char* ifname);
 size_t get_vlan_base_name_from_ifname(const char* ifname, char* base_ifname, size_t sz_base_ifname);
 
 /**
+ * Get alias base name from interface name
+ *
+ * @param ifname input interface name of device (e.g. eth2, eth2.5)
+ * @param base_ifname output base interface name of device (e.g. eth2)
+ * @param sz_base_ifname input the size of base_ifname param
+ * @return the alias base name length or 0 if not found
+ */
+
+size_t get_alias_base_name_from_ifname(const char* ifname, char* base_ifname, size_t sz_base_ifname);
+
+/**
  * Get peer node IPoIB QP number (remote_qpn) from the peer's IP
  * address 
  * 


### PR DESCRIPTION
some changes in get_interface_base_name logic and calls
