### PR TITLE
issue: 848172 Fix csbuild report errors in neighbor handling

### DIFF
--- a/src/vma/infra/sender.h
+++ b/src/vma/infra/sender.h
@@ -36,7 +36,6 @@
 
 #include "utils/bullseye.h"
 #include "vlogger/vlogger.h"
-#include "vma/util/vma_list.h"
 #include "vma/util/to_str.h"
 #include "vma/util/utils.h"
 #include "vma/event/event.h"
@@ -93,9 +92,6 @@ public:
 
 	header  *m_header;
 	uint8_t m_protocol;
-
-	static inline size_t unsent_node_offset(void) {return NODE_OFFSET(neigh_send_data, unsent_node);}
-	list_node<neigh_send_data, neigh_send_data::unsent_node_offset> unsent_node;
 };
 
 class send_event : public event

--- a/src/vma/proto/neighbour.cpp
+++ b/src/vma/proto/neighbour.cpp
@@ -182,8 +182,6 @@ neigh_entry::neigh_entry(neigh_key key, transport_type_t _type, bool is_init_res
 	m_is_first_send_arp(true), m_n_sysvar_neigh_wait_till_send_arp_msec(safe_mce_sys().neigh_wait_till_send_arp_msec),
 	m_n_sysvar_neigh_uc_arp_quata(safe_mce_sys().neigh_uc_arp_quata), m_n_sysvar_neigh_num_err_retries(safe_mce_sys().neigh_num_err_retries)
 {
-	m_unsent_queue.set_id("neigh_entry (%p) : m_unsent_queue", this);
-
 	m_val = NULL;
 	m_p_dev = key.get_net_device_val();
 

--- a/src/vma/proto/neighbour.h
+++ b/src/vma/proto/neighbour.h
@@ -196,7 +196,7 @@ private:
  * Key = address (peer IP)
  * Val = class neigh_val
  */
-typedef vma_list_t<neigh_send_data, neigh_send_data::unsent_node_offset> unsent_queue_t;
+typedef std::deque<neigh_send_data *> unsent_queue_t;
 
 class neigh_entry : public cache_entry_subject<neigh_key, neigh_val *>, public event_handler_rdma_cm, public timer_handler
 {


### PR DESCRIPTION
(CLANG_WARNING) warning: Use of memory after it is freed

Signed-off-by: Liran Oz <lirano@mellanox.com>