### PR TITLE
issue: 897296 Fix advanced routing issues

### DIFF
--- a/src/vma/proto/dst_entry.cpp
+++ b/src/vma/proto/dst_entry.cpp
@@ -50,8 +50,8 @@
 
 dst_entry::dst_entry(in_addr_t dst_ip, uint16_t dst_port, uint16_t src_port, int owner_fd):
 	m_dst_ip(dst_ip), m_dst_port(dst_port), m_src_port(src_port), m_bound_ip(0),
-	m_so_bindtodevice_ip(0), m_ring_alloc_logic(owner_fd, this), m_p_tx_mem_buf_desc_list(NULL),
-	m_b_tx_mem_buf_desc_list_pending(false), m_id(0)
+	m_so_bindtodevice_ip(0), m_src_ip(0), m_ring_alloc_logic(owner_fd, this), 
+	m_p_tx_mem_buf_desc_list(NULL), m_b_tx_mem_buf_desc_list_pending(false), m_id(0)
 {
 	dst_logdbg("dst:%s:%d src: %d", m_dst_ip.to_str().c_str(), ntohs(m_dst_port), ntohs(m_src_port));
 	init_members();
@@ -70,7 +70,7 @@ dst_entry::~dst_entry()
 	}
 
 	if (m_p_rt_entry) {
-		g_p_route_table_mgr->unregister_observer(route_rule_table_key(m_dst_ip.get_in_addr(), m_bound_ip ? m_bound_ip : m_so_bindtodevice_ip, m_tos), this);
+		g_p_route_table_mgr->unregister_observer(route_rule_table_key(m_dst_ip.get_in_addr(), m_src_ip, m_tos), this);
 		m_p_rt_entry = NULL;
 	}
 
@@ -97,6 +97,7 @@ dst_entry::~dst_entry()
 		delete m_p_neigh_val;
 		m_p_neigh_val = NULL;
 	}
+
 	dst_logdbg("Done %s", to_str().c_str());
 }
 
@@ -124,7 +125,6 @@ void dst_entry::init_members()
 	m_max_ip_payload_size = 0;
 	m_b_force_os = false;
 }
-
 
 bool dst_entry::update_net_dev_val()
 {
@@ -202,7 +202,7 @@ bool dst_entry::update_rt_val()
 	return ret_val;
 }
 
-bool dst_entry::resolve_net_dev()
+bool dst_entry::resolve_net_dev(bool is_connect)
 {
 	bool ret_val = false;
 
@@ -218,20 +218,39 @@ bool dst_entry::resolve_net_dev()
 		return ret_val;
 	}
 	
-	
-	route_rule_table_key rtk(m_dst_ip.get_in_addr(), m_bound_ip ? m_bound_ip : m_so_bindtodevice_ip, m_tos);
-	
-	if (m_p_rt_entry || g_p_route_table_mgr->register_observer(rtk, this, &p_ces)) {
-	
-		if (m_p_rt_entry == NULL) {
+	//When VMA will support routing with OIF, we need to check changing in outgoing interface
+	//Source address changes is not checked since multiple bind is not allowed on the same socket
+	if (!m_p_rt_entry) {
+		m_src_ip = m_bound_ip;
+		route_rule_table_key rtk(m_dst_ip.get_in_addr(), m_src_ip, m_tos);
+		if (g_p_route_table_mgr->register_observer(rtk, this, &p_ces)) {
 			// In case this is the first time we trying to resolve route entry,
 			// means that register_observer was run
 			m_p_rt_entry = dynamic_cast<route_entry*>(p_ces);
+			if (is_connect && !m_src_ip) {
+				route_val* p_rt_val = NULL;
+				if (m_p_rt_entry && m_p_rt_entry->get_val(p_rt_val) && p_rt_val->get_src_addr()) {
+					g_p_route_table_mgr->unregister_observer(rtk, this);
+					m_src_ip = p_rt_val->get_src_addr();
+					route_rule_table_key new_rtk(m_dst_ip.get_in_addr(), m_src_ip, m_tos);
+					if (g_p_route_table_mgr->register_observer(new_rtk, this, &p_ces)) {
+						m_p_rt_entry = dynamic_cast<route_entry*>(p_ces);
+					}
+					else {
+						dst_logdbg("Error in route resolving logic");
+						return ret_val;
+					}
+				}
+			}
 		}
+		else {
+			dst_logdbg("Error in registering route entry");
+			return ret_val;
+		}
+	}
 
-		if(update_rt_val()) {
-			ret_val = update_net_dev_val();
-		}
+	if (update_rt_val()) {
+		ret_val = update_net_dev_val();
 	}
 	return ret_val;
 }
@@ -306,7 +325,7 @@ void dst_entry::notify_cb()
 
 void dst_entry::configure_ip_header(header *h, uint16_t packet_id)
 {
-	h->configure_ip_header(get_protocol_type(), m_bound_ip ? m_bound_ip : m_p_net_dev_val->get_local_addr(), m_dst_ip.get_in_addr(), m_ttl, m_tos, packet_id);
+	h->configure_ip_header(get_protocol_type(), get_src_addr(), m_dst_ip.get_in_addr(), m_ttl, m_tos, packet_id);
 }
 
 bool dst_entry::conf_l2_hdr_and_snd_wqe_eth()
@@ -455,17 +474,13 @@ transport_type_t dst_entry::get_obs_transport_type() const
 
 flow_tuple dst_entry::get_flow_tuple() const
 {
-	in_addr_t src_ip = 0;
 	in_addr_t dst_ip = 0;
 	in_protocol_t protocol = PROTO_UNDEFINED;
 
-	if (m_p_net_dev_val) {
-		src_ip = m_p_net_dev_val->get_local_addr();
-	}
 	dst_ip = m_dst_ip.get_in_addr();
 	protocol = (in_protocol_t)get_protocol_type();
 
-	return flow_tuple(dst_ip, m_dst_port, src_ip, m_src_port, protocol);
+	return flow_tuple(dst_ip, m_dst_port, get_src_addr(), m_src_port, protocol);
 }
 
 #if _BullseyeCoverage
@@ -492,7 +507,7 @@ bool dst_entry::offloaded_according_to_rules()
 	return ret_val;
 }
 
-bool dst_entry::prepare_to_send(bool skip_rules)
+bool dst_entry::prepare_to_send(bool skip_rules, bool is_connect)
 {
 	bool resolved = false;
 	m_slow_path_lock.lock();
@@ -508,7 +523,7 @@ bool dst_entry::prepare_to_send(bool skip_rules)
 	if (!m_b_force_os && !is_valid()) {
 		bool is_ofloaded = false;
 		set_state(true);
-		if (resolve_net_dev()) {
+		if (resolve_net_dev(is_connect)) {
 			m_max_ip_payload_size = ((m_p_net_dev_val->get_mtu()-sizeof(struct iphdr)) & ~0x7);
 			if (resolve_ring()) {
 				is_ofloaded = true;
@@ -522,7 +537,7 @@ bool dst_entry::prepare_to_send(bool skip_rules)
 								     m_p_neigh_val->get_l2_address()->get_address(),
 								     ((ethhdr*)(m_header.m_actual_hdr_addr))->h_proto /* if vlan, use vlan proto */,
 								     htons(ETH_P_IP),
-								     m_bound_ip ? m_bound_ip : m_p_net_dev_val->get_local_addr(),
+								     get_src_addr(),
 								     m_dst_ip.get_in_addr(),
 								     m_src_port,
 								     m_dst_port);
@@ -627,16 +642,6 @@ void dst_entry::set_so_bindtodevice_addr(in_addr_t addr)
 	dst_logdbg("");
 	m_so_bindtodevice_ip = addr;
 	set_state(false);
-}
-
-in_addr_t dst_entry::get_src_addr()
-{
-	in_addr_t ret_val = INADDR_ANY;
-
-	if (m_p_net_dev_val) {
-		ret_val = m_p_net_dev_val->get_local_addr();
-	}
-	return ret_val;
 }
 
 in_addr_t dst_entry::get_dst_addr()

--- a/src/vma/proto/dst_entry.h
+++ b/src/vma/proto/dst_entry.h
@@ -65,7 +65,7 @@ public:
 
 	virtual void 	notify_cb();
 
-	virtual bool 	prepare_to_send(bool skip_rules=false);
+	virtual bool 	prepare_to_send(bool skip_rules=false, bool is_connect=false);
 	virtual ssize_t slow_send(const iovec* p_iov, size_t sz_iov, bool b_blocked = true, bool is_rexmit = false, int flags = 0, socket_fd_api* sock = 0, tx_call_t call_type = TX_UNDEF) = 0 ;
 	virtual ssize_t fast_send(const struct iovec* p_iov, const ssize_t sz_iov, bool b_blocked = true, bool is_rexmit = false, bool dont_inline = false) = 0;
 
@@ -74,9 +74,19 @@ public:
 	bool 		is_offloaded() { return m_b_is_offloaded; }
 	void		set_bound_addr(in_addr_t addr);
 	void		set_so_bindtodevice_addr(in_addr_t addr);
-	in_addr_t	get_src_addr();
 	in_addr_t	get_dst_addr();
 	uint16_t	get_dst_port();
+	inline in_addr_t get_src_addr() const {
+		if (!m_src_ip) {
+			if (m_p_rt_val && m_p_rt_val->get_src_addr()) {
+				return m_p_rt_val->get_src_addr();
+			}
+			if (m_p_net_dev_val && m_p_net_dev_val->get_local_addr()) {
+				return m_p_net_dev_val->get_local_addr();
+			}
+		}
+		return m_src_ip;
+	}
 
 #if _BullseyeCoverage
     #pragma BullseyeCoverage off
@@ -101,7 +111,7 @@ protected:
 
 	in_addr_t		m_bound_ip;
 	in_addr_t		m_so_bindtodevice_ip;
-
+	in_addr_t		m_src_ip;
 	lock_mutex_recursive 	m_slow_path_lock;
 	vma_ibv_send_wr 	m_inline_send_wqe;
 	vma_ibv_send_wr 	m_not_inline_send_wqe;
@@ -140,7 +150,7 @@ protected:
 
 	virtual bool 		offloaded_according_to_rules();
 	virtual void 		init_members();
-	virtual bool 		resolve_net_dev();
+	virtual bool 		resolve_net_dev(bool is_connect=false);
 	bool 			update_net_dev_val();
 	bool 			update_rt_val();
 	virtual bool 		resolve_neigh();

--- a/src/vma/proto/dst_entry.h
+++ b/src/vma/proto/dst_entry.h
@@ -77,15 +77,7 @@ public:
 	in_addr_t	get_dst_addr();
 	uint16_t	get_dst_port();
 	inline in_addr_t get_src_addr() const {
-		if (!m_src_ip) {
-			if (m_p_rt_val && m_p_rt_val->get_src_addr()) {
-				return m_p_rt_val->get_src_addr();
-			}
-			if (m_p_net_dev_val && m_p_net_dev_val->get_local_addr()) {
-				return m_p_net_dev_val->get_local_addr();
-			}
-		}
-		return m_src_ip;
+		return m_pkt_src_ip;
 	}
 
 #if _BullseyeCoverage
@@ -111,7 +103,8 @@ protected:
 
 	in_addr_t		m_bound_ip;
 	in_addr_t		m_so_bindtodevice_ip;
-	in_addr_t		m_src_ip;
+	in_addr_t		m_route_src_ip;
+	in_addr_t		m_pkt_src_ip;
 	lock_mutex_recursive 	m_slow_path_lock;
 	vma_ibv_send_wr 	m_inline_send_wqe;
 	vma_ibv_send_wr 	m_not_inline_send_wqe;
@@ -151,6 +144,7 @@ protected:
 	virtual bool 		offloaded_according_to_rules();
 	virtual void 		init_members();
 	virtual bool 		resolve_net_dev(bool is_connect=false);
+	void			set_src_addr();
 	bool 			update_net_dev_val();
 	bool 			update_rt_val();
 	virtual bool 		resolve_neigh();

--- a/src/vma/proto/dst_entry_udp_mc.cpp
+++ b/src/vma/proto/dst_entry_udp_mc.cpp
@@ -82,8 +82,9 @@ bool dst_entry_udp_mc::conf_l2_hdr_and_snd_wqe_ib()
 }
 
 //The following function supposed to be called under m_lock
-bool dst_entry_udp_mc::resolve_net_dev()
+bool dst_entry_udp_mc::resolve_net_dev(bool is_connect)
 {
+	NOT_IN_USE(is_connect);
 	bool ret_val = false;
 	cache_entry_subject<ip_address, net_device_val*>* p_ces = NULL;
 

--- a/src/vma/proto/dst_entry_udp_mc.h
+++ b/src/vma/proto/dst_entry_udp_mc.h
@@ -60,7 +60,7 @@ protected:
 
 	virtual bool 	get_net_dev_val();
 
-	virtual bool 	resolve_net_dev();
+	virtual bool 	resolve_net_dev(bool is_connect=false);
 };
 
 #endif /* DST_ENTRY_UDP_MC_H */

--- a/src/vma/proto/route_entry.cpp
+++ b/src/vma/proto/route_entry.cpp
@@ -89,21 +89,28 @@ void route_entry::set_val(IN route_val* &val)
 
 void route_entry::register_to_net_device()
 {
-	ip_address src_addr = m_val->get_src_addr();
-
-	rt_entry_logdbg("register to net device with src_addr %s", src_addr.to_str().c_str());
-
-	cache_entry_subject<ip_address, net_device_val*> *net_dev_entry = (cache_entry_subject<ip_address, net_device_val*> *)m_p_net_dev_entry;
-	if (g_p_net_device_table_mgr->register_observer(src_addr, this, &net_dev_entry)) {
-		rt_entry_logdbg("route_entry [%p] is registered to an offloaded device", this);
-		m_p_net_dev_entry = (net_device_entry *) net_dev_entry;
-		m_p_net_dev_entry->get_val(m_p_net_dev_val);
-		m_b_offloaded_net_dev = true;
-	} 
-	else {
-		rt_entry_logdbg("route_entry [%p] tried to register to non-offloaded device ---> registration failed", this);
+	net_dev_lst_t* dev_list = g_p_net_device_table_mgr->get_net_device_val_lst_from_index(m_val->get_if_index());
+	if (!dev_list || dev_list->empty()) {
+		rt_entry_logdbg("No matched net device for %s interface", m_val->get_if_name());
 		m_b_offloaded_net_dev = false;
 	}
+	else {
+		ip_address src_addr = dev_list->front()->get_local_addr();
+		rt_entry_logdbg("register to net device with src_addr %s", src_addr.to_str().c_str());
+
+		cache_entry_subject<ip_address, net_device_val*> *net_dev_entry = (cache_entry_subject<ip_address, net_device_val*> *)m_p_net_dev_entry;
+		if (g_p_net_device_table_mgr->register_observer(src_addr, this, &net_dev_entry)) {
+			rt_entry_logdbg("route_entry [%p] is registered to an offloaded device", this);
+			m_p_net_dev_entry = (net_device_entry *) net_dev_entry;
+			m_p_net_dev_entry->get_val(m_p_net_dev_val);
+			m_b_offloaded_net_dev = true;
+		} 
+		else {
+			rt_entry_logdbg("route_entry [%p] tried to register to non-offloaded device ---> registration failed", this);
+			m_b_offloaded_net_dev = false;
+		}
+	}
+	
 }
 
 void route_entry::unregister_to_net_device()
@@ -113,10 +120,9 @@ void route_entry::unregister_to_net_device()
 		return;
 	}
 
-	ip_address src_addr = m_val->get_src_addr();
-
-	if (m_b_offloaded_net_dev) {
-		rt_entry_logdbg("unregister to net device with src_addr %s", src_addr.to_str().c_str());
+	if (m_p_net_dev_val) {
+		ip_address src_addr = m_p_net_dev_val->get_local_addr();
+		rt_entry_logdbg("unregister from net device with src_addr %s", src_addr.to_str().c_str());
 		if (! g_p_net_device_table_mgr->unregister_observer(src_addr, this)) {
 			rt_entry_logdbg("ERROR: failed to unregister from net_device_entry");
 		}

--- a/src/vma/sock/sockinfo_tcp.cpp
+++ b/src/vma/sock/sockinfo_tcp.cpp
@@ -1793,7 +1793,7 @@ int sockinfo_tcp::connect(const sockaddr *__to, socklen_t __tolen)
 		si_tcp_logdbg("non offloaded socket --> connect only via OS");
 		return -1;
 	}
-	m_p_connected_dst_entry->prepare_to_send();
+	m_p_connected_dst_entry->prepare_to_send(false, true);
 
 	// update it after route was resolved and device was updated
 	m_p_socket_stats->bound_if = m_p_connected_dst_entry->get_src_addr();


### PR DESCRIPTION
- Let connect to double resolve route distination when source address isn't assigned

- Resolve the correct outgoing interface when the interface that hold route entry source address  is different than route entry interface index

Signed-off-by: ashanably <ashanably@asaltech.com>