### PR TITLE
issue: 900879 Fix netlink rule msg attribute type values.

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -451,6 +451,23 @@ AC_TRY_LINK(
   AC_DEFINE(DEFINED_MISSING_NET_TSTAMP, 1, [Define to 1 if linux/net_tstamp.h is missing])
 ])
 
+AC_MSG_CHECKING([if 'FRA_OIFNAME' enum value is defined])
+AC_TRY_LINK(
+#include <linux/fib_rules.h>
+,
+[
+  int oif = (int)FRA_OIFNAME;
+  oif = oif;
+],
+[
+  AC_MSG_RESULT([yes])
+  AC_DEFINE(DEFINED_FRA_OIFNAME, 1, [Define to 1 if enum value FRA_OIFNAME exists in linux/fib_rules.h])
+],
+[
+  AC_MSG_RESULT([no])
+  AC_DEFINE(DEFINED_FRA_OIFNAME, 0, [Define to 0 if enum value FRA_OIFNAME does not exist in linux/fib_rules.h])
+])
+
 AC_CHECK_TYPES([struct mmsghdr],[],[],[#include <sys/socket.h>])
 
 AC_MSG_CHECKING([if 'struct timespec' for recvmmsg() is const])

--- a/src/vma/proto/rule_table_mgr.cpp
+++ b/src/vma/proto/rule_table_mgr.cpp
@@ -39,6 +39,7 @@
 #include <sys/socket.h>
 #include <linux/rtnetlink.h>
 #include <linux/netlink.h>
+#include <linux/fib_rules.h>
 #include <netinet/in.h>
 #include <netinet/ether.h>
 #include <arpa/inet.h>
@@ -133,21 +134,23 @@ bool rule_table_mgr::parse_enrty(nlmsghdr *nl_header, rule_val *p_val)
 void rule_table_mgr::parse_attr(struct rtattr *rt_attribute, rule_val *p_val)
 {
 	switch (rt_attribute->rta_type) {
-		case RTA_PRIORITY:
+		case FRA_PRIORITY:
 			p_val->set_priority(*(uint32_t *)RTA_DATA(rt_attribute));
 			break;			
-		case RTA_DST:
+		case FRA_DST:
 			p_val->set_dst_addr(*(in_addr_t *)RTA_DATA(rt_attribute));
 			break;
-		case RTA_SRC:
+		case FRA_SRC:
 			p_val->set_src_addr(*(in_addr_t *)RTA_DATA(rt_attribute));
 			break;			
-		case RTA_IIF:
+		case FRA_IFNAME:
 			p_val->set_iif_name((char *)RTA_DATA(rt_attribute));
 			break;	
-		case RTA_OIF:
+#if DEFINED_FRA_OIFNAME
+		case FRA_OIFNAME:
 			p_val->set_oif_name((char *)RTA_DATA(rt_attribute));
 			break;				
+#endif
 		default:
 			break;
 	}


### PR DESCRIPTION
The values used when parsing netlink rule msg attributes are wrong.
Instead of RTA_* taken from /usr/include/linux/rtnetlink.h
they should be FRA_* values taken from /usr/include/linux/fib_rules.h.

Signed-off-by: Ilan Smith <ilansm@mellanox.com>