### PR TITLE
issue: 885183 Enable vma_poll() usage mode by default

### DIFF
--- a/src/vma/dev/cq_mgr.h
+++ b/src/vma/dev/cq_mgr.h
@@ -133,7 +133,7 @@ public:
 	 * @return  >=0 number of wce processed
 	 *          < 0 error
 	 */
-	int	drain_and_proccess(bool b_recycle_buffers = false);
+	int	drain_and_proccess(uintptr_t* p_recycle_buffers_last_wr_id = NULL);
 
 	// CQ implements the Rx mem_buf_desc_owner.
 	// These callbacks will be called for each Rx buffer that passed processed completion

--- a/src/vma/dev/net_device_table_mgr.cpp
+++ b/src/vma/dev/net_device_table_mgr.cpp
@@ -513,7 +513,13 @@ void net_device_table_mgr::handle_timer_expired(void* user_data)
 	int timer_type = (uint64_t)user_data;
 	switch (timer_type) {
 	case RING_PROGRESS_ENGINE_TIMER:
+#if 0 /* TODO: see explanation */
+		/* Do not call draining RX logic from internal thread for vma_poll mode
+		 * It is disable by default
+		 * See: cq_mgr::drain_and_proccess()
+		 */
 		global_ring_drain_and_procces();
+#endif
 		break;
 	case RING_ADAPT_CQ_MODERATION_TIMER:
 		global_ring_adapt_cq_moderation();

--- a/src/vma/dev/qp_mgr.cpp
+++ b/src/vma/dev/qp_mgr.cpp
@@ -44,7 +44,7 @@ qp_mgr::qp_mgr(const ring_simple* p_ring, const ib_ctx_handler* p_context, const
 	m_qp(NULL), m_p_ring((ring_simple*)p_ring), m_port_num((uint8_t)port_num), m_p_ib_ctx_handler((ib_ctx_handler*)p_context),
 	m_p_ahc_head(NULL), m_p_ahc_tail(NULL), m_max_inline_data(0), m_max_qp_wr(0), m_p_cq_mgr_rx(NULL), m_p_cq_mgr_tx(NULL),
 	m_rx_num_wr(safe_mce_sys().rx_num_wr), m_tx_num_wr(tx_num_wr), m_rx_num_wr_to_post_recv(safe_mce_sys().rx_num_wr_to_post_recv), 
-	m_curr_rx_wr(0), m_n_unsignaled_count(0), m_n_tx_count(0), m_p_last_tx_mem_buf_desc(NULL), m_p_prev_rx_desc_pushed(NULL),
+	m_curr_rx_wr(0), m_last_posted_rx_wr_id(0), m_n_unsignaled_count(0), m_n_tx_count(0), m_p_last_tx_mem_buf_desc(NULL), m_p_prev_rx_desc_pushed(NULL),
 	m_n_ip_id_base(0), m_n_ip_id_offset(0)
 {
 	m_ibv_rx_sg_array = new ibv_sge[m_rx_num_wr_to_post_recv];
@@ -212,7 +212,7 @@ void qp_mgr::down()
 	trigger_completion_for_all_sent_packets();
 
 	// let the QP drain all wqe's to flushed cqe's now that we moved 
-	// it to error state and post_sent final trigger for complition
+	// it to error state and post_sent final trigger for completion
 	usleep(1000);
 
 	release_tx_buffers();
@@ -260,7 +260,6 @@ void qp_mgr::modify_qp_to_error_state()
 
 void qp_mgr::release_rx_buffers()
 {
-	int ret = 0;
 	int total_ret = m_curr_rx_wr;
 	if (m_curr_rx_wr) {
 		qp_logdbg("Returning %d pending post_recv buffers to CQ owner", m_curr_rx_wr);
@@ -276,11 +275,21 @@ void qp_mgr::release_rx_buffers()
 		}
 	}
 
-	qp_logdbg("draining rx cq_mgr %p", m_p_cq_mgr_rx);
-	while (m_p_cq_mgr_rx && (ret = m_p_cq_mgr_rx->drain_and_proccess(true)) > 0) {
+	// Wait for all FLUSHed WQE on Rx CQ
+	qp_logdbg("draining rx cq_mgr %p (last_posted_rx_wr_id = %x)", m_p_cq_mgr_rx, m_last_posted_rx_wr_id);
+	uintptr_t last_polled_rx_wr_id = 0;
+	while (m_p_cq_mgr_rx && last_polled_rx_wr_id != m_last_posted_rx_wr_id) {
+
+		// Process the FLUSH'ed WQE's
+		int ret = m_p_cq_mgr_rx->drain_and_proccess(&last_polled_rx_wr_id);
 		qp_logdbg("draining completed on rx cq_mgr (%d wce)", ret);
 		total_ret += ret;
+
+		// Add short delay (500 usec) to allow for WQE's to be flushed to CQ every poll cycle
+		const struct timespec short_sleep = {0, 500000}; // 500 usec
+		nanosleep(&short_sleep, NULL);
 	}
+	m_last_posted_rx_wr_id = 0; // Clear the posted WR_ID flag, we just clear the entier RQ
 	qp_logdbg("draining completed with a total of %d wce's on rx cq_mgr", total_ret);
 }
 
@@ -457,6 +466,8 @@ int qp_mgr::post_recv(mem_buf_desc_t* p_mem_buf_desc)
 		m_rq_wqe_counter++;
 
 		if (m_curr_rx_wr == m_rx_num_wr_to_post_recv-1) {
+
+			m_last_posted_rx_wr_id = (uintptr_t)p_mem_buf_desc;
 
 			m_p_prev_rx_desc_pushed = NULL;
 			p_mem_buf_desc->p_prev_desc = NULL;

--- a/src/vma/dev/qp_mgr.h
+++ b/src/vma/dev/qp_mgr.h
@@ -154,6 +154,7 @@ protected:
 	ibv_sge*		m_ibv_rx_sg_array;
 	ibv_recv_wr*		m_ibv_rx_wr_array;
 	uint32_t		m_curr_rx_wr;
+	uintptr_t 		m_last_posted_rx_wr_id; // Remember so in case we flush RQ we know to wait until this WR_ID is received
 
 	// send wr
 	uint32_t		m_n_unsignaled_count;

--- a/src/vma/dev/ring.cpp
+++ b/src/vma/dev/ring.cpp
@@ -15,7 +15,8 @@
 
 ring::ring(int count, uint32_t mtu) :
 	m_n_num_resources(count), m_p_n_rx_channel_fds(NULL), m_parent(NULL),
-	m_vma_active(false), m_mtu(mtu)
+	m_vma_active(true), /* TODO: This VMA version supports vma_poll() usage mode only */
+	m_mtu(mtu)
 {
 	INIT_LIST_HEAD(&m_ec_list);
 	m_vma_poll_completion = NULL;

--- a/src/vma/dev/ring_simple.cpp
+++ b/src/vma/dev/ring_simple.cpp
@@ -102,8 +102,6 @@ ring_simple::~ring_simple()
 {
 	ring_logdbg("delete ring()");
 
-	set_vma_active(false);
-
 	// Go over all hash and for each flow: 1.Detach from qp 2.Delete related rfs object 3.Remove flow from hash
 	m_lock_ring_rx.lock();
 	flow_udp_uc_del_all();
@@ -1237,8 +1235,6 @@ int ring_simple::vma_poll(struct vma_completion_t *vma_completions, unsigned int
 	mem_buf_desc_t *desc;
 
 	NOT_IN_USE(flags);
-
-	set_vma_active(true);
 
 	if (likely(vma_completions) && ncompletions) {
 		struct ring_ec *ec = NULL;

--- a/tests/resource_release_checker/server_socket_receive_and_recreate_loop.py
+++ b/tests/resource_release_checker/server_socket_receive_and_recreate_loop.py
@@ -1,0 +1,129 @@
+#!/usr/bin/env python
+#
+#
+#@copyright:
+#        Copyright (c) 2001-2016 Mellanox Technologies, Ltd. All rights reserved.
+#
+#        This software is available to you under a choice of one of two
+#        licenses.  You may choose to be licensed under the terms of the GNU
+#        General Public License (GPL) Version 2, available from the file
+#        COPYING in the main directory of this source tree, or the
+#        BSD license below:
+#
+#            Redistribution and use in source and binary forms, with or
+#            without modification, are permitted provided that the following
+#            conditions are met:
+#
+#             - Redistributions of source code must retain the above
+#               copyright notice, this list of conditions and the following
+#               disclaimer.
+#
+#             - Redistributions in binary form must reproduce the above
+#               copyright notice, this list of conditions and the following
+#               disclaimer in the documentation and/or other materials
+#               provided with the distribution.
+#
+#        THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+#        EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+#        MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+#        NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+#        BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+#        ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+#        CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+#        SOFTWARE.
+#
+#@author: Alex Rosenbaum
+
+#@date: 20160520
+#
+#
+import socket, select, os, time, sys, fcntl, errno
+
+EPOLL_TIMEOUT=1 # infinity
+
+def echo_server(argv):
+	if (len(argv) <4):
+	    print "Incorrect parameter : " + argv[0] + " server-ip server-port-lower num-socket packet-count-to-restart"
+	    sys.exit(-1)
+
+	# read configuration
+	IP = argv[1]
+	PORT = int(argv[2])
+	SKT_COUNT=100
+	PKT_TO_RESTART_COUNT = 100000
+	if (len(argv) > 3): 
+		SKT_COUNT  = int(argv[3])
+		if (len(argv) > 4): 
+			PKT_TO_RESTART_COUNT = int(argv[4])
+
+	loops = 10
+	while loops > 0:
+
+		# init structures
+		sock = None
+		sock_fd = 0
+		streams = {}
+		epoll = select.epoll()
+
+		# create socket and add to epoll()
+		counter = 0
+		while counter < SKT_COUNT:
+			sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+			print IP, int(PORT + counter)
+			sock.bind((IP, int(PORT + counter)))
+			fd = sock.fileno()
+			epoll.register(fd, select.EPOLLIN)
+			streams[fd] = sock
+			counter += 1
+
+		# block on epoll until received expected packets
+		counter = 0
+		print "expected to process ", PKT_TO_RESTART_COUNT, " ingress packet before leaving loop..."
+		while counter < PKT_TO_RESTART_COUNT:
+			# print "calling epoll ..."
+			eevents = epoll.poll(EPOLL_TIMEOUT)
+			if len(eevents) == 0:
+				# print "wakeup from epoll (timeout)"
+				continue # epoll timeout
+			else:
+				# check epoll ready events
+				# print "wakeup from epoll (rc=", eevents, ")"
+				for fd, evt in eevents:
+					if evt & select.EPOLLIN: # error on socket close it and restart from begining
+						sock = streams[fd]
+						data = sock.recv(1500)
+						counter += 1
+						# print "Rx counter=", counter
+				continue
+		print "done epoll Rx of ", counter, " packets"
+
+		print "... 4s sleep before continueing..."
+		time.sleep (4)
+	
+		# close before restart session
+		print "starting disconnect..."
+		for fd in streams:
+			sock = streams[fd]
+			sock.close()
+		print "closed sockets .. 4s sleep before continueing..."
+		time.sleep (4)
+		epoll.close()
+		print "closed epoll .. 4s sleep before continueing..."
+		time.sleep (4)
+
+		print "Done...(loop=", loops, ")"
+		loops -= 1
+
+		print "... 1s sleep before continueing..."
+		time.sleep (1)
+
+		continue
+
+	print "... big sleep before exit..."
+	time.sleep (100)
+
+def main():
+	echo_server(sys.argv)
+
+if __name__ == "__main__":
+    main()

--- a/tests/resource_release_checker/server_socket_recreate_loop.py
+++ b/tests/resource_release_checker/server_socket_recreate_loop.py
@@ -1,0 +1,67 @@
+#!/usr/bin/env python
+#
+#
+#@copyright:
+#        Copyright (c) 2001-2016 Mellanox Technologies, Ltd. All rights reserved.
+#
+#        This software is available to you under a choice of one of two
+#        licenses.  You may choose to be licensed under the terms of the GNU
+#        General Public License (GPL) Version 2, available from the file
+#        COPYING in the main directory of this source tree, or the
+#        BSD license below:
+#
+#            Redistribution and use in source and binary forms, with or
+#            without modification, are permitted provided that the following
+#            conditions are met:
+#
+#             - Redistributions of source code must retain the above
+#               copyright notice, this list of conditions and the following
+#               disclaimer.
+#
+#             - Redistributions in binary form must reproduce the above
+#               copyright notice, this list of conditions and the following
+#               disclaimer in the documentation and/or other materials
+#               provided with the distribution.
+#
+#        THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+#        EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+#        MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+#        NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+#        BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+#        ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+#        CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+#        SOFTWARE.
+#
+#@author: Alex Rosenbaum
+
+#@date: 20160520
+#
+#
+import socket, select, os, time, sys, fcntl, errno
+
+def main():
+
+	argv = sys.argv
+	if (len(argv) < 2):
+		print "Incorrect parameter : " + argv[0] + " server-ip server-port-lower"
+		sys.exit(-1)
+
+	# read configuration
+	IP = argv[1]
+	PORT = int(argv[2])
+
+	loops = 4
+	while loops > 0:
+		print "socket create..."
+		sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+		sock.bind((IP, int(PORT)))
+		print ".. created ... sleep before continueing..."
+		time.sleep (4)
+		print "socket closing ..."
+		sock.close()
+		print ".. closed ... sleep before continueing..."
+		time.sleep (4)
+		loops -= 1
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
There is race condition possibility in current implementation
related switching from legacy to vma_poll modes and back.
As far as this implementation is oriented to vma_poll mode
only we can set this mode by default.

See:
master: https://github.com/Mellanox/libvma/pull/101

@alexvm @OphirMunk please look at and pay attention on note.
