### PR TITLE
issue: 854219 Getting ring after binding for TCP/UDP

### DIFF
--- a/src/vma/main.cpp
+++ b/src/vma/main.cpp
@@ -510,6 +510,7 @@ void print_vma_global_settings()
 	VLOG_PARAM_NUMBER("TCP timestamp option", safe_mce_sys().tcp_ts_opt, MCE_DEFAULT_TCP_TIMESTAMP_OPTION, SYS_VAR_TCP_TIMESTAMP_OPTION);
 	VLOG_PARAM_NUMSTR(vma_exception_handling::getName(), (int)safe_mce_sys().exception_handling, vma_exception_handling::MODE_DEFAULT, vma_exception_handling::getSysVar(), safe_mce_sys().exception_handling.to_str());
 	VLOG_PARAM_STRING("Avoid sys-calls on tcp fd", safe_mce_sys().avoid_sys_calls_on_tcp_fd, MCE_DEFAULT_AVOID_SYS_CALLS_ON_TCP_FD, SYS_VAR_AVOID_SYS_CALLS_ON_TCP_FD, safe_mce_sys().avoid_sys_calls_on_tcp_fd ? "Enabled" : "Disabled");
+	VLOG_PARAM_STRING("Allow privileged sock opt", safe_mce_sys().allow_privileged_sock_opt, MCE_DEFAULT_ALLOW_PRIVILEGED_SOCK_OPT, SYS_VAR_ALLOW_PRIVILEGED_SOCK_OPT, safe_mce_sys().allow_privileged_sock_opt ? "Enabled" : "Disabled");
 	VLOG_PARAM_NUMBER("Delay after join (msec)", safe_mce_sys().wait_after_join_msec, MCE_DEFAULT_WAIT_AFTER_JOIN_MSEC, SYS_VAR_WAIT_AFTER_JOIN_MSEC);
 	VLOG_STR_PARAM_STRING("Internal Thread Affinity", safe_mce_sys().internal_thread_affinity_str, MCE_DEFAULT_INTERNAL_THREAD_AFFINITY_STR, SYS_VAR_INTERNAL_THREAD_AFFINITY, safe_mce_sys().internal_thread_affinity_str);
 	VLOG_STR_PARAM_STRING("Internal Thread Cpuset", safe_mce_sys().internal_thread_cpuset, MCE_DEFAULT_INTERNAL_THREAD_CPUSET, SYS_VAR_INTERNAL_THREAD_CPUSET, safe_mce_sys().internal_thread_cpuset);

--- a/src/vma/sock/sock-redirect.cpp
+++ b/src/vma/sock/sock-redirect.cpp
@@ -486,7 +486,7 @@ int vma_get_socket_rings_fds(int fd, int *ring_fds, int ring_fds_sz)
 
 	if (ring_fds_sz > 0) {
 		p_socket_object = fd_collection_get_sockfd(fd);
-		if (p_socket_object && p_socket_object->check_rings_fds()) {
+		if (p_socket_object && p_socket_object->check_rings()) {
 				p_rings_fds = p_socket_object->get_rings_fds();
 				*ring_fds = p_rings_fds[0];
 				rings_num = 1;

--- a/src/vma/sock/socket_fd_api.h
+++ b/src/vma/sock/socket_fd_api.h
@@ -189,7 +189,7 @@ public:
 
 	list_node<socket_fd_api> node;
 	virtual int get_rings_num() {return 0;}
-	virtual bool check_rings_fds() {return false;}
+	virtual bool check_rings() {return false;}
 	virtual int* get_rings_fds() {return NULL;}
 
 protected:

--- a/src/vma/sock/sockinfo.cpp
+++ b/src/vma/sock/sockinfo.cpp
@@ -396,20 +396,18 @@ bool sockinfo::attach_receiver(flow_tuple_with_local_if &flow_key)
 		return false;
 	}
 
-	net_device_resources_t* p_nd_resources = get_nd_resources((const ip_address)flow_key.get_local_if());
+	// Allocate resources on specific interface (create ring)
+	net_device_resources_t* p_nd_resources = create_nd_resources((const ip_address)flow_key.get_local_if());
 	if (NULL == p_nd_resources) {
 		si_logerr("Failed to get net device resources %s", flow_key.to_str());
 		return false;
 	}
 
-	// Now we have the net_device object (created or found)
+	/* just increment reference counter on attach */
 	p_nd_resources->refcnt++;
 
 	// Map flow in local map
 	m_rx_flow_map[flow_key] = p_nd_resources->p_ring;
-
-	// Save the new CQ from ring
-	rx_add_ring_cb(flow_key, p_nd_resources->p_ring);
 
 	// Attach tuple
 	BULLSEYE_EXCLUDE_BLOCK_START
@@ -466,46 +464,14 @@ bool sockinfo::detach_receiver(flow_tuple_with_local_if &flow_key)
 	lock_rx_q();
 
 	// Un-map flow from local map
-	rx_del_ring_cb(flow_key, p_ring);
 	m_rx_flow_map.erase(rx_flow_iter);
 
-	// Check if we are already registered to net_device with the local ip as observers
-	ip_address ip_local(flow_key.get_local_if());
-	rx_net_device_map_t::iterator rx_nd_iter = m_rx_nd_map.find(ip_local.get_in_addr());
-	BULLSEYE_EXCLUDE_BLOCK_START
-	if (rx_nd_iter == m_rx_nd_map.end()) {
-		si_logerr("Failed to net_device associated with: %s", flow_key.to_str());
-		return false;
-	}
-	BULLSEYE_EXCLUDE_BLOCK_END
-	net_device_resources_t* p_nd_resources = &(rx_nd_iter->second);
-	p_nd_resources->refcnt--;
-	if (p_nd_resources->refcnt == 0) {
-
-		// Release ring reference
-		BULLSEYE_EXCLUDE_BLOCK_START
-		unlock_rx_q();
-		if (!p_nd_resources->p_ndv->release_ring(m_ring_alloc_logic.get_key())) {
-			lock_rx_q();
-			si_logerr("Failed to release ring for allocation key %d on lip %s", m_ring_alloc_logic.get_key(), ip_local.to_str().c_str());
-			return false;
-		}
-		lock_rx_q();
-
-		// Release observer reference
-		if (!g_p_net_device_table_mgr->unregister_observer(ip_local, &m_rx_nd_observer)) {
-			si_logerr("Failed registering as observer for lip %s", ip_local.to_str().c_str());
-			return false;
-		}
-		BULLSEYE_EXCLUDE_BLOCK_END
-
-		m_rx_nd_map.erase(rx_nd_iter);
-	}
+	destroy_nd_resources((const ip_address)flow_key.get_local_if());
 
 	return true;
 }
 
-net_device_resources_t* sockinfo::get_nd_resources(const ip_address ip_local)
+net_device_resources_t* sockinfo::create_nd_resources(const ip_address ip_local)
 {
 	net_device_resources_t* p_nd_resources = NULL;
 
@@ -567,9 +533,62 @@ net_device_resources_t* sockinfo::get_nd_resources(const ip_address ip_local)
 	// Now we have the net_device object (created or found)
 	p_nd_resources = &rx_nd_iter->second;
 
+	// Save the new CQ from ring (fake_flow_key is not used)
+	{
+		flow_tuple_with_local_if fake_flow_key(m_bound, m_connected, m_protocol, ip_local.get_in_addr());
+		rx_add_ring_cb(fake_flow_key, p_nd_resources->p_ring);
+	}
+
 	return p_nd_resources;
 err:
 	return NULL;
+}
+
+void sockinfo::destroy_nd_resources(const ip_address ip_local)
+{
+	net_device_resources_t* p_nd_resources = NULL;
+	rx_net_device_map_t::iterator rx_nd_iter = m_rx_nd_map.find(ip_local.get_in_addr());
+	BULLSEYE_EXCLUDE_BLOCK_START
+	if (rx_nd_iter == m_rx_nd_map.end()) {
+		si_logerr("Failed to net_device associated with: %s", ip_local.to_str().c_str());
+		goto err;
+	}
+	BULLSEYE_EXCLUDE_BLOCK_END
+
+	p_nd_resources = &(rx_nd_iter->second);
+
+	p_nd_resources->refcnt--;
+
+	// Release the new CQ from ring (fake flow_key is not used)
+	{
+		flow_tuple_with_local_if fake_flow_key(m_bound, m_connected, m_protocol, ip_local.get_in_addr());
+		rx_del_ring_cb(fake_flow_key, p_nd_resources->p_ring);
+	}
+
+	if (p_nd_resources->refcnt == 0) {
+
+		// Release ring reference
+		BULLSEYE_EXCLUDE_BLOCK_START
+		unlock_rx_q();
+		if (!p_nd_resources->p_ndv->release_ring(m_ring_alloc_logic.get_key())) {
+			lock_rx_q();
+			si_logerr("Failed to release ring for allocation key %d on lip %s", m_ring_alloc_logic.get_key(), ip_local.to_str().c_str());
+			goto err;
+		}
+		lock_rx_q();
+
+		// Release observer reference
+		if (!g_p_net_device_table_mgr->unregister_observer(ip_local, &m_rx_nd_observer)) {
+			si_logerr("Failed registering as observer for lip %s", ip_local.to_str().c_str());
+			goto err;
+		}
+		BULLSEYE_EXCLUDE_BLOCK_END
+
+		m_rx_nd_map.erase(rx_nd_iter);
+	}
+
+err:
+	return ;
 }
 
 void sockinfo::do_rings_migration()
@@ -769,6 +788,7 @@ void sockinfo::rx_add_ring_cb(flow_tuple_with_local_if &flow_key, ring* p_ring, 
 		// Increase ref count on cq_mgr object
 		rx_ring_iter->second->refcnt++;
 	}
+
 	unlock_rx_q();
 	m_rx_ring_map_lock.unlock();
 

--- a/src/vma/sock/sockinfo.cpp
+++ b/src/vma/sock/sockinfo.cpp
@@ -396,66 +396,13 @@ bool sockinfo::attach_receiver(flow_tuple_with_local_if &flow_key)
 		return false;
 	}
 
-	net_device_resources_t* p_nd_resources = NULL;
-
-	// Check if we are already registered to net_device with the local ip as observers
-	ip_address ip_local(flow_key.get_local_if());
-	rx_net_device_map_t::iterator rx_nd_iter = m_rx_nd_map.find(ip_local.get_in_addr());
-	if (rx_nd_iter == m_rx_nd_map.end()) {
-
-		// Need to register as observer to net_device
-		net_device_resources_t nd_resources;
-		nd_resources.refcnt = 0;
-		nd_resources.p_nde = NULL;
-		nd_resources.p_ndv = NULL;
-		nd_resources.p_ring = NULL;
-
-		BULLSEYE_EXCLUDE_BLOCK_START
-		cache_entry_subject<ip_address, net_device_val*>* p_ces = NULL;
-		if (!g_p_net_device_table_mgr->register_observer(ip_local, &m_rx_nd_observer, &p_ces)) {
-			si_logdbg("Failed registering as observer for local ip %s", ip_local.to_str().c_str());
-			return false;
-		}
-		nd_resources.p_nde = (net_device_entry*)p_ces;
-		if (!nd_resources.p_nde) {
-			si_logerr("Got NULL net_devide_entry for local ip %s", ip_local.to_str().c_str());
-			return false;
-		}
-		if (!nd_resources.p_nde->get_val(nd_resources.p_ndv)) {
-			si_logerr("Got net_device_val=NULL (interface is not offloaded) for local ip %s", ip_local.to_str().c_str());
-			return false;
-		}
-
-		unlock_rx_q();
-		m_rx_ring_map_lock.lock();
-		resource_allocation_key key = 0;
-		if (m_rx_ring_map.size()) {
-			key = m_ring_alloc_logic.get_key();
-		} else {
-			key = m_ring_alloc_logic.create_new_key();
-		}
-		nd_resources.p_ring = nd_resources.p_ndv->reserve_ring(key);
-		m_rx_ring_map_lock.unlock();
-		lock_rx_q();
-		if (!nd_resources.p_ring) {
-			si_logdbg("Failed to reserve ring for allocation key %d on lip %s", m_ring_alloc_logic.get_key(), ip_local.to_str().c_str());
-			return false;
-		}
-
-		// Add new net_device to rx_map
-		m_rx_nd_map[ip_local.get_in_addr()] = nd_resources;
-
-		rx_nd_iter = m_rx_nd_map.find(ip_local.get_in_addr());
-		if (rx_nd_iter == m_rx_nd_map.end()) {
-			si_logerr("Failed to find rx_nd_iter");
-			return false;
-		}
-		BULLSEYE_EXCLUDE_BLOCK_END
-
+	net_device_resources_t* p_nd_resources = get_nd_resources((const ip_address)flow_key.get_local_if());
+	if (NULL == p_nd_resources) {
+		si_logerr("Failed to get net device resources %s", flow_key.to_str());
+		return false;
 	}
 
 	// Now we have the net_device object (created or found)
-	p_nd_resources = &rx_nd_iter->second;
 	p_nd_resources->refcnt++;
 
 	// Map flow in local map
@@ -556,6 +503,73 @@ bool sockinfo::detach_receiver(flow_tuple_with_local_if &flow_key)
 	}
 
 	return true;
+}
+
+net_device_resources_t* sockinfo::get_nd_resources(const ip_address ip_local)
+{
+	net_device_resources_t* p_nd_resources = NULL;
+
+	// Check if we are already registered to net_device with the local ip as observers
+	rx_net_device_map_t::iterator rx_nd_iter = m_rx_nd_map.find(ip_local.get_in_addr());
+	if (rx_nd_iter == m_rx_nd_map.end()) {
+
+		// Need to register as observer to net_device
+		net_device_resources_t nd_resources;
+		nd_resources.refcnt = 0;
+		nd_resources.p_nde = NULL;
+		nd_resources.p_ndv = NULL;
+		nd_resources.p_ring = NULL;
+
+		BULLSEYE_EXCLUDE_BLOCK_START
+		cache_entry_subject<ip_address, net_device_val*>* p_ces = NULL;
+		if (!g_p_net_device_table_mgr->register_observer(ip_local, &m_rx_nd_observer, &p_ces)) {
+			si_logdbg("Failed registering as observer for local ip %s", ip_local.to_str().c_str());
+			goto err;
+		}
+		nd_resources.p_nde = (net_device_entry*)p_ces;
+		if (!nd_resources.p_nde) {
+			si_logerr("Got NULL net_devide_entry for local ip %s", ip_local.to_str().c_str());
+			goto err;
+		}
+		if (!nd_resources.p_nde->get_val(nd_resources.p_ndv)) {
+			si_logerr("Got net_device_val=NULL (interface is not offloaded) for local ip %s", ip_local.to_str().c_str());
+			goto err;
+		}
+
+		unlock_rx_q();
+		m_rx_ring_map_lock.lock();
+		resource_allocation_key key = 0;
+		if (m_rx_ring_map.size()) {
+			key = m_ring_alloc_logic.get_key();
+		} else {
+			key = m_ring_alloc_logic.create_new_key();
+		}
+		nd_resources.p_ring = nd_resources.p_ndv->reserve_ring(key);
+		m_rx_ring_map_lock.unlock();
+		lock_rx_q();
+		if (!nd_resources.p_ring) {
+			si_logdbg("Failed to reserve ring for allocation key %d on lip %s", m_ring_alloc_logic.get_key(), ip_local.to_str().c_str());
+			goto err;
+		}
+
+		// Add new net_device to rx_map
+		m_rx_nd_map[ip_local.get_in_addr()] = nd_resources;
+
+		rx_nd_iter = m_rx_nd_map.find(ip_local.get_in_addr());
+		if (rx_nd_iter == m_rx_nd_map.end()) {
+			si_logerr("Failed to find rx_nd_iter");
+			goto err;
+		}
+		BULLSEYE_EXCLUDE_BLOCK_END
+
+	}
+
+	// Now we have the net_device object (created or found)
+	p_nd_resources = &rx_nd_iter->second;
+
+	return p_nd_resources;
+err:
+	return NULL;
 }
 
 void sockinfo::do_rings_migration()

--- a/src/vma/sock/sockinfo.h
+++ b/src/vma/sock/sockinfo.h
@@ -101,7 +101,7 @@ public:
 	virtual void remove_epoll_context(epfd_info *epfd);
 	virtual int fast_nonblocking_rx(vma_packets_t *vma_pkts);
 	virtual int get_rings_num() {return 1;}
-	virtual bool check_rings_fds() {return m_p_rx_ring ? true: false;}
+	virtual bool check_rings() {return m_p_rx_ring ? true: false;}
 	virtual int* get_rings_fds() {int* channel_fds = m_p_rx_ring->get_rx_channel_fds(); return channel_fds;}
 
 protected:

--- a/src/vma/sock/sockinfo.h
+++ b/src/vma/sock/sockinfo.h
@@ -183,7 +183,8 @@ protected:
 
 	bool 			attach_receiver(flow_tuple_with_local_if &flow_key);
 	bool 			detach_receiver(flow_tuple_with_local_if &flow_key);
-	net_device_resources_t* get_nd_resources(const ip_address ip_local);
+	net_device_resources_t* create_nd_resources(const ip_address ip_local);
+	void                    destroy_nd_resources(const ip_address ip_local);
 	void			do_rings_migration();
 
 	// Attach to all relevant rings for offloading receive flows - always used from slow path

--- a/src/vma/sock/sockinfo.h
+++ b/src/vma/sock/sockinfo.h
@@ -183,6 +183,7 @@ protected:
 
 	bool 			attach_receiver(flow_tuple_with_local_if &flow_key);
 	bool 			detach_receiver(flow_tuple_with_local_if &flow_key);
+	net_device_resources_t* get_nd_resources(const ip_address ip_local);
 	void			do_rings_migration();
 
 	// Attach to all relevant rings for offloading receive flows - always used from slow path

--- a/src/vma/sock/sockinfo_tcp.cpp
+++ b/src/vma/sock/sockinfo_tcp.cpp
@@ -2011,18 +2011,6 @@ int sockinfo_tcp::bind(const sockaddr *__addr, socklen_t __addrlen)
 		return -1; //error
 	}
 
-	if (!m_bound.is_anyaddr() && !m_bound.is_local_loopback()) {
-		ip_address local_ip(m_bound.get_in_addr());
-
-		net_device_resources_t* p_nd_resources = get_nd_resources((const ip_address)local_ip);
-		if (p_nd_resources) {
-			/* Ring is available now but not ready to receive */
-			m_p_rx_ring = p_nd_resources->p_ring;
-		} else {
-			si_tcp_logerr("Failed to get net device resources on ip %s", local_ip.to_str().c_str());
-		}
-	}
-
 	m_sock_state = TCP_SOCK_BOUND;
 
 	m_bound.set(tmp_sin);
@@ -3180,6 +3168,7 @@ int sockinfo_tcp::setsockopt(int __level, int __optname,
 
 	int val, ret = 0;
 	bool supported = true;
+	bool allow_privileged_sys_call = false;
 
 	/* Process VMA specific options only at the moment
 	 * VMA option does not require additional processing after return
@@ -3265,6 +3254,7 @@ int sockinfo_tcp::setsockopt(int __level, int __optname,
 		}
 		case SO_BINDTODEVICE:
 			struct sockaddr_in sockaddr;
+			allow_privileged_sys_call = safe_mce_sys().allow_privileged_sys_calls;
 			if (__optlen == 0 || ((char*)__optval)[0] == '\0') {
 				m_so_bindtodevice_ip = 0;
 			} else if (get_ipv4_from_ifname((char*)__optval, &sockaddr)) {
@@ -3274,6 +3264,31 @@ int sockinfo_tcp::setsockopt(int __level, int __optname,
 				break;
 			} else {
 				m_so_bindtodevice_ip = sockaddr.sin_addr.s_addr;
+
+				if (!is_connected()) {
+					/* Current implementation allows to create separate rings for tx and rx.
+					 * tx ring is created basing on destination ip during connect() call,
+					 * SO_BINDTODEVICE and routing table information
+					 * whereas rx ring creation can be based on bound (local) ip
+					 * As a result there are limitations in using this capability.
+					 * Also we can not have bound information as
+					 * (!m_bound.is_anyaddr() && !m_bound.is_local_loopback())
+					 * and can not detect offload/non-offload socket
+					 * Note:
+					 * This inconsistence should be resolved.
+					 */
+					ip_address local_ip(m_so_bindtodevice_ip);
+
+					lock_tcp_con();
+					net_device_resources_t* p_nd_resources = get_nd_resources((const ip_address)local_ip);
+					if (p_nd_resources) {
+						/* Ring is available now but not ready to receive */
+						m_p_rx_ring = p_nd_resources->p_ring;
+					} else {
+						si_tcp_logerr("Failed to get net device resources on ip %s", local_ip.to_str().c_str());
+					}
+					unlock_tcp_con();
+				}
 			}
 			// handle TX side
 			if (m_p_connected_dst_entry) {
@@ -3317,9 +3332,17 @@ int sockinfo_tcp::setsockopt(int __level, int __optname,
 	ret = orig_os_api.setsockopt(m_fd, __level, __optname, __optval, __optlen);
 	BULLSEYE_EXCLUDE_BLOCK_START
 	if (ret) {
-		si_tcp_logdbg("setsockopt failed (ret=%d %m)", ret);
+		if (EPERM == errno && allow_privileged_sys_call) {
+			ret = 0;
+			errno = 0;
+			si_tcp_logdbg("setsockopt failure is suppressed (ret=%d %m)", ret);
+		}
+		else {
+			si_tcp_logdbg("setsockopt failed (ret=%d %m)", ret);
+		}
 	}
 	BULLSEYE_EXCLUDE_BLOCK_END
+
 	return ret;
 }
 

--- a/src/vma/sock/sockinfo_tcp.cpp
+++ b/src/vma/sock/sockinfo_tcp.cpp
@@ -3280,11 +3280,13 @@ int sockinfo_tcp::setsockopt(int __level, int __optname,
 					ip_address local_ip(m_so_bindtodevice_ip);
 
 					lock_tcp_con();
-					net_device_resources_t* p_nd_resources = get_nd_resources((const ip_address)local_ip);
+					/* TODO: we need to destroy this if attach/detach receiver is not called */
+					net_device_resources_t* p_nd_resources = create_nd_resources((const ip_address)local_ip);
 					if (p_nd_resources) {
-						/* Ring is available now but not ready to receive */
+						/* TODO: consider moving one to rx_add_ring_cb() */
 						m_p_rx_ring = p_nd_resources->p_ring;
-					} else {
+					}
+					else {
 						si_tcp_logerr("Failed to get net device resources on ip %s", local_ip.to_str().c_str());
 					}
 					unlock_tcp_con();

--- a/src/vma/sock/sockinfo_tcp.cpp
+++ b/src/vma/sock/sockinfo_tcp.cpp
@@ -3168,7 +3168,7 @@ int sockinfo_tcp::setsockopt(int __level, int __optname,
 
 	int val, ret = 0;
 	bool supported = true;
-	bool allow_privileged_sys_call = false;
+	bool allow_privileged_sock_opt = false;
 
 	/* Process VMA specific options only at the moment
 	 * VMA option does not require additional processing after return
@@ -3254,7 +3254,7 @@ int sockinfo_tcp::setsockopt(int __level, int __optname,
 		}
 		case SO_BINDTODEVICE:
 			struct sockaddr_in sockaddr;
-			allow_privileged_sys_call = safe_mce_sys().allow_privileged_sys_calls;
+			allow_privileged_sock_opt = safe_mce_sys().allow_privileged_sock_opt;
 			if (__optlen == 0 || ((char*)__optval)[0] == '\0') {
 				m_so_bindtodevice_ip = 0;
 			} else if (get_ipv4_from_ifname((char*)__optval, &sockaddr)) {
@@ -3332,7 +3332,7 @@ int sockinfo_tcp::setsockopt(int __level, int __optname,
 	ret = orig_os_api.setsockopt(m_fd, __level, __optname, __optval, __optlen);
 	BULLSEYE_EXCLUDE_BLOCK_START
 	if (ret) {
-		if (EPERM == errno && allow_privileged_sys_call) {
+		if (EPERM == errno && allow_privileged_sock_opt) {
 			ret = 0;
 			errno = 0;
 			si_tcp_logdbg("setsockopt failure is suppressed (ret=%d %m)", ret);

--- a/src/vma/sock/sockinfo_tcp.cpp
+++ b/src/vma/sock/sockinfo_tcp.cpp
@@ -2011,6 +2011,18 @@ int sockinfo_tcp::bind(const sockaddr *__addr, socklen_t __addrlen)
 		return -1; //error
 	}
 
+	if (!m_bound.is_anyaddr() && !m_bound.is_local_loopback()) {
+		ip_address local_ip(m_bound.get_in_addr());
+
+		net_device_resources_t* p_nd_resources = get_nd_resources((const ip_address)local_ip);
+		if (p_nd_resources) {
+			/* Ring is available now but not ready to receive */
+			m_p_rx_ring = p_nd_resources->p_ring;
+		} else {
+			si_tcp_logerr("Failed to get net device resources on ip %s", local_ip.to_str().c_str());
+		}
+	}
+
 	m_sock_state = TCP_SOCK_BOUND;
 
 	m_bound.set(tmp_sin);

--- a/src/vma/util/sys_vars.cpp
+++ b/src/vma/util/sys_vars.cpp
@@ -395,6 +395,7 @@ void mce_sys_var::get_env_params()
 	tcp_ts_opt		= MCE_DEFAULT_TCP_TIMESTAMP_OPTION;
 //	exception_handling is handled by its CTOR
 	avoid_sys_calls_on_tcp_fd = MCE_DEFAULT_AVOID_SYS_CALLS_ON_TCP_FD;
+	allow_privileged_sock_opt = MCE_DEFAULT_ALLOW_PRIVILEGED_SOCK_OPT;
 	wait_after_join_msec	= MCE_DEFAULT_WAIT_AFTER_JOIN_MSEC;
 	thread_mode		= MCE_DEFAULT_THREAD_MODE;
 	buffer_batching_mode	= MCE_DEFAULT_BUFFER_BATCHING_MODE;
@@ -812,6 +813,10 @@ void mce_sys_var::get_env_params()
 
 	if ((env_ptr = getenv(SYS_VAR_AVOID_SYS_CALLS_ON_TCP_FD)) != NULL) {
 			avoid_sys_calls_on_tcp_fd = atoi(env_ptr) ? true : false;
+	}
+
+	if ((env_ptr = getenv(SYS_VAR_ALLOW_PRIVILEGED_SOCK_OPT)) != NULL) {
+			allow_privileged_sock_opt = atoi(env_ptr) ? true : false;
 	}
 
 	if(tcp_timer_resolution_msec < timer_resolution_msec){

--- a/src/vma/util/sys_vars.h
+++ b/src/vma/util/sys_vars.h
@@ -341,6 +341,7 @@ struct mce_sys_var {
 	tcp_ts_opt_t	tcp_ts_opt;
 	vma_exception_handling exception_handling;
 	bool		avoid_sys_calls_on_tcp_fd;
+	bool		allow_privileged_sock_opt;
 	uint32_t	wait_after_join_msec;
 	in_port_t	block_udp_port;
 	thread_mode_t	thread_mode;
@@ -464,6 +465,7 @@ extern mce_sys_var & safe_mce_sys();
 #define SYS_VAR_TCP_TIMESTAMP_OPTION			"VMA_TCP_TIMESTAMP_OPTION"
 #define SYS_VAR_VMA_EXCEPTION_HANDLING			(vma_exception_handling::getSysVar())
 #define SYS_VAR_AVOID_SYS_CALLS_ON_TCP_FD		"VMA_AVOID_SYS_CALLS_ON_TCP_FD"
+#define SYS_VAR_ALLOW_PRIVILEGED_SOCK_OPT		"VMA_ALLOW_PRIVILEGED_SOCK_OPT"
 #define SYS_VAR_WAIT_AFTER_JOIN_MSEC			"VMA_WAIT_AFTER_JOIN_MSEC"
 #define SYS_VAR_THREAD_MODE				"VMA_THREAD_MODE"
 #define SYS_VAR_BUFFER_BATCHING_MODE			"VMA_BUFFER_BATCHING_MODE"
@@ -568,6 +570,7 @@ extern mce_sys_var & safe_mce_sys();
 #define MCE_DEFAULT_TCP_TIMESTAMP_OPTION		(TCP_TS_OPTION_DISABLE)
 #define MCE_DEFAULT_VMA_EXCEPTION_HANDLING	(vma_exception_handling::MODE_DEFAULT)
 #define MCE_DEFAULT_AVOID_SYS_CALLS_ON_TCP_FD		(false)
+#define MCE_DEFAULT_ALLOW_PRIVILEGED_SOCK_OPT		(true)
 #define MCE_DEFAULT_WAIT_AFTER_JOIN_MSEC		(0)
 #define MCE_DEFAULT_THREAD_MODE				(THREAD_MODE_MULTI)
 #define MCE_DEFAULT_BUFFER_BATCHING_MODE		(BUFFER_BATCHING_WITH_RECLAIM)


### PR DESCRIPTION
This changes do possible to get ring after  bind() call for TCP sockets.
There are following limitations:
- It does not support INADDR_ANY
- It does not work for loopback

@alexvm @rosenbaumalex @OphirMunk please look at changes