### PR TITLE
issue: 865172 fixed illegal memory access by netlink wrapper.

### DIFF
--- a/src/vma/netlink/netlink_wrapper.cpp
+++ b/src/vma/netlink/netlink_wrapper.cpp
@@ -152,12 +152,12 @@ netlink_wrapper::~netlink_wrapper()
 	/* different handling under LIBNL1 versus LIBNL3 */
 #ifdef HAVE_LIBNL3
 	nl_logdbg( "---> netlink_route_listener DTOR (LIBNL3)");
-	nl_socket_handle_free(m_socket_handle); 
 	/* should not call nl_cache_free() for link, neigh, route as nl_cach_mngr_free() does the freeing */
 	// nl_cache_free(m_cache_link);
 	// nl_cache_free(m_cache_neigh);
 	// nl_cache_free(m_cache_route);
 	nl_cache_mngr_free(m_mngr);	
+	nl_socket_handle_free(m_socket_handle); 
 #else // HAVE_LINBL1
 	nl_logdbg( "---> netlink_route_listener DTOR (LIBNL1)");
 	/* should not call nl_socket_handle_free(m_socket_handle) as nl_cache_mngr_free() does the freeing */ 


### PR DESCRIPTION
Calling nl_socket_handle_free() freed memory which was then
accessed by nl_cache_mngr_free.

Signed-off-by: Ilan Smith ilansm@mellanox.com
