### PR TITLE
issue: 768398 Add peer notification in case unexpected termination (option#1)

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -1,7 +1,7 @@
-SUBDIRS := src
+SUBDIRS := src tools
 
 
-DIST_SUBDIRS := src tests
+DIST_SUBDIRS := src tests tools
 EXTRA_DIST = \
 	build \
 	contrib \

--- a/Makefile.am
+++ b/Makefile.am
@@ -2,6 +2,10 @@ SUBDIRS := src tools
 
 
 DIST_SUBDIRS := src tests tools
+
+noinst_SCRIPTS = \
+	$(wildcard contrib/scripts/*)
+
 EXTRA_DIST = \
 	build \
 	contrib \
@@ -19,6 +23,14 @@ EXTRA_DIST = \
 
 mydocdir = $(if $(docdir),$(docdir),${datadir}/doc/$(distdir))
 mydoc_DATA = README.txt journal.txt VMA_VERSION
+
+install-exec-hook:
+	$(top_srcdir)/config/install-sh -m 755 -d $(DESTDIR)/$(sysconfdir)/init.d
+	cp $(top_builddir)/contrib/scripts/vma.init $(DESTDIR)/$(sysconfdir)/init.d/vma
+	chmod 755 $(DESTDIR)/$(sysconfdir)/init.d/vma
+
+uninstall-hook:
+	rm -rf $(DESTDIR)/$(sysconfdir)/init.d
 
 install-all: install
 

--- a/build/build_deb.sh
+++ b/build/build_deb.sh
@@ -5,7 +5,7 @@ script_dir=`dirname $(readlink -f $0)`
 cd $script_dir/..
 
 BUILD_DIR=`pwd`/build_debian
-mkdir $BUILD_DIR
+mkdir -p $BUILD_DIR
 
 LOG_FILE=$BUILD_DIR/build_debian.log
 

--- a/build/libvma.spec.in
+++ b/build/libvma.spec.in
@@ -81,6 +81,7 @@ install -m 755 tests/vma_perf_envelope/vma_perf_envelope.sh $RPM_BUILD_ROOT/%{vm
 install -m 644 src/vma/vma_extra.h $RPM_BUILD_ROOT/%{include_dir}/vma_extra.h
 install -m 644 src/vma/util/libvma.conf $RPM_BUILD_ROOT/%{_sysconfdir}/
 install -s -m 755 src/stats/vma_stats $RPM_BUILD_ROOT/%{_bindir}/vma_stats
+install -s -m 755 tools/daemon/vmad $RPM_BUILD_ROOT/%{_bindir}/vmad
 
 
 %post
@@ -117,8 +118,11 @@ fi
 %files utils
 %defattr(-,root,root)
 %{_bindir}/vma_stats
+%{_bindir}/vmad
 %{vma_datadir}/scripts/vma_perf_envelope.sh
 
 %changelog
+* Mon Nov 28 2016 Igor Ivanov <igor.ivanov.va@gmail.com>
+- Add daemon
 * Mon Jan  4 2016 Avner BenHanoch <avnerb@mellanox.com> 7.0.12-1
-– Initial Packaging
+- Initial Packaging

--- a/build/libvma.spec.in
+++ b/build/libvma.spec.in
@@ -81,8 +81,8 @@ install -m 755 tests/vma_perf_envelope/vma_perf_envelope.sh $RPM_BUILD_ROOT/%{vm
 install -m 644 src/vma/vma_extra.h $RPM_BUILD_ROOT/%{include_dir}/vma_extra.h
 install -m 644 src/vma/util/libvma.conf $RPM_BUILD_ROOT/%{_sysconfdir}/
 install -s -m 755 src/stats/vma_stats $RPM_BUILD_ROOT/%{_bindir}/vma_stats
-install -s -m 755 tools/daemon/vmad $RPM_BUILD_ROOT/%{_bindir}/vmad
-
+install -s -m 755 tools/daemon/vmad $RPM_BUILD_ROOT/%{_sbindir}/vmad
+install -m 755 contrib/scripts/vma.init $RPM_BUILD_ROOT/%{_sysconfdir}/init.d/vma
 
 %post
 if [ `grep memlock /etc/security/limits.conf |grep unlimited |wc -l` -le 0 ]; then
@@ -94,6 +94,36 @@ if [ `grep memlock /etc/security/limits.conf |grep unlimited |wc -l` -le 0 ]; th
         echo "  Read more about this topic in the VMA's User Manual"
 fi
 /sbin/ldconfig
+
+# daemon registration
+if [ $1 = 1 ]; then
+    if [ -e /sbin/chkconfig ]; then
+        /sbin/chkconfig --add vma
+    elif [ -e /usr/sbin/update-rc.d ]; then
+        /usr/sbin/update-rc.d vma defaults
+    else
+        /usr/lib/lsb/install_initd /etc/init.d/vma
+    fi
+    if type systemctl >/dev/null 2>&1; then
+        systemctl --system daemon-reload
+    fi
+    /etc/init.d/vma start
+fi
+
+%preun
+# daemon unregistration
+if [ $1 = 0 ]; then
+    /etc/init.d/vma stop
+    if [ -e /sbin/chkconfig ]; then
+        /sbin/chkconfig --del vma
+    elif [ -e /usr/sbin/update-rc.d ]; then
+        /usr/sbin/update-rc.d -f vma remove
+    else
+        /usr/lib/lsb/remove_initd /etc/init.d/vma
+    fi
+    rm -f /var/cache/vma/*
+fi
+
 
 %clean
 [ "${RPM_BUILD_ROOT}" != "/" -a -d ${RPM_BUILD_ROOT} ] && rm -rf ${RPM_BUILD_ROOT}
@@ -110,6 +140,8 @@ fi
 %{_docdir}/%{name}-%{version}/VMA_VERSION
 %config(noreplace) %{_sysconfdir}/libvma.conf
 %{_sysconfdir}/security/limits.d/30-libvma-limits.conf
+%{_sbindir}/vmad
+%{_sysconfdir}/init.d/vma
 
 %files devel
 %defattr(-,root,root,-)
@@ -118,11 +150,11 @@ fi
 %files utils
 %defattr(-,root,root)
 %{_bindir}/vma_stats
-%{_bindir}/vmad
 %{vma_datadir}/scripts/vma_perf_envelope.sh
 
 %changelog
 * Mon Nov 28 2016 Igor Ivanov <igor.ivanov.va@gmail.com>
 - Add daemon
+
 * Mon Jan  4 2016 Avner BenHanoch <avnerb@mellanox.com> 7.0.12-1
 - Initial Packaging

--- a/build/libvma_fedora.spec
+++ b/build/libvma_fedora.spec
@@ -65,6 +65,8 @@ rm -f $RPM_BUILD_ROOT%{_libdir}/*.la
 %doc README.txt journal.txt VMA_VERSION
 %config(noreplace) %{_sysconfdir}/libvma.conf
 %config(noreplace) %{_sysconfdir}/security/limits.d/30-libvma-limits.conf
+%{_sbindir}/vmad
+%config(noreplace) %{_sysconfdir}/init.d/vma
 
 %files devel
 %{_includedir}/*
@@ -73,6 +75,9 @@ rm -f $RPM_BUILD_ROOT%{_libdir}/*.la
 %{_bindir}/vma_stats
 
 %changelog
+* Thu Dec 03 2016 Alex Vainman <igor.ivanov.va@gmail.com>
+- Add daemon
+
 * Thu Mar 13 2016 Alex Vainman <alexv@mellanox.com> - 8.0.1-1
 - New upstream release
 - Move to dual license: GPLv2 or BSD

--- a/configure.ac
+++ b/configure.ac
@@ -58,6 +58,8 @@ PKG_PROG_PKG_CONFIG
 with_debug_info=yes
 with_debug=no
 
+AC_CHECK_HEADERS([sys/prctl.h sys/inotify.h sys/fanotify.h])
+
 AC_CHECK_HEADERS([infiniband/verbs.h], ,
                  [AC_MSG_ERROR([Unable to find the libibverbs-devel header files])])
 
@@ -507,6 +509,8 @@ AC_CONFIG_FILES([
 		tests/pps_test/Makefile
 		tests/latency_test/Makefile
 		tests/throughput_test/Makefile
+		tools/Makefile
+		tools/daemon/Makefile
 		build/libvma.spec
 		debian/changelog
 		VMA_VERSION

--- a/configure.ac
+++ b/configure.ac
@@ -511,6 +511,7 @@ AC_CONFIG_FILES([
 		tests/throughput_test/Makefile
 		tools/Makefile
 		tools/daemon/Makefile
+		contrib/scripts/vma.init
 		build/libvma.spec
 		debian/changelog
 		VMA_VERSION

--- a/contrib/jenkins_tests/tool.sh
+++ b/contrib/jenkins_tests/tool.sh
@@ -1,0 +1,59 @@
+#!/bin/bash -eExl
+
+source $(dirname $0)/globals.sh
+
+check_filter "Checking for tool ..." "off"
+
+cd $WORKSPACE
+
+rm -rf $tool_dir
+mkdir -p $tool_dir
+cd $tool_dir
+
+tool_list="daemon"
+
+tool_tap=${WORKSPACE}/${prefix}/tool.tap
+echo "1..$(echo $tool_list | tr " " "\n" | wc -l)" > $tool_tap
+
+function check_daemon()
+{
+    local ret=0
+    local out_log=$1
+
+    rm -rf ${out_log}
+    pkill -9 vmad
+
+    echo "daemon check output: ${install_dir}/sbin/vmad" > ${out_log}
+    if [ $(sudo ${install_dir}/etc/init.d/vma start >>${out_log} 2>&1 || echo $?) ]; then
+        ret=1
+    fi
+    if [ "0" == "$ret" -a "" != "$(pgrep vma >>${out_log} 2>&1 || echo $?)" ]; then
+        ret=1
+    fi
+    if [ $(sudo ${install_dir}/etc/init.d/vma status >>${out_log} 2>&1 || echo $?) ]; then
+        ret=1
+    fi
+    if [ $(sudo ${install_dir}/etc/init.d/vma stop >>${out_log} 2>&1 || echo $?) ]; then
+        ret=1
+    fi
+    if [ "0" == "$ret" -a "" = "$(pgrep vma >>${out_log} 2>&1 || echo $?)" ]; then
+        ret=1
+    fi
+
+    pkill -9 vmad
+
+    echo "$ret"
+}
+
+test_id=0
+for tool in $tool_list; do
+    mkdir -p ${tool_dir}/${tool}
+    cd ${tool_dir}/${tool}
+    test_id=$((test_id+1))
+    test_exec="[ 0 = $(check_daemon "${tool_dir}/${tool}/output.log") ]"
+    check_result "$test_exec" "$test_id" "$tool" "$tool_tap"
+    cd ${tool_dir}
+done
+
+echo "[${0##*/}]..................exit code = $rc"
+exit $rc

--- a/contrib/scripts/vma.init.in
+++ b/contrib/scripts/vma.init.in
@@ -69,6 +69,7 @@ function do_start()
     fi
     if [[ $RETVAL -eq 0 ]]; then
         success
+        sleep 1
     else
         failure
     fi
@@ -79,16 +80,18 @@ function do_stop()
 {
     echo -n "Shutting down ${exefile}: "
 
-    killproc "${exefile}" -INT
-    RETVAL=$?
+    RETVAL=0
+    if [ $(command -v pkill >/dev/null 2>&1 && echo $?) ]; then
+        pkill -INT "${exefile}"
+        RETVAL=$?
+    fi
     if [[ $RETVAL -ne 0 ]]; then
-        if [ $(command -v pkill >/dev/null 2>&1 && echo $?) ]; then
-            pkill -INT "${exefile}"
-            RETVAL=$?
-        fi
+        killproc "${exefile}" -INT
+        RETVAL=$?
     fi
     if [[ $RETVAL -eq 0 ]]; then
         success
+        sleep 1
     else
         failure
     fi
@@ -97,13 +100,13 @@ function do_stop()
 
 function do_status ()
 {
-	pid="`pidof ${exefile}`"
-	ret=$?
-	if [ $ret -eq 0 ] ; then
-		echo "${exefile} is running... pid=$pid"
-	else
-		echo "${exefile} is not running."
-	fi
+    pid="`pidof ${exefile}`"
+    ret=$?
+    if [ $ret -eq 0 ] ; then
+        echo "${exefile} is running... pid=$pid"
+    else
+        echo "${exefile} is not running."
+    fi
 }
 
 function do_restart()

--- a/contrib/scripts/vma.init.in
+++ b/contrib/scripts/vma.init.in
@@ -1,0 +1,139 @@
+#!/bin/bash
+#
+# Copyright (C) Mellanox Technologies Ltd. 2016.  ALL RIGHTS RESERVED.
+# See file LICENSE for terms.
+#
+# vma:         Start the VMA Daemon
+#
+# chkconfig:   345 80 20
+# description: This is a daemon which handles the task of \
+#              monitoring processes launched under VMA.
+#
+### BEGIN INIT INFO
+# Provides: vma
+# Required-Start: $syslog
+# Required-Stop: $syslog
+# Default-Start: 3 4 5
+# Default-Stop: 0 1 6
+# Short-Description: Start the VMA Daemon
+# Description: This is a daemon which handles the task of
+#              monitoring processes launched under VMA.
+### END INIT INFO
+
+prefix=@prefix@
+exec_prefix=@exec_prefix@
+  
+RETVAL=0
+exefile=vmad
+options=
+pidfile=/var/run/lock/vmad.lock
+
+# Source function library.
+if [[ -s /etc/init.d/functions ]]; then
+    # RHEL / CentOS / SL / Fedora.
+    . /etc/init.d/functions
+    rc_status() { :; }
+elif [[ -s /lib/lsb/init-functions ]]; then
+    # SLES / openSuSE / Debian.
+    . /lib/lsb/init-functions
+    success() { log_success_msg; }
+    failure() { log_failure_msg; }
+elif [[ -s /etc/rc.status ]]; then
+    # Older SuSE systems.
+    . /etc/rc.status
+    failure() { rc_status -v; }
+    success() { rc_status -v; }
+fi
+
+
+function check_running()
+{
+    [ -e ${pidfile} ] &&
+        [ "$(readlink "/proc/$(<${pidfile})/exe")" = "@sbindir@/${exefile}" ]
+}
+
+function check_permission()
+{
+    [ "$(whoami)" = "root" ]
+}
+
+function do_start()
+{
+    echo -n "Starting ${exefile}: "
+
+    if check_running; then
+        RETVAL=0
+    else
+        @sbindir@/${exefile} ${options} > /dev/null 2>&1
+        RETVAL=$?
+    fi
+    if [[ $RETVAL -eq 0 ]]; then
+        success
+    else
+        failure
+    fi
+    echo
+}
+
+function do_stop()
+{
+    echo -n "Shutting down ${exefile}: "
+
+    killproc "${exefile}" -INT
+    RETVAL=$?
+    if [[ $RETVAL -ne 0 ]]; then
+        if [ $(command -v pkill >/dev/null 2>&1 && echo $?) ]; then
+            pkill -INT "${exefile}"
+            RETVAL=$?
+        fi
+    fi
+    if [[ $RETVAL -eq 0 ]]; then
+        success
+    else
+        failure
+    fi
+    echo
+}
+
+function do_status ()
+{
+	pid="`pidof ${exefile}`"
+	ret=$?
+	if [ $ret -eq 0 ] ; then
+		echo "${exefile} is running... pid=$pid"
+	else
+		echo "${exefile} is not running."
+	fi
+}
+
+function do_restart()
+{
+    do_stop
+    do_start
+}
+
+if ! check_permission; then
+    echo "root permission is required"
+    exit 1
+fi
+
+case "$1" in
+    start)
+        do_start
+	    ;;
+    stop)
+	    do_stop
+	    ;;
+    status)
+        do_status
+	    ;;
+    restart)
+	    do_restart
+	    ;;
+    *)
+	    echo $"Usage: $0 {start|stop|status|restart}"
+	    RETVAL=1
+	    ;;
+esac
+
+exit $RETVAL

--- a/contrib/test_jenkins.sh
+++ b/contrib/test_jenkins.sh
@@ -34,6 +34,7 @@ jenkins_test_cppcheck=${jenkins_test_cppcheck:="yes"}
 jenkins_test_csbuild=${jenkins_test_csbuild:="yes"}
 jenkins_test_vg=${jenkins_test_vg:="no"}
 jenkins_test_style=${jenkins_test_style:="no"}
+jenkins_test_tool=${jenkins_test_tool:="yes"}
 
 
 echo Starting on host: $(hostname)
@@ -87,6 +88,10 @@ if [ "$jenkins_test_vg" = "yes" ]; then
 fi
 if [ "$jenkins_test_style" = "yes" ]; then
     $WORKSPACE/contrib/jenkins_tests/style.sh
+    rc=$((rc + $?))
+fi
+if [ "$jenkins_test_tool" = "yes" ]; then
+    $WORKSPACE/contrib/jenkins_tests/tool.sh
     rc=$((rc + $?))
 fi
 set -e

--- a/debian/libvma.install
+++ b/debian/libvma.install
@@ -4,3 +4,5 @@ usr/share/doc/libvma/README.txt
 usr/share/doc/libvma/journal.txt
 usr/share/doc/libvma/VMA_VERSION
 etc/libvma.conf
+usr/sbin/vmad
+etc/init.d/vma

--- a/debian/postinst
+++ b/debian/postinst
@@ -9,3 +9,15 @@ if [ `grep memlock /etc/security/limits.conf |grep unlimited |wc -l` -le 0 ]; th
 fi
 
 /sbin/ldconfig
+
+if [ -e /sbin/chkconfig ]; then
+    /sbin/chkconfig --add vma
+elif [ -e /usr/sbin/update-rc.d ]; then
+    /usr/sbin/update-rc.d vma defaults
+else
+    /usr/lib/lsb/install_initd /etc/init.d/vma
+fi
+if type systemctl >/dev/null 2>&1; then
+    systemctl --system daemon-reload
+fi
+/etc/init.d/vma start

--- a/debian/postrm
+++ b/debian/postrm
@@ -1,2 +1,3 @@
 #!/bin/bash
+rm -rf etc/init.d/vma
 /sbin/ldconfig

--- a/debian/prerm
+++ b/debian/prerm
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+/etc/init.d/vma stop

--- a/src/vma/Makefile.am
+++ b/src/vma/Makefile.am
@@ -146,6 +146,8 @@ libvma_la_SOURCES := \
 	util/verbs_extra.cpp \
 	util/instrumentation.cpp \
 	util/sys_vars.cpp \
+	util/agent.cpp \
+	\
 	libvma.c \
 	main.cpp \
 	\
@@ -170,6 +172,7 @@ libvma_la_SOURCES := \
 	dev/ring_simple.h \
 	dev/wqe_send_handler.h \
 	dev/wqe_send_ib_handler.h \
+	\
 	event/command.h \
 	event/delta_timer.h \
 	event/event.h \
@@ -181,15 +184,18 @@ libvma_la_SOURCES := \
 	event/timer_handler.h \
 	event/timers_group.h \
 	event/vlogger_timer_handler.h \
+	\
 	infra/sender.h \
 	infra/sender_info_dst.h \
 	infra/subject_observer.h \
 	infra/cache_subject_observer.h \
+	\
 	iomux/epfd_info.h \
 	iomux/epoll_wait_call.h \
 	iomux/io_mux_call.h \
 	iomux/poll_call.h \
 	iomux/select_call.h \
+	\
 	lwip/cc_cubic.h \
 	lwip/cc.h \
 	lwip/def.h \
@@ -202,23 +208,25 @@ libvma_la_SOURCES := \
 	lwip/stats.h \
 	lwip/tcp.h \
 	lwip/tcp_impl.h \
+	\
 	netlink/link_info.h \
 	netlink/neigh_info.h \
 	netlink/netlink_compatibility.h \
 	netlink/netlink_wrapper.h \
 	netlink/route_info.h \
+	\
 	proto/arp.h \
-        proto/dst_entry.h \
-        proto/dst_entry_tcp.h \
-        proto/dst_entry_udp.h \
-        proto/dst_entry_udp_mc.h \
-        proto/flow_tuple.h \
-        proto/header.h \
-        proto/igmp_handler.h \
-        proto/igmp_mgr.h \
-        proto/ip_address.h \
-        proto/ip_frag.h \
-        proto/L2_address.h \
+	proto/dst_entry.h \
+	proto/dst_entry_tcp.h \
+	proto/dst_entry_udp.h \
+	proto/dst_entry_udp_mc.h \
+	proto/flow_tuple.h \
+	proto/header.h \
+	proto/igmp_handler.h \
+	proto/igmp_mgr.h \
+	proto/ip_address.h \
+	proto/ip_frag.h \
+	proto/L2_address.h \
 	proto/mem_buf_desc.h \
 	proto/neighbour.h \
 	proto/neighbour_observer.h \
@@ -233,34 +241,38 @@ libvma_la_SOURCES := \
 	proto/rule_table_mgr.h \
 	proto/rule_val.h \
 	proto/vma_lwip.h \
+	\
 	sock/cleanable_obj.h \
-        sock/fd_collection.h \
-        sock/pipeinfo.h \
-        sock/pkt_rcvr_sink.h \
-        sock/pkt_sndr_source.h \
-        sock/socket_fd_api.h \
-        sock/sockinfo.h \
-        sock/sockinfo_tcp.h \
-        sock/sockinfo_udp.h \
-        sock/sock-redirect.h \
-        util/hash_map.h \
-        util/if.h \
-        util/instrumentation.h \
-        util/libvma.h \
-        util/linked_unordered_map.h \
-        util/list.h \
-        util/sock_addr.h \
-        util/sysctl_reader.h \
-        util/sys_vars.h \
-        util/to_str.h \
-        util/utils.h \
-        util/valgrind.h \
-        util/verbs_extra.h \
-        util/vma_list.h \
-        util/vma_stats.h \
-        util/vtypes.h \
-        util/wakeup.h \
-        util/wakeup_pipe.h \
+	sock/fd_collection.h \
+	sock/pipeinfo.h \
+	sock/pkt_rcvr_sink.h \
+	sock/pkt_sndr_source.h \
+	sock/socket_fd_api.h \
+	sock/sockinfo.h \
+	sock/sockinfo_tcp.h \
+	sock/sockinfo_udp.h \
+	sock/sock-redirect.h \
+	\
+	util/hash_map.h \
+	util/if.h \
+	util/instrumentation.h \
+	util/libvma.h \
+	util/linked_unordered_map.h \
+	util/list.h \
+	util/sock_addr.h \
+	util/sysctl_reader.h \
+	util/sys_vars.h \
+	util/to_str.h \
+	util/utils.h \
+	util/valgrind.h \
+	util/verbs_extra.h \
+	util/vma_list.h \
+	util/vma_stats.h \
+	util/vtypes.h \
+	util/wakeup.h \
+	util/wakeup_pipe.h \
+	util/agent.h \
+	\
 	config_parser.h \
 	main.h \
 	vma_extra.h

--- a/src/vma/Makefile.am
+++ b/src/vma/Makefile.am
@@ -272,6 +272,7 @@ libvma_la_SOURCES := \
 	util/wakeup.h \
 	util/wakeup_pipe.h \
 	util/agent.h \
+	util/agent_def.h \
 	\
 	config_parser.h \
 	main.h \

--- a/src/vma/main.cpp
+++ b/src/vma/main.cpp
@@ -74,6 +74,7 @@
 #include "vma/iomux/io_mux_call.h"
 
 #include "vma/util/instrumentation.h"
+#include "vma/util/agent.h"
 
 void check_netperf_flags();
 
@@ -223,6 +224,9 @@ static int free_libvma_resources()
 	vlog_printf(VLOG_DEBUG, "Stopping logger module\n");
 
 	sock_redirect_exit();
+
+	/* Close communication with daemon */
+	agent_close();
 
 	vlog_stop();
 
@@ -788,6 +792,9 @@ static void do_global_ctors_helper()
 	
 	if (g_is_forked_child == true)
 		g_is_forked_child = false;
+
+	/* Open communication with daemon */
+	agent_open();
 
 	// Create all global managment objects
 	NEW_CTOR(g_p_event_handler_manager, event_handler_manager());

--- a/src/vma/main.cpp
+++ b/src/vma/main.cpp
@@ -221,12 +221,12 @@ static int free_libvma_resources()
 	if (g_p_event_handler_manager) delete g_p_event_handler_manager;
 	g_p_event_handler_manager = NULL;
 
+	if (g_p_agent) delete g_p_agent;
+	g_p_agent = NULL;
+
 	vlog_printf(VLOG_DEBUG, "Stopping logger module\n");
 
 	sock_redirect_exit();
-
-	/* Close communication with daemon */
-	agent_close();
 
 	vlog_stop();
 
@@ -794,7 +794,9 @@ static void do_global_ctors_helper()
 		g_is_forked_child = false;
 
 	/* Open communication with daemon */
-	agent_open();
+	NEW_CTOR(g_p_agent, agent());
+	vlog_printf(VLOG_DEBUG,"Agent setup state: g_p_agent=%p active=%d\n",
+			g_p_agent, (g_p_agent ? g_p_agent->state() : -1));
 
 	// Create all global managment objects
 	NEW_CTOR(g_p_event_handler_manager, event_handler_manager());

--- a/src/vma/sock/sockinfo_tcp.cpp
+++ b/src/vma/sock/sockinfo_tcp.cpp
@@ -47,6 +47,7 @@
 #include "vma/proto/vma_lwip.h"
 #include "vma/proto/dst_entry_tcp.h"
 #include "vma/iomux/io_mux_call.h"
+#include "vma/util/agent.h"
 
 #include "sock-redirect.h"
 #include "fd_collection.h"
@@ -878,6 +879,13 @@ err_t sockinfo_tcp::ip_output_syn_ack(struct pbuf *p, void* v_p_conn, int is_rex
 {
 	sockinfo_tcp *p_si_tcp = (sockinfo_tcp *)pcb_container;
 	p_si_tcp->m_p_socket_stats->tcp_state = new_state;
+
+	/* Keep vma stats data actual for offloaded connection */
+	if (likely(p_si_tcp->m_sock_offload == TCP_SOCK_LWIP)) {
+		agent_send_msg_state(p_si_tcp->get_fd(), new_state, SOCK_STREAM,
+			p_si_tcp->m_bound.get_in_addr(), p_si_tcp->m_bound.get_in_port(),
+			p_si_tcp->m_connected.get_in_addr(), p_si_tcp->m_connected.get_in_port());
+	}
 }
 
 void sockinfo_tcp::err_lwip_cb(void *pcb_container, err_t err)

--- a/src/vma/util/agent.cpp
+++ b/src/vma/util/agent.cpp
@@ -1,0 +1,368 @@
+/*
+ * Copyright (c) 2016 Mellanox Technologies, Ltd. All rights reserved.
+ *
+ * This software is available to you under a choice of one of two
+ * licenses.  You may choose to be licensed under the terms of the GNU
+ * General Public License (GPL) Version 2, available from the file
+ * COPYING in the main directory of this source tree, or the
+ * BSD license below:
+ *
+ *     Redistribution and use in source and binary forms, with or
+ *     without modification, are permitted provided that the following
+ *     conditions are met:
+ *
+ *      - Redistributions of source code must retain the above
+ *        copyright notice, this list of conditions and the following
+ *        disclaimer.
+ *
+ *      - Redistributions in binary form must reproduce the above
+ *        copyright notice, this list of conditions and the following
+ *        disclaimer in the documentation and/or other materials
+ *        provided with the distribution.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+ * BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ * ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#ifdef HAVE_CONFIG_H
+#include "config.h"
+#endif
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <stdint.h>
+#include <fcntl.h>
+#include <sys/time.h>
+#include <sys/socket.h>
+#include <sys/un.h>
+
+#include "vlogger/vlogger.h"
+#include "vma/sock/sock-redirect.h"
+#include "vma/util/agent.h"
+
+#undef  MODULE_NAME
+#define MODULE_NAME     "agent"
+#undef  MODULE_HDR
+#define MODULE_HDR      MODULE_NAME "%d:%s() "
+
+
+/* Force system call */
+#define sys_call(_result, _func, ...) \
+	do {                                              \
+		if (orig_os_api._func)                        \
+			_result = orig_os_api._func(__VA_ARGS__); \
+		else                                          \
+			_result = _func(__VA_ARGS__);             \
+	} while (0)
+
+static struct {
+	int active;
+	int sock_fd;
+	int pid_fd;
+	char sock_file[100];    /* size should be less than sockaddr_un.sun_path */
+	char pid_file[100];
+} agent_cfg = {
+		0, -1, -1, "", ""
+};
+
+
+static int create_agent_socket(void);
+
+
+int agent_open(void)
+{
+	int rc = 0;
+
+	agent_cfg.sock_fd = -1;
+	agent_cfg.pid_fd = -1;
+
+	if ((mkdir(VMA_AGENT_PATH, 0777) != 0) && (errno != EEXIST)) {
+		rc = -errno;
+		__log_dbg("failed create folder %s (errno = %d)\n", VMA_AGENT_PATH, errno);
+		goto err;
+	}
+
+	rc = snprintf(agent_cfg.sock_file, sizeof(agent_cfg.sock_file) - 1,
+			"%s/%s.%d.sock", VMA_AGENT_PATH, VMA_AGENT_BASE_NAME, getpid());
+	if ((rc < 0 ) || (rc == (sizeof(agent_cfg.sock_file) - 1) )) {
+		rc = -ENOMEM;
+		__log_dbg("failed allocate sock file (errno = %d)\n", errno);
+		goto err;
+	}
+	rc = snprintf(agent_cfg.pid_file, sizeof(agent_cfg.pid_file) - 1,
+			"%s/%s.%d.pid", VMA_AGENT_PATH, VMA_AGENT_BASE_NAME, getpid());
+	if ((rc < 0 ) || (rc == (sizeof(agent_cfg.pid_file) - 1) )) {
+		rc = -ENOMEM;
+		__log_dbg("failed allocate pid file (errno = %d)\n", errno);
+		goto err;
+	}
+
+	sys_call(agent_cfg.pid_fd, open, agent_cfg.pid_file,
+			O_RDWR | O_CREAT, S_IRUSR | S_IWUSR | S_IRGRP);
+	if (agent_cfg.pid_fd < 0) {
+		rc = -errno;
+		__log_dbg("failed allocate pid file (errno = %d)\n", errno);
+		goto err;
+	}
+
+	rc = create_agent_socket();
+	if (rc < 0) {
+		goto err;
+	}
+
+	rc = agent_send_msg_init();
+	if (rc < 0) {
+		goto err;
+	}
+
+	agent_cfg.active = 1;
+
+	return rc;
+
+err:
+	vlog_printf(VLOG_WARNING, "Peer notification functionality is not supported.\n");
+	vlog_printf(VLOG_WARNING, "Increase output level to see a reason\n");
+
+	if (agent_cfg.pid_fd > 0) {
+		int ret = 0;
+		NOT_IN_USE(ret);
+		sys_call(ret, close, agent_cfg.pid_fd);
+		agent_cfg.pid_fd = -1;
+		unlink(agent_cfg.pid_file);
+	}
+
+	if (agent_cfg.sock_fd > 0) {
+		int ret = 0;
+		NOT_IN_USE(ret);
+		sys_call(ret, close, agent_cfg.sock_fd);
+		agent_cfg.sock_fd = -1;
+		unlink(agent_cfg.sock_file);
+	}
+
+	return rc;
+}
+
+void agent_close(void)
+{
+	if (!agent_cfg.active) {
+		return ;
+	}
+
+	agent_send_msg_exit();
+
+	if (agent_cfg.sock_fd > 0) {
+		int ret = 0;
+		NOT_IN_USE(ret);
+		sys_call(ret, close, agent_cfg.sock_fd);
+		unlink(agent_cfg.sock_file);
+	}
+
+	if (agent_cfg.pid_fd > 0) {
+		int ret = 0;
+		NOT_IN_USE(ret);
+		sys_call(ret, close, agent_cfg.pid_fd);
+		unlink(agent_cfg.pid_file);
+	}
+
+	agent_cfg.active = 0;
+}
+
+int agent_send_msg_init(void)
+{
+	int rc = 0;
+	struct sockaddr_un server_addr;
+	struct vma_msg_init data;
+	uint8_t *version;
+
+	if (agent_cfg.sock_fd < 0) {
+		return -EBADF;
+	}
+
+	/* Set server address */
+	memset(&server_addr, 0, sizeof(server_addr));
+	server_addr.sun_family = AF_UNIX;
+	strncpy(server_addr.sun_path, VMA_AGENT_ADDR, sizeof(server_addr.sun_path) - 1);
+
+	sys_call(rc, connect, agent_cfg.sock_fd, (struct sockaddr *)&server_addr,
+			sizeof(struct sockaddr_un));
+	if (rc < 0) {
+		__log_dbg("Failed to connect() errno %d (%s)\n",
+				errno, strerror(errno));
+		rc = -errno;
+		goto err;
+	}
+
+	memset(&data, 0, sizeof(data));
+	data.hdr.code = VMA_MSG_INIT;
+	data.hdr.ver = VMA_AGENT_VER;
+	data.hdr.pid = getpid();
+	version = (uint8_t *)&data.ver;
+	version[0] = VMA_LIBRARY_MAJOR;
+	version[1] = VMA_LIBRARY_MINOR;
+	version[2] = VMA_LIBRARY_RELEASE;
+	version[3] = VMA_LIBRARY_REVISION;
+
+	/* send(VMA_MSG_INIT) in blocking manner */
+	sys_call(rc, send, agent_cfg.sock_fd, &data, sizeof(data), 0);
+	if (rc < 0) {
+		__log_dbg("Failed to send(VMA_MSG_INIT) errno %d (%s)\n",
+				errno, strerror(errno));
+		rc = -errno;
+		goto err;
+	}
+
+	/* recv(VMA_MSG_INIT|ACK) in blocking manner */
+	memset(&data, 0, sizeof(data));
+	sys_call(rc, recv, agent_cfg.sock_fd, &data, sizeof(data), 0);
+	if (rc < (int)sizeof(data)) {
+		__log_dbg("Failed to recv(VMA_MSG_INIT) errno %d (%s)\n",
+				errno, strerror(errno));
+		rc = -errno;
+		goto err;
+	}
+
+	if (data.hdr.code != (VMA_MSG_INIT | VMA_MSG_ACK) ||
+			data.hdr.ver < VMA_AGENT_VER ||
+			data.hdr.pid != getpid()) {
+		__log_dbg("Protocol version mismatch: code = 0x%X ver = 0x%X pid = %d\n",
+				data.hdr.code, data.hdr.ver, data.hdr.pid);
+		rc = -EPROTO;
+		goto err;
+	}
+
+err:
+	return rc;
+}
+
+int agent_send_msg_exit(void)
+{
+	int rc = 0;
+	struct vma_msg_exit data;
+
+	if (agent_cfg.sock_fd < 0) {
+		return -EBADF;
+	}
+
+	memset(&data, 0, sizeof(data));
+	data.hdr.code = VMA_MSG_EXIT;
+	data.hdr.ver = VMA_AGENT_VER;
+	data.hdr.pid = getpid();
+
+	/* send(VMA_MSG_EXIT) in blocking manner */
+	sys_call(rc, send, agent_cfg.sock_fd, &data, sizeof(data), 0);
+	if (rc < 0) {
+		__log_dbg("Failed to send(VMA_MSG_EXIT) errno %d (%s)\n",
+				errno, strerror(errno));
+		rc = -errno;
+		goto err;
+	}
+
+err:
+	return rc;
+}
+
+int agent_send_msg_state(uint32_t fid, uint8_t state, uint8_t type,
+		uint32_t src_ip, uint16_t src_port,
+		uint32_t dst_ip, uint16_t dst_port)
+{
+	int rc = 0;
+	struct vma_msg_state data;
+
+	if (!agent_cfg.active) {
+		return -ENODEV;
+	}
+
+	if (agent_cfg.sock_fd < 0) {
+		return -EBADF;
+	}
+
+	memset(&data, 0, sizeof(data));
+	data.hdr.code = VMA_MSG_STATE;
+	data.hdr.ver = VMA_AGENT_VER;
+	data.hdr.pid = getpid();
+	data.fid = fid;
+	data.state = state;
+	data.type = type;
+	data.src_ip = src_ip;
+	data.src_port = src_port;
+	data.dst_ip = dst_ip;
+	data.dst_port = dst_port;
+
+	/* send(VMA_MSG_STATE) in blocking manner */
+	sys_call(rc, send, agent_cfg.sock_fd, &data, sizeof(data), 0);
+	if (rc < 0) {
+		__log_dbg("Failed to send(VMA_MSG_STATE) errno %d (%s)\n",
+				errno, strerror(errno));
+		rc = -errno;
+		goto err;
+	}
+
+err:
+	return rc;
+}
+
+static int create_agent_socket(void)
+{
+	int rc = 0;
+	int optval = 1;
+	struct timeval opttv;
+	struct sockaddr_un sock_addr;
+
+	/* Create UNIX UDP socket to receive data from VMA processes */
+	memset(&sock_addr, 0, sizeof(sock_addr));
+	sock_addr.sun_family = AF_UNIX;
+	strncpy(sock_addr.sun_path, agent_cfg.sock_file, sizeof(sock_addr.sun_path) - 1);
+	/* remove possible old socket */
+	unlink(agent_cfg.sock_file);
+
+	sys_call(agent_cfg.sock_fd, socket, AF_UNIX, SOCK_DGRAM, 0);
+	if (agent_cfg.sock_fd < 0) {
+		__log_dbg("Failed to call socket() errno %d (%s)\n",
+				errno, strerror(errno));
+		rc = -errno;
+		goto err;
+	}
+
+	optval = 1;
+	sys_call(rc, setsockopt, agent_cfg.sock_fd, SOL_SOCKET, SO_REUSEADDR,
+			(const void *)&optval, sizeof(optval));
+	if (rc < 0) {
+		__log_dbg("Failed to call setsockopt(SO_REUSEADDR) errno %d (%s)\n",
+				errno, strerror(errno));
+		rc = -errno;
+		goto err;
+	}
+
+	/* Sets the timeout value as 1 sec that specifies the maximum amount of time
+	 * an input function waits until it completes.
+	 */
+	opttv.tv_sec = 1;
+	opttv.tv_usec = 0;
+	sys_call(rc, setsockopt, agent_cfg.sock_fd, SOL_SOCKET, SO_RCVTIMEO,
+			(const void *)&opttv, sizeof(opttv));
+	if (rc < 0) {
+		__log_dbg("Failed to call setsockopt(SO_RCVTIMEO) errno %d (%s)\n",
+				errno, strerror(errno));
+		rc = -errno;
+		goto err;
+	}
+
+	/* bind created socket */
+	sys_call(rc, bind, agent_cfg.sock_fd, (struct sockaddr *)&sock_addr,
+			sizeof(sock_addr));
+	if (rc < 0) {
+		__log_dbg("Failed to call bind() errno %d (%s)\n",
+				errno, strerror(errno));
+		rc = -errno;
+		goto err;
+	}
+
+err:
+	return rc;
+}

--- a/src/vma/util/agent.h
+++ b/src/vma/util/agent.h
@@ -1,0 +1,94 @@
+/*
+ * Copyright (c) 2016 Mellanox Technologies, Ltd. All rights reserved.
+ *
+ * This software is available to you under a choice of one of two
+ * licenses.  You may choose to be licensed under the terms of the GNU
+ * General Public License (GPL) Version 2, available from the file
+ * COPYING in the main directory of this source tree, or the
+ * BSD license below:
+ *
+ *     Redistribution and use in source and binary forms, with or
+ *     without modification, are permitted provided that the following
+ *     conditions are met:
+ *
+ *      - Redistributions of source code must retain the above
+ *        copyright notice, this list of conditions and the following
+ *        disclaimer.
+ *
+ *      - Redistributions in binary form must reproduce the above
+ *        copyright notice, this list of conditions and the following
+ *        disclaimer in the documentation and/or other materials
+ *        provided with the distribution.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+ * BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ * ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#ifndef SRC_VMA_UTIL_AGENT_H_
+#define SRC_VMA_UTIL_AGENT_H_
+
+/* List of supported messages in range 0..63
+ * Two bits as 6-7 are reserved.
+ * 6-bit is reserved
+ * 7-bit in message code is for ACK flag in case specific
+ * message requires the confirmation
+ */
+#define VMA_MSG_INIT    0x01
+#define VMA_MSG_STATE   0x02
+#define VMA_MSG_EXIT    0x03
+
+#define VMA_MSG_ACK     0x80
+
+#define VMA_AGENT_VER   0x01
+
+#define VMA_AGENT_BASE_NAME "vma_agent"
+#define VMA_AGENT_ADDR      "/var/run/" VMA_AGENT_BASE_NAME ".sock"
+#define VMA_AGENT_PATH      "/tmp/vma"
+
+
+#pragma pack(push, 1)
+struct vma_hdr {
+	uint8_t        code;
+	uint8_t        ver;
+	uint8_t        reserve[2];
+	int32_t        pid;
+
+};
+
+struct vma_msg_init {
+	struct vma_hdr hdr;
+	uint32_t       ver;
+};
+
+struct vma_msg_exit {
+	struct vma_hdr hdr;
+};
+
+struct vma_msg_state {
+	struct vma_hdr hdr;
+	uint32_t       fid;
+	uint32_t       src_ip;
+	uint32_t       dst_ip;
+	uint16_t       src_port;
+	uint16_t       dst_port;
+	uint8_t        type;
+	uint8_t        state;
+};
+#pragma pack( pop )
+
+
+int agent_open(void);
+void agent_close(void);
+int agent_send_msg_init(void);
+int agent_send_msg_exit(void);
+int agent_send_msg_state(uint32_t fid, uint8_t state, uint8_t type,
+		uint32_t src_ip, uint16_t src_port,
+		uint32_t dst_ip, uint16_t dst_port);
+
+#endif /* SRC_VMA_UTIL_AGENT_H_ */

--- a/src/vma/util/agent_def.h
+++ b/src/vma/util/agent_def.h
@@ -1,0 +1,85 @@
+/*
+ * Copyright (c) 2016 Mellanox Technologies, Ltd. All rights reserved.
+ *
+ * This software is available to you under a choice of one of two
+ * licenses.  You may choose to be licensed under the terms of the GNU
+ * General Public License (GPL) Version 2, available from the file
+ * COPYING in the main directory of this source tree, or the
+ * BSD license below:
+ *
+ *     Redistribution and use in source and binary forms, with or
+ *     without modification, are permitted provided that the following
+ *     conditions are met:
+ *
+ *      - Redistributions of source code must retain the above
+ *        copyright notice, this list of conditions and the following
+ *        disclaimer.
+ *
+ *      - Redistributions in binary form must reproduce the above
+ *        copyright notice, this list of conditions and the following
+ *        disclaimer in the documentation and/or other materials
+ *        provided with the distribution.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+ * BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ * ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#ifndef SRC_VMA_UTIL_AGENT_DEF_H_
+#define SRC_VMA_UTIL_AGENT_DEF_H_
+
+/* List of supported messages in range 0..63
+ * Two bits as 6-7 are reserved.
+ * 6-bit is reserved
+ * 7-bit in message code is for ACK flag in case specific
+ * message requires the confirmation
+ */
+#define VMA_MSG_INIT    0x01
+#define VMA_MSG_STATE   0x02
+#define VMA_MSG_EXIT    0x03
+
+#define VMA_MSG_ACK     0x80
+
+#define VMA_AGENT_VER   0x01
+
+#define VMA_AGENT_BASE_NAME "vma_agent"
+#define VMA_AGENT_ADDR      "/var/run/" VMA_AGENT_BASE_NAME ".sock"
+#define VMA_AGENT_PATH      "/tmp/vma"
+
+
+#pragma pack(push, 1)
+struct vma_hdr {
+	uint8_t        code;
+	uint8_t        ver;
+	uint8_t        reserve[2];
+	int32_t        pid;
+
+};
+
+struct vma_msg_init {
+	struct vma_hdr hdr;
+	uint32_t       ver;
+};
+
+struct vma_msg_exit {
+	struct vma_hdr hdr;
+};
+
+struct vma_msg_state {
+	struct vma_hdr hdr;
+	uint32_t       fid;
+	uint32_t       src_ip;
+	uint32_t       dst_ip;
+	uint16_t       src_port;
+	uint16_t       dst_port;
+	uint8_t        type;
+	uint8_t        state;
+};
+#pragma pack( pop )
+
+#endif /* SRC_VMA_UTIL_AGENT_DEF_H_ */

--- a/src/vma/util/list.h
+++ b/src/vma/util/list.h
@@ -342,8 +342,13 @@ static inline void list_splice_tail_init(struct list_head *list,
  * @type:	the type of the struct this is embedded in.
  * @member:	the name of the list_struct within the struct.
  */
+#ifdef __cplusplus
+#define list_entry(ptr, type, member) \
+	(reinterpret_cast<type *>((char *)(ptr)-(char *)(&(reinterpret_cast<type *>(1)->member))+1))
+#else
 #define list_entry(ptr, type, member) \
 	container_of(ptr, type, member)
+#endif
 
 /**
  * list_first_entry - get the first element from a list

--- a/tools/Makefile.am
+++ b/tools/Makefile.am
@@ -1,0 +1,5 @@
+SUBDIRS := \
+	daemon
+
+EXTRA_DIST = \
+	daemon

--- a/tools/daemon/Makefile.am
+++ b/tools/daemon/Makefile.am
@@ -1,0 +1,22 @@
+sbin_PROGRAMS = vmad
+
+vmad_LDADD =
+
+vmad_CPPFLAGS = \
+	-I$(top_srcdir)/src \
+	-I$(top_srcdir)/src/vma
+
+vmad_LDFLAGS  = 
+vmad_CFLAGS = 
+
+vmad_SOURCES = \
+	daemon.c \
+	loop.c \
+	hash.c \
+	store.c \
+	message.c \
+	notify.c
+
+noinst_HEADERS = \
+	daemon.h \
+	hash.h

--- a/tools/daemon/daemon.c
+++ b/tools/daemon/daemon.c
@@ -1,0 +1,367 @@
+/*
+ * Copyright (c) 2016 Mellanox Technologies, Ltd. All rights reserved.
+ *
+ * This software is available to you under a choice of one of two
+ * licenses.  You may choose to be licensed under the terms of the GNU
+ * General Public License (GPL) Version 2, available from the file
+ * COPYING in the main directory of this source tree, or the
+ * BSD license below:
+ *
+ *     Redistribution and use in source and binary forms, with or
+ *     without modification, are permitted provided that the following
+ *     conditions are met:
+ *
+ *      - Redistributions of source code must retain the above
+ *        copyright notice, this list of conditions and the following
+ *        disclaimer.
+ *
+ *      - Redistributions in binary form must reproduce the above
+ *        copyright notice, this list of conditions and the following
+ *        disclaimer in the documentation and/or other materials
+ *        provided with the distribution.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+ * BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ * ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+
+#ifdef HAVE_CONFIG_H
+#include "config.h"
+#endif
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <stdint.h>
+#include <getopt.h>
+
+#if HAVE_SYS_PRCTL_H
+#  include <sys/prctl.h>
+#endif
+
+#include "vma/util/agent.h"
+#include "hash.h"
+#include "daemon.h"
+
+
+extern int proc_loop(void);
+
+static void handle_signal(int signo);
+static void daemonize(void);
+static int config_def(void);
+static int config_set(int argc, char **argv);
+static void usage(void);
+
+struct module_cfg daemon_cfg;
+
+int main(int argc, char *argv[])
+{
+	/* Setup syslog logging */
+	openlog(MODULE_NAME, LOG_PID, LOG_LOCAL5);
+
+	/* already a daemon */
+	if (getppid() == 1) {
+		return 0;
+	}
+
+	/* command line parsing... */
+	config_def();
+	log_info("Starting\n");
+
+	config_set(argc, argv);
+
+	/* Daemonize */
+	if (0 == daemon_cfg.opt.mode) {
+		daemonize();
+	}
+
+	/* Change the file mode mask */
+	umask(0);
+
+	/* Set name of the process */
+#if HAVE_SYS_PRCTL_H
+	if (prctl(PR_SET_NAME, MODULE_NAME, NULL, NULL, NULL) < 0) {
+		log_error("cannot set process name to %s, errno=%d (%s)\n",
+				MODULE_NAME, errno, strerror(errno));
+		goto err;
+	}
+#endif
+
+	/* Ensure only one copy */
+	if (daemon_cfg.lock_file[0]) {
+		char str[10];
+
+		daemon_cfg.lock_fd = open(daemon_cfg.lock_file, O_RDWR | O_CREAT, S_IRUSR | S_IWUSR | S_IRGRP);
+		if (daemon_cfg.lock_fd < 0) {
+			log_error("could not open PID lock file %s, errno=%d (%s)\n",
+					daemon_cfg.lock_file, errno, strerror(errno));
+			goto err;
+		}
+
+		if (lockf(daemon_cfg.lock_fd, F_TLOCK, 0) < 0) {
+			log_error("could not lock PID lock file %s, errno=%d (%s)\n",
+					daemon_cfg.lock_file, errno, strerror(errno));
+			goto err;
+		}
+
+		/* Write pid to lockfile */
+		sprintf(str,"%d\n", getpid());
+		if (write(daemon_cfg.lock_fd, str, strlen(str)) < 0) {
+			log_error("could not write to PID lock file %s, errno=%d (%s)\n",
+					daemon_cfg.lock_file, errno, strerror(errno));
+			goto err;
+		}
+	}
+
+	/* Main loop */
+	proc_loop();
+
+	/* Finish up */
+	close(daemon_cfg.lock_fd);
+	unlink(daemon_cfg.lock_file);
+
+	log_info("Terminated\n");
+	closelog();
+
+	return EXIT_SUCCESS;
+err:
+	return EXIT_FAILURE;
+}
+
+static void handle_signal(int signo)
+{
+	log_debug("Getting signal (%d)\n", signo);
+
+	switch (signo) {
+	case SIGALRM:
+	case SIGCHLD:
+	case SIGUSR1:
+		daemon_cfg.sig = SIGUSR1;
+		_exit(EXIT_SUCCESS);
+		break;
+	default:
+		daemon_cfg.sig = signo;
+		return;
+	}
+}
+
+static void daemonize(void)
+{
+	struct sigaction sa;
+	pid_t pid, sid, parent;
+
+	/* Fork off the parent process */
+	pid = fork();
+	if (pid < 0) {
+		log_error("unable to fork daemon, code=%d (%s)\n", errno,
+				strerror(errno));
+		exit(EXIT_FAILURE);
+	}
+	/* If we got a good PID, then we can exit the parent process. */
+	if (pid > 0) {
+
+		/* Setup signal handling before we start */
+		sa.sa_handler = &handle_signal;
+		sigemptyset(&sa.sa_mask);
+		sa.sa_flags = 0;
+		if (sigaction(SIGUSR1, &sa, NULL) < 0) {
+			log_error("cannot register SIGUSR1 signal handler, errno=%d (%s)\n",
+					errno, strerror(errno));
+			exit(EXIT_FAILURE);
+		}
+		if (sigaction(SIGCHLD, &sa, NULL) < 0) {
+			log_error("cannot register SIGCHLD signal handler, errno=%d (%s)\n",
+					errno, strerror(errno));
+			exit(EXIT_FAILURE);
+		}
+		if (sigaction(SIGALRM, &sa, NULL) < 0) {
+			log_error("cannot register SIGALRM signal handler, errno=%d (%s)\n",
+					errno, strerror(errno));
+			exit(EXIT_FAILURE);
+		}
+
+		/* Wait for confirmation from the child via SIGTERM or SIGCHLD, or
+		 * for two seconds to elapse (SIGALRM).
+		 * pause() should not return.
+		 */
+		alarm(2);
+		pause();
+		exit(EXIT_FAILURE);
+	}
+
+	/* At this point we are executing as the child process */
+	parent = getppid();
+
+	/* Cancel certain signals */
+	signal(SIGTSTP, SIG_IGN); /* Various TTY signals */
+	signal(SIGTTOU, SIG_IGN);
+	signal(SIGTTIN, SIG_IGN);
+	signal(SIGALRM, SIG_IGN);
+	signal(SIGUSR1, SIG_IGN);
+	signal(SIGHUP, SIG_IGN);
+	signal(SIGCHLD, SIG_DFL); /* A child process dies */
+	signal(SIGTERM, SIG_DFL); /* Die on SIGTERM */
+
+	/* Setup signal handling before we start */
+	sa.sa_handler = &handle_signal;
+	sigemptyset(&sa.sa_mask);
+	sa.sa_flags = 0;
+	if (sigaction(SIGINT, &sa, NULL) < 0) {
+		log_error("cannot register SIGINT signal handler, errno=%d (%s)\n",
+				errno, strerror(errno));
+		exit(EXIT_FAILURE);
+	}
+
+	/* Create a new SID for the child process */
+	sid = setsid();
+	if (sid < 0) {
+		log_error("unable to create a new session, errno %d (%s)\n", errno,
+				strerror(errno));
+		exit(EXIT_FAILURE);
+	}
+
+	/* Change the current working directory */
+	if ((chdir("/")) < 0) {
+		log_error("unable to change directory to %s, errno %d (%s)\n", "/",
+				errno, strerror(errno));
+		exit(EXIT_FAILURE);
+	}
+
+	/* Redirect standard files to /dev/null */
+	if (NULL == freopen("/dev/null", "r", stdin)) {
+		log_error("unable redirect stdin, errno %d (%s)\n",
+				errno, strerror(errno));
+		exit(EXIT_FAILURE);
+	}
+
+	if (NULL == freopen("/dev/null", "w", stdout)) {
+		log_error("unable redirect stdout, errno %d (%s)\n",
+				errno, strerror(errno));
+		exit(EXIT_FAILURE);
+	}
+
+	if (NULL == freopen("/dev/null", "w", stderr)) {
+		log_error("unable redirect stderr, errno %d (%s)\n",
+				errno, strerror(errno));
+		exit(EXIT_FAILURE);
+	}
+
+	/* Send a signal to the parent to it can terminate. */
+	kill(parent, SIGUSR1);
+}
+
+static int config_def(void)
+{
+	int rc = 0;
+
+	memset(&daemon_cfg, 0, sizeof(daemon_cfg));
+
+	daemon_cfg.opt.mode = 0;
+	daemon_cfg.opt.log_level = 4;
+	daemon_cfg.opt.max_pid_num = PID_MAX;
+	daemon_cfg.opt.max_fid_num = FID_MAX;
+	daemon_cfg.opt.force_rst = 0;
+
+	daemon_cfg.lock_file = "/var/lock/" MODULE_NAME ".lock";
+	daemon_cfg.lock_fd = -1;
+	daemon_cfg.sock_file = VMA_AGENT_ADDR;
+	daemon_cfg.sock_fd = -1;
+	daemon_cfg.sig = 0;
+	daemon_cfg.raw_fd = -1;
+	daemon_cfg.notify_fd = -1;
+	daemon_cfg.notify_dir = VMA_AGENT_PATH;
+
+	return rc;
+}
+
+static int config_set(int argc, char **argv)
+{
+	int rc = 0;
+	static struct option long_options[] = {
+		{"console",      no_argument,       &daemon_cfg.opt.mode,      1},
+		{"verbose",      required_argument, 0,                         'v'},
+		{"pid",          required_argument, 0,                         'p'},
+		{"fid",          required_argument, 0,                         'f'},
+		{"force-rst",    no_argument,       &daemon_cfg.opt.force_rst, 1},
+		{"help",         no_argument,       0,                         'h'},
+		{ 0, 0, 0, 0 }
+	};
+	int op;
+	int option_index;
+
+	while ((op = getopt_long(argc, argv, "v:p:f:h", long_options, &option_index)) != -1) {
+		switch (op) {
+			case 'v':
+				errno = 0;
+				daemon_cfg.opt.log_level = strtol(optarg, NULL, 0);
+				if (0 != errno) {
+					rc = -EINVAL;
+				}
+				break;
+			case 'p':
+				errno = 0;
+				daemon_cfg.opt.max_pid_num = strtol(optarg, NULL, 0);
+				if (0 != errno) {
+					rc = -EINVAL;
+				}
+				break;
+			case 'f':
+				errno = 0;
+				daemon_cfg.opt.max_fid_num = strtol(optarg, NULL, 0);
+				if (0 != errno) {
+					rc = -EINVAL;
+				}
+				break;
+			case 'h':
+				usage();
+				break;
+			case 0:
+				/* getopt_long() set a variable, just keep going */
+				break;
+			case ':':
+			case '?':
+			default:
+				rc = -EINVAL;
+				break;
+		}
+	}
+
+	log_debug("CONFIGURATION:\n");
+	log_debug("mode: %d\n", daemon_cfg.opt.mode);
+	log_debug("log level: %d\n", daemon_cfg.opt.log_level);
+	log_debug("max pid: %d\n", daemon_cfg.opt.max_pid_num);
+	log_debug("max fid: %d\n", daemon_cfg.opt.max_fid_num);
+	log_debug("force rst: %d\n", daemon_cfg.opt.force_rst);
+	log_debug("lock file: %s\n", daemon_cfg.lock_file);
+	log_debug("sock file: %s\n", daemon_cfg.sock_file);
+	log_debug("notify dir: %s\n", daemon_cfg.notify_dir);
+
+	if (0 != rc) {
+		usage();
+	}
+
+	return rc;
+}
+
+static void usage(void)
+{
+	printf("Usage: " MODULE_NAME " [options]\n"
+		"\t--console               Enable foreground mode (default: %s)\n"
+		"\t--pid,-p <num>          Set prime number as maximum of processes per node. (default: %d).\n"
+		"\t--fid,-f <num>          Set prime number as maximum of sockets per process. (default: %d).\n"
+		"\t--force-rst             Force internal RST. (default: %s).\n"
+		"\t--verbose,-v <level>    Output verbose level (default: %d).\n"
+		"\t--help,-h               Print help and exit\n",
+			(daemon_cfg.opt.mode ? "on" : "off"),
+			daemon_cfg.opt.max_pid_num,
+			daemon_cfg.opt.max_fid_num,
+			(daemon_cfg.opt.force_rst ? "on" : "off"),
+			daemon_cfg.opt.log_level);
+
+	exit(EXIT_SUCCESS);
+}

--- a/tools/daemon/daemon.c
+++ b/tools/daemon/daemon.c
@@ -44,7 +44,6 @@
 #  include <sys/prctl.h>
 #endif
 
-#include "vma/util/agent.h"
 #include "hash.h"
 #include "daemon.h"
 

--- a/tools/daemon/daemon.h
+++ b/tools/daemon/daemon.h
@@ -53,6 +53,9 @@
 #include <linux/limits.h>
 #endif
 
+#include "vma/util/agent_def.h"
+
+
 #define MODULE_NAME             "vmad"
 
 #define EXIT_SUCCESS 0

--- a/tools/daemon/daemon.h
+++ b/tools/daemon/daemon.h
@@ -1,0 +1,211 @@
+/*
+ * Copyright (c) 2016 Mellanox Technologies, Ltd. All rights reserved.
+ *
+ * This software is available to you under a choice of one of two
+ * licenses.  You may choose to be licensed under the terms of the GNU
+ * General Public License (GPL) Version 2, available from the file
+ * COPYING in the main directory of this source tree, or the
+ * BSD license below:
+ *
+ *     Redistribution and use in source and binary forms, with or
+ *     without modification, are permitted provided that the following
+ *     conditions are met:
+ *
+ *      - Redistributions of source code must retain the above
+ *        copyright notice, this list of conditions and the following
+ *        disclaimer.
+ *
+ *      - Redistributions in binary form must reproduce the above
+ *        copyright notice, this list of conditions and the following
+ *        disclaimer in the documentation and/or other materials
+ *        provided with the distribution.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+ * BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ * ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#ifndef TOOLS_DAEMON_DAEMON_H_
+#define TOOLS_DAEMON_DAEMON_H_
+
+#include <stdio.h>
+#include <string.h>
+#include <stdlib.h>
+#include <unistd.h>
+#include <stdint.h>
+#include <errno.h>
+#include <signal.h>
+#include <fcntl.h>
+#include <time.h>
+#include <assert.h>
+#include <stdarg.h>
+#include <syslog.h>
+#include <sys/types.h>
+#include <sys/stat.h>
+#include <arpa/inet.h>
+
+#ifdef HAVE_LINUX_LIMITS_H
+#include <linux/limits.h>
+#endif
+
+#define MODULE_NAME             "vmad"
+
+#define EXIT_SUCCESS 0
+#define EXIT_FAILURE 1
+
+#define INVALID_VALUE (-1)
+#define STATE_ESTABLISHED	4
+
+#define PID_MAX         499    /**< Default maximum number of processes
+                                    per node (should be prime number) */
+#define FID_MAX         2203   /**< Default maximum number of sockets
+                                    per process (should be prime number) */
+
+#ifndef HAVE_LINUX_LIMITS_H
+#define NAME_MAX         255    /**< chars in a file name */
+#define PATH_MAX        4096    /**< chars in a path name including null */
+#endif
+
+#define log_fatal(fmt, ...) \
+	do {                                                        \
+		if (daemon_cfg.opt.log_level > 0)                              \
+			sys_log(LOG_ALERT, "[FATAL ] " fmt, ##__VA_ARGS__);    \
+	} while (0)
+
+#define log_error(fmt, ...) \
+	do {                                                        \
+		if (daemon_cfg.opt.log_level > 1)                              \
+			sys_log(LOG_ERR, "[ERROR ] " fmt, ##__VA_ARGS__);      \
+	} while (0)
+
+#define log_warn(fmt, ...) \
+	do {                                                         \
+		if (daemon_cfg.opt.log_level > 2)                               \
+			sys_log(LOG_WARNING, "[WARN  ] " fmt, ##__VA_ARGS__);   \
+	} while (0)
+
+#define log_info(fmt, ...) \
+	do {                                                         \
+		if (daemon_cfg.opt.log_level > 3)                               \
+			sys_log(LOG_NOTICE, "[INFO  ] " fmt, ##__VA_ARGS__);    \
+	} while (0)
+
+#define log_debug(fmt, ...) \
+	do {                                                         \
+		if (daemon_cfg.opt.log_level > 4)                               \
+			sys_log(LOG_INFO, "[DEBUG ] " fmt, ##__VA_ARGS__);    \
+	} while (0)
+
+/**
+ * @struct module_cfg
+ * @brief Configuration parameters in global values
+ */
+struct module_cfg {
+	struct {
+		int mode;                   /**< 0 - daemon, 1 - console */
+		int log_level;              /**< 0..5 verbose level */
+		int max_pid_num;            /**< maximum number of processes per node */
+		int max_fid_num;            /**< maximum number of sockets per process */
+		int force_rst;              /**< RST method
+	                                     * 0 - only system RST is sent as
+	                                     * reaction on spoofed SYN
+	                                     * 1 - form and send internal RST
+	                                     * based on SeqNo */
+	} opt;
+	volatile sig_atomic_t sig;
+	const char *lock_file;
+	int lock_fd;
+	const char *sock_file;
+	int sock_fd;
+	int raw_fd;
+	int notify_fd;
+	const char *notify_dir;
+	hash_t ht;
+};
+
+extern struct module_cfg daemon_cfg;
+
+/**
+ * @struct store_pid
+ * @brief Describe process using pid as unique key
+ */
+struct store_pid {
+	pid_t          pid;         /**< Process id */
+	hash_t         ht;          /**< Handle to socket store */
+	uint32_t       lib_ver;     /**< Library version that the process uses */
+	struct timeval t_start;     /**< Start time of the process */
+};
+
+/**
+ * @struct store_fid
+ * @brief Describe socket using fid as unique key
+ */
+struct store_fid {
+	int            fid;         /**< Socket id */
+	uint32_t       src_ip;      /**< Source IP address */
+	uint32_t       dst_ip;      /**< Destination IP address */
+	uint16_t       src_port;    /**< Source port number */
+	uint16_t       dst_port;    /**< Destination port number */
+	uint8_t        type;        /**< Connection type */
+	uint8_t        state;       /**< Current TCP state of the connection */
+};
+
+
+static inline void sys_log(int level, const char *format, ...)
+{
+	va_list args;
+	va_start(args, format);
+
+	if (0 == daemon_cfg.opt.mode) {
+		vsyslog(level, format, args);
+	} else {
+		vprintf(format, args);
+	}
+	va_end(args);
+}
+
+
+static inline char *sys_addr2str(struct sockaddr_in *addr)
+{
+	static __thread char addrbuf[100];
+	static char buf[100];
+	inet_ntop(AF_INET, &addr->sin_addr, buf, sizeof(buf) - 1);
+	sprintf(addrbuf, "%s:%d", buf, ntohs(addr->sin_port));
+
+	return addrbuf;
+}
+
+
+static inline ssize_t sys_sendto(int sockfd,
+		const void *buf, size_t len, int flags,
+		const struct sockaddr *dest_addr, socklen_t addrlen)
+{
+	char *data = (char *)buf;
+	int n, nb;
+
+	nb = 0;
+	do {
+		n = sendto(sockfd, data, len, flags, dest_addr, addrlen);
+		if (n <= 0) {
+			if (errno == EAGAIN || errno == EWOULDBLOCK || errno == EINTR) {
+				if (flags & MSG_DONTWAIT) {
+					break;
+				}
+				continue;
+			}
+			return -errno;
+		}
+		len -= n;
+		data += n;
+		nb += n;
+	} while (!(flags & MSG_DONTWAIT) && (len > 0));
+
+	return nb;
+}
+
+#endif /* TOOLS_DAEMON_DAEMON_H_ */

--- a/tools/daemon/hash.c
+++ b/tools/daemon/hash.c
@@ -1,0 +1,242 @@
+/*
+ * Copyright (c) 2016 Mellanox Technologies, Ltd. All rights reserved.
+ *
+ * This software is available to you under a choice of one of two
+ * licenses.  You may choose to be licensed under the terms of the GNU
+ * General Public License (GPL) Version 2, available from the file
+ * COPYING in the main directory of this source tree, or the
+ * BSD license below:
+ *
+ *     Redistribution and use in source and binary forms, with or
+ *     without modification, are permitted provided that the following
+ *     conditions are met:
+ *
+ *      - Redistributions of source code must retain the above
+ *        copyright notice, this list of conditions and the following
+ *        disclaimer.
+ *
+ *      - Redistributions in binary form must reproduce the above
+ *        copyright notice, this list of conditions and the following
+ *        disclaimer in the documentation and/or other materials
+ *        provided with the distribution.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+ * BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ * ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <stdint.h>
+
+#include "hash.h"
+
+
+#define HASH_KEY_INVALID    (hash_key_t)(-1)
+
+/**
+ * @struct hash_element
+ * @brief It is an object to be stored in a hash container
+ */
+struct hash_element {
+	hash_key_t key; /**< key */
+	void *value;    /**< value */
+};
+
+/**
+ * @struct hash_object
+ * @brief hash container
+ */
+struct hash_object {
+	struct hash_element *hash_table; /**< hash table */
+	struct hash_element *last;       /**< last accessed */
+	int size;                        /**< maximum number of elements */
+	int count;                       /**< current count of elements */
+	hash_freefunc_t free;            /**< free function */
+};
+
+static struct hash_element* hash_find(hash_t ht, hash_key_t key);
+static int check_prime(int value);
+
+
+hash_t hash_create(hash_freefunc_t free_func, size_t size)
+{
+	hash_t ht = NULL;
+
+	/* Check passed size */
+	if (!check_prime(size)) {
+		return NULL;
+	}
+
+	ht = (struct hash_object *)malloc(sizeof(*ht));
+	if (ht) {
+		ht->size = size;
+		ht->hash_table = (struct hash_element *)calloc(ht->size,
+				sizeof(*ht->hash_table));
+		if (ht->hash_table) {
+			int i = 0;
+
+			ht->last = NULL;
+			ht->count = 0;
+			ht->free = free_func;
+			for (i = 0; i < ht->size; i++) {
+				ht->hash_table[i].key = HASH_KEY_INVALID;
+			}
+		} else {
+			free(ht);
+			ht = NULL;
+		}
+	}
+
+	return ht;
+}
+
+void hash_destroy(hash_t ht)
+{
+	if (ht) {
+		if (ht->hash_table) {
+			int i = 0;
+
+			for (i = 0; i < ht->size; i++) {
+				if (ht->hash_table[i].key != HASH_KEY_INVALID) {
+					if (ht->free && ht->hash_table[i].value) {
+						ht->free(ht->hash_table[i].value);
+					}
+					ht->hash_table[i].key = HASH_KEY_INVALID;
+					ht->hash_table[i].value = NULL;
+				}
+			}
+			free(ht->hash_table);
+			ht->hash_table = NULL;
+		}
+		free(ht);
+		ht = NULL;
+	}
+}
+
+int hash_count(hash_t ht)
+{
+	return ht->count;
+}
+
+int hash_size(hash_t ht)
+{
+	return ht->size;
+}
+
+void *hash_get(hash_t ht, hash_key_t key)
+{
+	if (ht) {
+		struct hash_element *entry = NULL;
+
+		entry = hash_find(ht, key);
+		if (entry) {
+			return entry->value;
+		}
+	}
+
+	return NULL;
+}
+
+void *hash_enum(hash_t ht, size_t index)
+{
+	if (ht) {
+		struct hash_element *entry = NULL;
+
+		entry = &(ht->hash_table[index]);
+		if (entry) {
+			return entry->value;
+		}
+	}
+
+	return NULL;
+}
+
+void *hash_put(hash_t ht, hash_key_t key, void *value)
+{
+	if (ht) {
+		struct hash_element *entry = NULL;
+
+		entry = hash_find(ht, key);
+		if (entry) {
+			if (ht->free && entry->value) {
+				ht->free(entry->value);
+			}
+			entry->value = value;
+			return value;
+		}
+	}
+
+	return NULL;
+}
+
+void hash_del(hash_t ht, hash_key_t key)
+{
+	if (ht) {
+		struct hash_element *entry = NULL;
+
+		entry = hash_find(ht, key);
+		if (entry) {
+			if (ht->free && entry->value) {
+				ht->free(entry->value);
+			}
+			entry->key = HASH_KEY_INVALID;
+			entry->value = NULL;
+			ht->count--;
+		}
+	}
+}
+
+static struct hash_element* hash_find(hash_t ht, hash_key_t key)
+{
+	struct hash_element *entry = NULL;
+	int attempts = 0;
+	int idx = 0;
+
+	if (ht->last && ht->last->key == key)
+		return ht->last;
+
+	idx = key % ht->size;
+
+	do {
+		entry = &(ht->hash_table[idx]);
+
+		if ((ht->count < ht->size) &&
+			(entry->key == HASH_KEY_INVALID)) {
+			entry->key = key;
+			entry->value = NULL;
+			ht->count++;
+			break;
+		} else {
+			if (attempts >= (ht->size - 1)) {
+				entry = NULL;
+				break;
+			}
+			attempts++;
+			idx = (idx + 1) % ht->size;
+		}
+	} while (entry->key != key);
+
+	ht->last = (entry ? entry : ht->last);
+
+	return entry;
+}
+
+static int check_prime(int value)
+{
+	int i = 0;
+
+	for (i = 2; i <= value / 2; i++) {
+		if ((value % i) == 0) {
+			return 0;
+		}
+	}
+
+	return 1;
+}

--- a/tools/daemon/hash.h
+++ b/tools/daemon/hash.h
@@ -1,0 +1,123 @@
+/*
+ * Copyright (c) 2016 Mellanox Technologies, Ltd. All rights reserved.
+ *
+ * This software is available to you under a choice of one of two
+ * licenses.  You may choose to be licensed under the terms of the GNU
+ * General Public License (GPL) Version 2, available from the file
+ * COPYING in the main directory of this source tree, or the
+ * BSD license below:
+ *
+ *     Redistribution and use in source and binary forms, with or
+ *     without modification, are permitted provided that the following
+ *     conditions are met:
+ *
+ *      - Redistributions of source code must retain the above
+ *        copyright notice, this list of conditions and the following
+ *        disclaimer.
+ *
+ *      - Redistributions in binary form must reproduce the above
+ *        copyright notice, this list of conditions and the following
+ *        disclaimer in the documentation and/or other materials
+ *        provided with the distribution.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+ * BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ * ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#ifndef TOOLS_DAEMON_HASH_H_
+#define TOOLS_DAEMON_HASH_H_
+
+
+/* The hash_t opaque data type
+ */
+typedef struct hash_object* hash_t;
+
+/* The hash key data type
+ */
+typedef uint32_t hash_key_t;
+
+
+/* This type of function is used to free data inserted into hash table
+ */
+typedef void (*hash_freefunc_t)(void *);
+
+
+/* hash_create():
+ *
+ * Create a hash object.
+ * @param free_func - user defined function for destroy data
+ *       inserted into hash
+ * @param size - size of hash that should be Prime number
+ * @return the newly allocated hash table. Must be freed with hash_destory.
+ */
+hash_t hash_create(hash_freefunc_t free_func, size_t size);
+
+/* hash_destroy():
+ *
+ * Destroy a hash object.
+ * @param ht - hash to be freed
+ * @return @a none
+ */
+void hash_destroy(hash_t ht);
+
+/* hash_count():
+ *
+ * Return number of valid elements in the hash object.
+ * @param ht - point to hash object
+ * @return number of elements
+ */
+int hash_count(hash_t ht);
+
+/* hash_size():
+ *
+ * Return maximum number of elements in the hash object.
+ * @param ht - point to hash object
+ * @return maximum number of elements
+ */
+int hash_size(hash_t ht);
+
+/* hash_get():
+ *
+ * Return value stored in hash object by found by key.
+ * @param ht - point to hash object
+ * @param key - key identified data
+ * @return value
+ */
+void *hash_get(hash_t ht, hash_key_t key);
+
+/* hash_enum():
+ *
+ * Return value stored in hash object by index.
+ * @param ht - point to hash object
+ * @param index - index in hash object
+ * @return value
+ */
+void *hash_enum(hash_t ht, size_t index);
+
+/* hash_put():
+ *
+ * Store data in hash object.
+ * @param ht - point to hash object
+ * @param key - key identified data
+ * @param value - stored data
+ * @return value or NULL in case of error.
+ */
+void *hash_put(hash_t ht, hash_key_t key, void *value);
+
+/* hash_del():
+ *
+ * Remove value stored in hash object and free memory
+ * if freefunc() is passed during hash object creation.
+ * @param ht - point to hash object
+ * @param key - key identified data
+ * @return @a none
+ */
+void hash_del(hash_t ht, hash_key_t key);
+
+#endif /* TOOLS_DAEMON_HASH_H_ */

--- a/tools/daemon/loop.c
+++ b/tools/daemon/loop.c
@@ -41,7 +41,6 @@
 #include <sys/socket.h>
 #include <sys/un.h>
 
-#include "vma/util/agent.h"
 #include "hash.h"
 #include "daemon.h"
 

--- a/tools/daemon/loop.c
+++ b/tools/daemon/loop.c
@@ -1,0 +1,137 @@
+/*
+ * Copyright (c) 2016 Mellanox Technologies, Ltd. All rights reserved.
+ *
+ * This software is available to you under a choice of one of two
+ * licenses.  You may choose to be licensed under the terms of the GNU
+ * General Public License (GPL) Version 2, available from the file
+ * COPYING in the main directory of this source tree, or the
+ * BSD license below:
+ *
+ *     Redistribution and use in source and binary forms, with or
+ *     without modification, are permitted provided that the following
+ *     conditions are met:
+ *
+ *      - Redistributions of source code must retain the above
+ *        copyright notice, this list of conditions and the following
+ *        disclaimer.
+ *
+ *      - Redistributions in binary form must reproduce the above
+ *        copyright notice, this list of conditions and the following
+ *        disclaimer in the documentation and/or other materials
+ *        provided with the distribution.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+ * BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ * ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+
+#ifdef HAVE_CONFIG_H
+#include "config.h"
+#endif
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <stdint.h>
+#include <sys/socket.h>
+#include <sys/un.h>
+
+#include "vma/util/agent.h"
+#include "hash.h"
+#include "daemon.h"
+
+extern int open_store(void);
+extern void close_store(void);
+extern int open_message(void);
+extern void close_message(void);
+extern int proc_message(void);
+extern int open_notify(void);
+extern void close_notify(void);
+extern int proc_notify(void);
+
+int proc_loop(void)
+{
+	int rc = 0;
+
+	log_debug("setting working directory ...\n");
+	if ((mkdir(VMA_AGENT_PATH, 0777) != 0) && (errno != EEXIST)) {
+		rc = -errno;
+		log_error("failed create folder %s (errno = %d)\n", VMA_AGENT_PATH, errno);
+		goto err;
+	}
+
+	log_debug("setting store ...\n");
+	rc = open_store();
+	if (rc < 0) {
+		goto err;
+	}
+
+	log_debug("setting notification ...\n");
+	rc = open_notify();
+	if (rc < 0) {
+		goto err;
+	}
+
+	log_debug("setting message processing ...\n");
+	rc = open_message();
+	if (rc < 0) {
+		goto err;
+	}
+
+	log_debug("starting loop ...\n");
+	while ((0 == daemon_cfg.sig) && (0 == rc)) {
+		fd_set readfds;
+		struct timeval tv;
+		int max_fd = -1;
+
+		FD_ZERO(&readfds);
+		FD_SET(daemon_cfg.sock_fd, &readfds);
+		max_fd = daemon_cfg.sock_fd;
+		FD_SET(daemon_cfg.notify_fd, &readfds);
+		max_fd = (max_fd < daemon_cfg.notify_fd ? daemon_cfg.notify_fd : max_fd);
+
+		/* Use timeout for select() call */
+		tv.tv_sec = 60;
+		tv.tv_usec = 0;
+
+		rc = select(max_fd + 1, &readfds, NULL, NULL, &tv);
+		if (rc < 0) {
+			if (errno != EINTR) {
+				log_error("Failed select() errno %d (%s)\n", errno,
+						strerror(errno));
+			}
+			rc = -errno;
+			goto err;
+		} else if (rc == 0) {
+			continue;
+		}
+
+		/* Check any events from fanotify */
+		if (FD_ISSET(daemon_cfg.notify_fd, &readfds)) {
+			log_debug("notification processing ...\n");
+			rc = proc_notify();
+		}
+
+		/* Check messages from processes */
+		if (FD_ISSET(daemon_cfg.sock_fd, &readfds)) {
+			log_debug("message processing ...\n");
+			rc = proc_message();
+		}
+	}
+
+err:
+	log_debug("finishing loop ...\n");
+
+	close_store();
+
+	close_message();
+
+	close_notify();
+
+	return rc;
+}

--- a/tools/daemon/message.c
+++ b/tools/daemon/message.c
@@ -1,0 +1,340 @@
+/*
+ * Copyright (c) 2016 Mellanox Technologies, Ltd. All rights reserved.
+ *
+ * This software is available to you under a choice of one of two
+ * licenses.  You may choose to be licensed under the terms of the GNU
+ * General Public License (GPL) Version 2, available from the file
+ * COPYING in the main directory of this source tree, or the
+ * BSD license below:
+ *
+ *     Redistribution and use in source and binary forms, with or
+ *     without modification, are permitted provided that the following
+ *     conditions are met:
+ *
+ *      - Redistributions of source code must retain the above
+ *        copyright notice, this list of conditions and the following
+ *        disclaimer.
+ *
+ *      - Redistributions in binary form must reproduce the above
+ *        copyright notice, this list of conditions and the following
+ *        disclaimer in the documentation and/or other materials
+ *        provided with the distribution.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+ * BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ * ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+
+#ifdef HAVE_CONFIG_H
+#include "config.h"
+#endif
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <stdint.h>
+#include <sys/time.h>
+#include <sys/socket.h>
+#include <sys/un.h>
+#include <netinet/ip.h>
+#include <netinet/tcp.h>
+
+#include "vma/lwip/tcp.h"    /* display TCP states */
+#include "vma/util/agent.h"  /* get message layout format */
+#include "hash.h"
+#include "daemon.h"
+
+
+int open_message(void);
+void close_message(void);
+int proc_message(void);
+
+static int proc_msg_init(struct vma_hdr *msg_hdr, size_t size, struct sockaddr_un *peeraddr);
+static int proc_msg_exit(struct vma_hdr *msg_hdr, size_t size);
+static int proc_msg_state(struct vma_hdr *msg_hdr, size_t size);
+
+
+int open_message(void)
+{
+	int rc = 0;
+	int optval = 1;
+	struct sockaddr_un server_addr;
+
+	/* Create UNIX UDP socket to receive data from VMA processes */
+	memset(&server_addr, 0, sizeof(server_addr));
+	server_addr.sun_family = AF_UNIX;
+	strncpy(server_addr.sun_path, daemon_cfg.sock_file, sizeof(server_addr.sun_path) - 1);
+	/* remove possible old socket */
+	unlink(daemon_cfg.sock_file);
+
+	if ((daemon_cfg.sock_fd = socket(AF_UNIX, SOCK_DGRAM, 0)) < 0) {
+		log_error("Failed to call socket() errno %d (%s)\n", errno,
+				strerror(errno));
+		rc = -errno;
+		goto err;
+	}
+
+	optval = 1;
+	rc = setsockopt(daemon_cfg.sock_fd, SOL_SOCKET, SO_REUSEADDR, &optval, sizeof(optval));
+	if (rc < 0) {
+		log_error("Failed to call setsockopt() errno %d (%s)\n", errno,
+				strerror(errno));
+		rc = -errno;
+		goto err;
+	}
+
+	/* bind created socket */
+	if (bind(daemon_cfg.sock_fd, (struct sockaddr *)&server_addr, sizeof(server_addr)) < 0) {
+		log_error("Failed to call bind() errno %d (%s)\n", errno,
+				strerror(errno));
+		rc = -errno;
+		goto err;
+	}
+
+	/* Make the socket non-blocking */
+	optval = fcntl(daemon_cfg.sock_fd, F_GETFL);
+	if (optval < 0) {
+		rc = -errno;
+		log_error("Failed to get socket flags errno %d (%s)\n", errno,
+				strerror(errno));
+		goto err;
+	}
+	optval |= O_NONBLOCK;
+	rc = fcntl(daemon_cfg.sock_fd, F_SETFL, optval);
+	if (rc < 0) {
+		rc = -errno;
+		log_error("Failed to set socket flags errno %d (%s)\n", errno,
+				strerror(errno));
+		goto err;
+	}
+
+err:
+	return rc;
+}
+
+void close_message(void)
+{
+	if (daemon_cfg.sock_fd > 0) {
+		close(daemon_cfg.sock_fd);
+	}
+	unlink(daemon_cfg.sock_file);
+}
+
+int proc_message(void)
+{
+	int rc = 0;
+	struct sockaddr_un peeraddr;
+	socklen_t addrlen = sizeof(peeraddr);
+	char msg_recv[4096];
+	int len = 0;
+	struct vma_hdr *msg_hdr = NULL;
+
+again:
+	len = recvfrom(daemon_cfg.sock_fd, &msg_recv, sizeof(msg_recv), 0,
+			(struct sockaddr *) &peeraddr, &addrlen);
+	if ((len < 0 || len < (int)sizeof(struct vma_hdr))) {
+		if (errno == EINTR) {
+			goto again;
+		}
+		rc = -errno;
+		log_error("Failed recvfrom() errno %d (%s)\n", errno,
+				strerror(errno));
+		goto err;
+	}
+
+	/* Parse and process messages */
+	while (len > 0) {
+		if (len < (int)sizeof(struct vma_hdr)) {
+			rc = -EBADMSG;
+			log_error("Invalid message lenght from %s as %d errno %d (%s)\n",
+					(addrlen > 0 ? peeraddr.sun_path: "n/a"), len, errno,	strerror(errno));
+			goto err;
+		}
+		msg_hdr = (struct vma_hdr *)&msg_recv;
+		log_debug("getting message ([%d] ver: %d pid: %d)\n",
+				msg_hdr->code, msg_hdr->ver, msg_hdr->pid);
+
+		switch (msg_hdr->code) {
+		case VMA_MSG_INIT:
+			rc = proc_msg_init(msg_hdr, len, &peeraddr);
+			break;
+		case VMA_MSG_STATE:
+			rc = proc_msg_state(msg_hdr, len);
+			break;
+		case VMA_MSG_EXIT:
+			rc = proc_msg_exit(msg_hdr, len);
+			break;
+		default:
+			rc = -EPROTO;
+			log_error("Received unknow message errno %d (%s)\n", errno,
+					strerror(errno));
+			goto err;
+		}
+		if (0 < rc) {
+			len -= rc;
+			rc = 0;
+		} else {
+			goto err;
+		}
+	}
+
+err:
+	return rc;
+}
+
+static int proc_msg_init(struct vma_hdr *msg_hdr, size_t size, struct sockaddr_un *peeraddr)
+{
+	struct vma_msg_init *data;
+	struct store_pid *value;
+
+	assert(msg_hdr);
+	assert(msg_hdr->code == VMA_MSG_INIT);
+	assert(size);
+
+	data = (struct vma_msg_init *)msg_hdr;
+	if (size < sizeof(*data)) {
+		return -EBADMSG;
+	}
+
+	/* Message protocol version check */
+	if (data->hdr.ver > VMA_AGENT_VER) {
+		log_error("Protocol message mismatch (VMA_AGENT_VER = %d) errno %d (%s)\n",
+				VMA_AGENT_VER, errno, strerror(errno));
+		return -EBADMSG;
+	}
+
+	/* Allocate memory for this value in this place
+	 * Free this memory during hash_del() call or hash_destroy()
+	 */
+	value = (void *)calloc(1, sizeof(*value));
+	if (NULL == value) {
+		return -ENOMEM;
+	}
+
+	value->pid = data->hdr.pid;
+	value->lib_ver = data->ver;
+	gettimeofday(&value->t_start, NULL);
+
+	value->ht = hash_create(&free, daemon_cfg.opt.max_fid_num);
+	if (NULL == value->ht) {
+		log_error("Failed hash_create() for %d entries errno %d (%s)\n",
+				daemon_cfg.opt.max_fid_num, errno, strerror(errno));
+		free(value);
+		return -EFAULT;
+	}
+
+	if (hash_put(daemon_cfg.ht, value->pid, value) != value) {
+		log_error("Failed hash_put() count: %d size: %d errno %d (%s)\n",
+				hash_count(daemon_cfg.ht), hash_size(daemon_cfg.ht),
+				errno, strerror(errno));
+		hash_destroy(value->ht);
+		free(value);
+		return -EFAULT;
+	}
+
+	log_debug("[%d] put into the storage\n", data->hdr.pid);
+
+	data->hdr.code |= VMA_MSG_ACK;
+	data->hdr.ver = VMA_AGENT_VER;
+	if (0 > sys_sendto(daemon_cfg.sock_fd, data, sizeof(*data), 0,
+			(struct sockaddr *)peeraddr, sizeof(*peeraddr))) {
+		log_error("Failed sendto() message errno %d (%s)\n", errno,
+				strerror(errno));
+	}
+
+	return (sizeof(*data));
+}
+
+static int proc_msg_exit(struct vma_hdr *msg_hdr, size_t size)
+{
+	struct vma_msg_exit *data;
+
+	assert(msg_hdr);
+	assert(msg_hdr->code == VMA_MSG_EXIT);
+	assert(size);
+
+	data = (struct vma_msg_exit *)msg_hdr;
+	if (size < sizeof(*data)) {
+		return -EBADMSG;
+	}
+
+	hash_del(daemon_cfg.ht, data->hdr.pid);
+
+	log_debug("[%d] remove from the storage\n", data->hdr.pid);
+
+	return (sizeof(*data));
+}
+
+static int proc_msg_state(struct vma_hdr *msg_hdr, size_t size)
+{
+	struct vma_msg_state *data;
+	struct store_pid *pid_value;
+	struct store_fid *value;
+
+	assert(msg_hdr);
+	assert(msg_hdr->code == VMA_MSG_STATE);
+	assert(size);
+
+	data = (struct vma_msg_state *)msg_hdr;
+	if (size < sizeof(*data)) {
+		return -EBADMSG;
+	}
+
+	pid_value = hash_get(daemon_cfg.ht, data->hdr.pid);
+	if (NULL == pid_value) {
+		log_error("Failed hash_get() for pid %d errno %d (%s)\n",
+				data->hdr.pid, errno, strerror(errno));
+		return -ENOENT;
+	}
+
+	/* Do not store information about closed socket
+	 * It is a protection for hypothetical scenario when number for new
+	 * sockets are incremented instead of using number
+	 * of closed sockets
+	 */
+	if ((CLOSED == data->state) && (SOCK_STREAM == data->type)) {
+		hash_del(pid_value->ht, data->fid);
+
+		log_debug("[%d] remove fid: %d type: %d state: %s\n",
+				data->hdr.pid, data->fid, data->type,
+				(data->state < (sizeof(tcp_state_str)/sizeof(tcp_state_str[0])) ?
+						tcp_state_str[data->state] : "n/a"));
+		return (sizeof(*data));
+	}
+
+	/* Allocate memory for this value in this place
+	 * Free this memory during hash_del() call or hash_destroy()
+	 */
+	value = (void *)calloc(1, sizeof(*value));
+	if (NULL == value) {
+		return -ENOMEM;
+	}
+
+	value->fid = data->fid;
+	value->type = data->type;
+	value->state = data->state;
+	value->src_ip = data->src_ip;
+	value->dst_ip = data->dst_ip;
+	value->src_port = data->src_port;
+	value->dst_port = data->dst_port;
+
+	if (hash_put(pid_value->ht, value->fid, value) != value) {
+		log_error("Failed hash_put() count: %d size: %d errno %d (%s)\n",
+				hash_count(pid_value->ht), hash_size(pid_value->ht),
+				errno, strerror(errno));
+		free(value);
+		return -EFAULT;
+	}
+
+	log_debug("[%d] update fid: %d type: %d state: %s\n",
+			pid_value->pid, value->fid, value->type,
+			(value->state < (sizeof(tcp_state_str)/sizeof(tcp_state_str[0])) ?
+					tcp_state_str[value->state] : "n/a"));
+
+	return (sizeof(*data));
+}

--- a/tools/daemon/message.c
+++ b/tools/daemon/message.c
@@ -45,7 +45,6 @@
 #include <netinet/tcp.h>
 
 #include "vma/lwip/tcp.h"    /* display TCP states */
-#include "vma/util/agent.h"  /* get message layout format */
 #include "hash.h"
 #include "daemon.h"
 

--- a/tools/daemon/notify.c
+++ b/tools/daemon/notify.c
@@ -1,0 +1,716 @@
+/*
+ * Copyright (c) 2016 Mellanox Technologies, Ltd. All rights reserved.
+ *
+ * This software is available to you under a choice of one of two
+ * licenses.  You may choose to be licensed under the terms of the GNU
+ * General Public License (GPL) Version 2, available from the file
+ * COPYING in the main directory of this source tree, or the
+ * BSD license below:
+ *
+ *     Redistribution and use in source and binary forms, with or
+ *     without modification, are permitted provided that the following
+ *     conditions are met:
+ *
+ *      - Redistributions of source code must retain the above
+ *        copyright notice, this list of conditions and the following
+ *        disclaimer.
+ *
+ *      - Redistributions in binary form must reproduce the above
+ *        copyright notice, this list of conditions and the following
+ *        disclaimer in the documentation and/or other materials
+ *        provided with the distribution.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+ * BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ * ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+
+#ifdef HAVE_CONFIG_H
+#include "config.h"
+#endif
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <stdint.h>
+#include <sys/socket.h>
+#include <netinet/ip.h>
+#include <netinet/tcp.h>
+
+#ifdef HAVE_SYS_INOTIFY_H
+#include <sys/inotify.h>
+#endif
+#ifdef HAVE_SYS_FANOTIFY_H
+#include <sys/fanotify.h>
+#endif
+
+
+#include "vma/util/agent.h"
+#include "hash.h"
+#include "daemon.h"
+
+/* work around kernels which do not have this fix yet:
+ * http://git.kernel.org/cgit/linux/kernel/git/torvalds/linux.git/commit/?id=1e2ee49f7
+ * O_LARGEFILE is usually 0, so hardcode it here
+ */
+#ifndef KERNEL_O_LARGEFILE
+#define KERNEL_O_LARGEFILE 00100000
+#endif
+
+
+struct rst_info {
+	struct sockaddr_in local_addr;
+	struct sockaddr_in remote_addr;
+	uint32_t seqno;
+};
+
+#pragma pack(push, 1)
+struct tcp_msg {
+	struct iphdr  ip;
+	struct tcphdr tcp;
+	uint8_t       data[8192];
+};
+#pragma pack( pop )
+
+#pragma pack(push, 1)
+struct pseudo_header {
+	uint32_t      source_address;
+	uint32_t      dest_address;
+	uint8_t       placeholder;
+	uint8_t       protocol;
+	uint16_t      tcp_length;
+	struct tcphdr tcp;
+} pseudo_header;
+#pragma pack( pop )
+
+
+int open_notify(void);
+void close_notify(void);
+int proc_notify(void);
+
+static int create_raw_socket(void);
+static int send_peer_notification(pid_t pid);
+static int check_process(pid_t pid);
+static unsigned short calc_csum(unsigned short *ptr, int nbytes);
+static int get_seqno(struct rst_info *rst);
+static int send_rst(struct rst_info *rst);
+
+#ifdef HAVE_SYS_INOTIFY_H
+static int open_inotify(void);
+static int proc_inotify(void *buf, int size);
+#endif
+
+#ifdef HAVE_SYS_FANOTIFY_H
+static int open_fanotify(void);
+static int proc_fanotify(void *buf, int size);
+#endif
+
+#if !defined(HAVE_SYS_FANOTIFY_H) && !defined(HAVE_SYS_INOTIFY_H)
+#error neither inotify nor fanotify is supported
+#endif
+
+static int (*do_open_notify)(void) = NULL;
+static int (*do_proc_notify)(void*, int) = NULL;
+
+
+int open_notify(void)
+{
+	int rc = 0;
+
+	/* Set method for processing
+	 * fanotify has the highest priority because it has better
+	 * performance
+	 */
+#if defined(HAVE_SYS_INOTIFY_H)
+	do_open_notify = open_inotify;
+	do_proc_notify = proc_inotify;
+#endif
+
+#if defined(HAVE_SYS_FANOTIFY_H)
+	do_open_notify = open_fanotify;
+	do_proc_notify = proc_fanotify;
+#endif
+
+	rc = create_raw_socket();
+	if (rc < 0) {
+		goto err;
+	}
+	log_debug("setting raw socket ...\n");
+
+	rc = do_open_notify();
+	if (rc < 0) {
+		goto err;
+	}
+
+err:
+	return rc;
+}
+
+void close_notify(void)
+{
+	log_debug("closing raw socket ...\n");
+
+	if (daemon_cfg.notify_fd > 0) {
+		close(daemon_cfg.notify_fd);
+	}
+
+	if (daemon_cfg.raw_fd > 0) {
+		close(daemon_cfg.raw_fd);
+	}
+}
+
+int proc_notify(void)
+{
+	int rc = 0;
+	int len = 0;
+	char msg_recv[4096];
+
+	memset((void *)&msg_recv, 0, sizeof(msg_recv));
+again:
+	/* coverity[tainted_string_argument] */
+	len = read(daemon_cfg.notify_fd, msg_recv, sizeof(msg_recv));
+	if (len <= 0) {
+		if (errno == EINTR) {
+			goto again;
+		}
+		rc = -errno;
+		log_error("Failed read events() errno %d (%s)\n", errno,
+				strerror(errno));
+		goto err;
+	}
+
+	rc = do_proc_notify((void *)msg_recv, len);
+	if (rc < 0) {
+		goto err;
+	}
+
+err:
+	return rc;
+}
+
+static int create_raw_socket(void)
+{
+	int rc = 0;
+	int optval = 1;
+
+	/* Create RAW socket to use for sending RST to peers */
+	daemon_cfg.raw_fd = socket(PF_INET, SOCK_RAW, IPPROTO_TCP);
+	if (daemon_cfg.raw_fd < 0) {
+		/* socket creation failed, may be because of non-root privileges */
+		log_error("Failed to call socket() errno %d (%s)\n", errno,
+				strerror(errno));
+		rc = -errno;
+		goto err;
+	}
+
+	optval = 1;
+	rc = setsockopt(daemon_cfg.raw_fd, IPPROTO_IP, IP_HDRINCL, &optval, sizeof(optval));
+	if (rc < 0) {
+		log_error("Failed to call setsockopt() errno %d (%s)\n", errno,
+				strerror(errno));
+		rc = -errno;
+		goto err;
+	}
+
+err:
+	return rc;
+}
+
+static int send_peer_notification(pid_t pid)
+{
+	int rc = -ESRCH;
+	int wait = 0;
+	struct rst_info rst;
+
+	wait = 100;
+	do {
+		/* Wait for parent process completion */
+		if (!check_process(pid)) {
+			struct store_pid *pid_value = NULL;
+
+			log_debug("[%d] detect abnormal termination\n", pid);
+			pid_value = hash_get(daemon_cfg.ht, pid);
+			if (pid_value) {
+				struct store_fid *fid_value;
+				int i, j;
+
+				j = 0;
+				for (i = 0; (i < hash_size(pid_value->ht)) &&
+							(j < hash_count(pid_value->ht)); i++) {
+					fid_value = hash_enum(pid_value->ht, i);
+					if (NULL == fid_value) {
+						continue;
+					}
+
+					j++;
+					log_debug("[%d] #%d found fid: %d type: %d state: %d\n",
+							pid, j,
+							fid_value->fid, fid_value->type, fid_value->state);
+
+					if (STATE_ESTABLISHED != fid_value->state) {
+						log_debug("[%d] #%d skip fid: %d\n",
+								pid, j, fid_value->fid);
+						continue;
+					}
+
+					log_debug("[%d] #%d process fid: %d\n",
+							pid, j, fid_value->fid);
+
+					/* Notification is based on sending RST packet to all peers
+					 * and looks as spoofing attacks that uses a technique
+					 * called Sequence Number Prediction.
+					 * This actively sends spoofed SYN packets and learns the
+					 *  SeqNo number from the answer. It then sends RST packets.
+					 * P1 - terminated process
+					 * P2 - peer of terminated process
+					 * H  - host (kernel) of terminated process
+					 * 1. [P1] sends SYN to [P2] with source IP of [H].
+					 * 2. [P2] replies to [H] by SYN/ACK.
+					 * 3. There is a possibility of:
+					 *    3.1 [H] should reply to an unknown SYN/ACK by RST.
+					 *    3.2 [P1] sends RST using SeqNo from SYN/ACK.
+					 */
+					rst.local_addr.sin_family = AF_INET;
+					rst.local_addr.sin_port = fid_value->src_port;
+					rst.local_addr.sin_addr.s_addr = fid_value->src_ip;
+					rst.remote_addr.sin_family = AF_INET;
+					rst.remote_addr.sin_port = fid_value->dst_port;
+					rst.remote_addr.sin_addr.s_addr = fid_value->dst_ip;
+					rst.seqno = 1;
+
+					if (0 == get_seqno(&rst)) {
+						send_rst(&rst);
+					}
+				}
+
+				hash_del(daemon_cfg.ht, pid);
+				log_debug("[%d] remove from the storage\n", pid);
+
+				/* Set OK */
+				rc = 0;
+			}
+			break;
+		}
+		usleep(10000);
+	} while (wait--);
+
+	return rc;
+}
+
+static int check_process(pid_t pid)
+{
+	char pid_str[NAME_MAX];
+	char proccess_proc_dir[PATH_MAX];
+	struct stat st;
+
+	sprintf(pid_str, "%d", pid);
+	memset((void*)proccess_proc_dir, 0, sizeof(PATH_MAX));
+	strcat(strcpy(proccess_proc_dir, "/proc/"), pid_str);
+	return stat(proccess_proc_dir, &st) == 0;
+
+}
+
+static unsigned short calc_csum(unsigned short *ptr, int nbytes)
+{
+	register long sum;
+	unsigned short oddbyte;
+	register short answer;
+
+	sum = 0;
+	while (nbytes > 1) {
+		sum += *ptr++;
+		nbytes -= 2;
+	}
+	if (nbytes == 1) {
+		oddbyte = 0;
+		*((u_char*) &oddbyte) = *(u_char*) ptr;
+		sum += oddbyte;
+	}
+
+	sum = (sum >> 16) + (sum & 0xffff);
+	sum = sum + (sum >> 16);
+	answer = (short) ~sum;
+
+	return (answer);
+}
+
+static int get_seqno(struct rst_info *rst)
+{
+	int rc = 0;
+	struct tcp_msg msg;
+	struct pseudo_header pheader;
+
+	/* zero out the packet */
+	memset(&msg, 0, sizeof(msg));
+
+	/* IP Header */
+	msg.ip.version = 4;
+	msg.ip.ihl = 5;
+	msg.ip.tos = 0;
+	msg.ip.tot_len = sizeof(struct iphdr) + sizeof(struct tcphdr);
+	msg.ip.id = 0;
+	msg.ip.frag_off = htons(0x4000);         /* Flag: "Don't Fragment" */
+	msg.ip.ttl = 0x40;
+	msg.ip.protocol = IPPROTO_TCP;
+	msg.ip.check = 0;
+	msg.ip.saddr = rst->local_addr.sin_addr.s_addr;
+	msg.ip.daddr = rst->remote_addr.sin_addr.s_addr;
+
+	/* Calculate IP header checksum */
+	msg.ip.check = calc_csum((unsigned short *)&msg.ip, sizeof(msg.ip));
+
+	/* TCP Header */
+	msg.tcp.source = rst->local_addr.sin_port;
+	msg.tcp.dest = rst->remote_addr.sin_port;
+	msg.tcp.seq = rst->seqno;
+	msg.tcp.ack_seq = 0;
+	msg.tcp.doff = 5;
+	msg.tcp.fin = 0;
+	msg.tcp.syn = 1;
+	msg.tcp.rst = 0;
+	msg.tcp.psh = 0;
+	msg.tcp.ack = 0;
+	msg.tcp.urg = 0;
+	msg.tcp.window = 0;
+	msg.tcp.check = 0;
+	msg.tcp.urg_ptr = 0;
+
+	/* Calculate TCP header checksum */
+	pheader.source_address = msg.ip.saddr;
+	pheader.dest_address = msg.ip.daddr;
+	pheader.placeholder = 0;
+	pheader.protocol = IPPROTO_TCP;
+	pheader.tcp_length = htons(sizeof(struct tcphdr));
+	bcopy((const void *)&msg.tcp, (void *)&pheader.tcp, sizeof(struct tcphdr));
+	msg.tcp.check = calc_csum((unsigned short *)&pheader, sizeof(pheader));
+
+	/* Send invalid SYN packet */
+	rc = sys_sendto(daemon_cfg.raw_fd, &msg, sizeof(msg) - sizeof(msg.data), 0,
+			(struct sockaddr *) &rst->remote_addr, sizeof(rst->remote_addr));
+	if (rc < 0) {
+		goto out;
+	}
+	log_debug("send SYN to: %s\n", sys_addr2str(&rst->remote_addr));
+
+	rc = 0;
+
+	if (daemon_cfg.opt.force_rst) {
+		time_t wait;
+
+		/* Wait for 3s */
+		wait = time(0) + 3;
+		do {
+			struct tcp_msg msg_recv;
+			struct sockaddr_in gotaddr;
+			socklen_t addrlen = sizeof(gotaddr);
+			fd_set readfds;
+			struct timeval tv;
+
+			FD_ZERO(&readfds);
+			FD_SET(daemon_cfg.raw_fd, &readfds);
+
+			tv.tv_sec = 1;
+			tv.tv_usec = 0;
+
+			rc = select(daemon_cfg.raw_fd + 1, &readfds, NULL, NULL, &tv);
+			if (rc == 0) {
+				continue;
+			}
+			memcpy(&gotaddr, &rst->remote_addr, addrlen);
+			memset(&msg_recv, 0, sizeof(msg_recv));
+			rc = recvfrom(daemon_cfg.raw_fd, &msg_recv, sizeof(msg_recv), 0, (struct sockaddr *)&gotaddr, &addrlen);
+			if (rc < 0) {
+				goto out;
+			}
+
+			if ( msg_recv.ip.version == 4 &&
+					msg_recv.ip.ihl == 5 &&
+					msg_recv.ip.protocol == IPPROTO_TCP &&
+					msg_recv.ip.saddr == msg.ip.daddr &&
+					msg_recv.ip.daddr == msg.ip.saddr &&
+					msg_recv.tcp.source == msg.tcp.dest &&
+					msg_recv.tcp.dest == msg.tcp.source &&
+					msg_recv.tcp.ack == 1 ) {
+				rst->seqno = msg_recv.tcp.ack_seq;
+				log_debug("recv SYN|ACK from: %s with SegNo: %d\n",
+						sys_addr2str(&gotaddr), ntohl(rst->seqno));
+				rc = 0;
+				break;
+			}
+		} while (time(0) < wait);
+	}
+
+out:
+	return rc;
+}
+
+static int send_rst(struct rst_info *rst) {
+	int rc = 0;
+	struct tcp_msg msg;
+	struct pseudo_header pheader;
+
+	/* zero out the packet */
+	memset(&msg, 0, sizeof(msg));
+
+	/* IP Header */
+	msg.ip.version = 4;
+	msg.ip.ihl = 5;
+	msg.ip.tos = 0;
+	msg.ip.tot_len = sizeof(struct iphdr) + sizeof(struct tcphdr);
+	msg.ip.id = 0;
+	msg.ip.frag_off = htons(0x4000);         /* Flag: "Don't Fragment" */
+	msg.ip.ttl = 0x40;
+	msg.ip.protocol = IPPROTO_TCP;
+	msg.ip.check = 0;
+	msg.ip.saddr = rst->local_addr.sin_addr.s_addr;
+	msg.ip.daddr = rst->remote_addr.sin_addr.s_addr;
+
+	/* Calculate IP header checksum */
+	msg.ip.check = calc_csum((unsigned short *)&msg.ip, sizeof(msg.ip));
+
+	/* TCP Header */
+	msg.tcp.source = rst->local_addr.sin_port;
+	msg.tcp.dest = rst->remote_addr.sin_port;
+	msg.tcp.seq = rst->seqno;
+	msg.tcp.ack_seq = 0;
+	msg.tcp.doff = 5;
+	msg.tcp.fin = 0;
+	msg.tcp.syn = 0;
+	msg.tcp.rst = 1;
+	msg.tcp.psh = 0;
+	msg.tcp.ack = 0;
+	msg.tcp.urg = 0;
+	msg.tcp.window = 0;
+	msg.tcp.check = 0;
+	msg.tcp.urg_ptr = 0;
+
+	/* Calculate TCP header checksum */
+	pheader.source_address = msg.ip.saddr;
+	pheader.dest_address = msg.ip.daddr;
+	pheader.placeholder = 0;
+	pheader.protocol = IPPROTO_TCP;
+	pheader.tcp_length = htons(sizeof(struct tcphdr));
+	bcopy((const void *)&msg.tcp, (void *)&pheader.tcp, sizeof(struct tcphdr));
+	msg.tcp.check = calc_csum((unsigned short *)&pheader, sizeof(pheader));
+
+	rc = sys_sendto(daemon_cfg.raw_fd, &msg, sizeof(msg) - sizeof(msg.data), 0,
+			(struct sockaddr *) &rst->remote_addr, sizeof(rst->remote_addr));
+	if (rc < 0) {
+		goto out;
+	}
+	log_debug("send RST to: %s\n", sys_addr2str(&rst->remote_addr));
+
+	rc = 0;
+
+out:
+	return rc;
+}
+
+#ifdef HAVE_SYS_FANOTIFY_H
+static int open_fanotify(void)
+{
+	int rc = 0;
+
+	log_debug("selected fanotify ...\n");
+
+	if ((daemon_cfg.notify_fd = fanotify_init(0, KERNEL_O_LARGEFILE)) < 0) {
+		log_error("Cannot initialize fanotify_init() errno %d (%s)\n", errno,
+				strerror(errno));
+		rc = -errno;
+		goto err;
+	}
+
+	rc = fanotify_mark(daemon_cfg.notify_fd, FAN_MARK_ADD,
+			FAN_CLOSE | FAN_EVENT_ON_CHILD, AT_FDCWD, VMA_AGENT_PATH);
+	if (rc < 0) {
+		rc = -errno;
+		log_error("Failed to add watch for directory %s errno %d (%s)\n",
+				daemon_cfg.notify_dir, errno, strerror(errno));
+		goto err;
+	}
+
+err:
+	return rc;
+}
+
+static int proc_fanotify(void *buffer, int nbyte)
+{
+	int rc = 0;
+	int len = nbyte;
+	struct fanotify_event_metadata *data = (struct fanotify_event_metadata *)buffer;
+
+	while (FAN_EVENT_OK(data, len)) {
+
+		/* Check that run-time and compile-time structures match */
+		if (data->vers != FANOTIFY_METADATA_VERSION) {
+			rc = -EPROTO;
+			log_error("Mismatch of fanotify metadata version\n");
+			goto err;
+		}
+		/* Current check is based on monitoring special pid file events
+		 * This file is created on library startup
+		 * Event about closing this file should come if process exits
+		 * either after work completion or as result of unexpected termination
+		 */
+		if ((data->mask & FAN_CLOSE_WRITE || data->mask & FAN_CLOSE_NOWRITE) &&
+				hash_get(daemon_cfg.ht, data->pid)) {
+			char buf[PATH_MAX];
+			char pathname[PATH_MAX];
+
+			memset(buf, 0, sizeof(buf));
+			memset(pathname, 0, sizeof(pathname));
+
+			rc = snprintf(buf, sizeof(buf) - 1, "/proc/self/fd/%d", data->fd);
+			if ((rc < 0 ) || (rc == (sizeof(buf) - 1) )) {
+				rc = -ENOMEM;
+				log_error("Cannot read process name errno %d (%s)\n", errno,
+					strerror(errno));
+				goto err;
+			}
+			rc = readlink(buf, pathname, sizeof(pathname) - 1);
+			if (rc < 0) {
+				rc = -ENOMEM;
+				log_error("Cannot read process name errno %d (%s)\n", errno,
+					strerror(errno));
+				goto err;
+			}
+
+			log_debug("getting event ([0x%x] pid: %d fd: %d name: %s)\n",
+					data->mask, data->pid, data->fd, pathname);
+
+			rc = snprintf(buf, sizeof(buf) - 1, "%s/%s.%d.pid",
+					VMA_AGENT_PATH, VMA_AGENT_BASE_NAME, data->pid);
+			if ((rc < 0 ) || (rc == (sizeof(buf) - 1) )) {
+				rc = -ENOMEM;
+				log_error("failed allocate pid file errno %d (%s)\n", errno,
+					strerror(errno));
+				goto err;
+			}
+
+			/* Process event related pid file only */
+			rc = 0;
+			if (!strcmp(buf, pathname)) {
+				log_debug("[%d] check the event\n", data->pid);
+
+				/* Check if termination is unexpected and send RST to peers
+				 * Return status should be 0 in case we send RST and
+				 * nonzero in case we decide that processes exited accurately
+				 * or some internal error happens during RST send
+				 */
+				rc = send_peer_notification(data->pid);
+				if (0 == rc) {
+					/* Cleanup unexpected termination */
+					log_debug("[%d] cleanup after unexpected termination\n", data->pid);
+					unlink(pathname);
+					if (snprintf(pathname, sizeof(pathname) - 1, "%s/%s.%d.sock",
+							VMA_AGENT_PATH, VMA_AGENT_BASE_NAME, data->pid) > 0) {
+						unlink(pathname);
+					}
+				} else if (-ESRCH == rc) {
+					/* No need in peer notification */
+					log_debug("[%d] no need in peer notification\n", data->pid);
+					rc = 0;
+				}
+			} else {
+				log_debug("[%d] skip the event\n", data->pid);
+			}
+		}
+
+		/* Close the file descriptor of the event */
+		close(data->fd);
+		data = FAN_EVENT_NEXT(data, len);
+	}
+
+err:
+	return rc;
+}
+#endif
+
+#ifdef HAVE_SYS_INOTIFY_H
+static int open_inotify(void)
+{
+	int rc = 0;
+
+	log_debug("selected inotify ...\n");
+
+	if ((daemon_cfg.notify_fd = inotify_init()) < 0) {
+		log_error("Cannot initialize inotify_init() errno %d (%s)\n", errno,
+				strerror(errno));
+		rc = -errno;
+		goto err;
+	}
+
+	rc = inotify_add_watch(daemon_cfg.notify_fd,
+			VMA_AGENT_PATH,
+			IN_CLOSE_WRITE | IN_CLOSE_NOWRITE | IN_DELETE);
+	if (rc < 0) {
+		rc = -errno;
+		log_error("Failed to add watch for directory %s errno %d (%s)\n",
+				daemon_cfg.notify_dir, errno, strerror(errno));
+		goto err;
+	}
+
+err:
+	return rc;
+}
+
+static int proc_inotify(void *buffer, int nbyte)
+{
+	int rc = 0;
+	struct inotify_event *data = (struct inotify_event *)buffer;
+
+	while ((uintptr_t)data < ((uintptr_t)buffer + nbyte)) {
+		pid_t pid;
+		char buf[PATH_MAX];
+
+		memset(buf, 0, sizeof(buf));
+
+		/* Monitor only events from files */
+		if ((data->len > 0) &&
+				!(data->mask & IN_ISDIR ) &&
+				(0 < sscanf(data->name, VMA_AGENT_BASE_NAME ".%d.pid", &pid))) {
+
+			log_debug("getting event ([0x%x] pid: %d name: %s)\n",
+					data->mask, pid, data->name);
+
+			/* Process event related pid file only */
+			rc = 0;
+			if (hash_get(daemon_cfg.ht, pid)) {
+				log_debug("[%d] check the event\n", pid);
+
+				/* Check if termination is unexpected and send RST to peers
+				 * Return status should be 0 in case we send RST and
+				 * nonzero in case we decide that processes exited accurately
+				 * or some internal error happens during RST send
+				 */
+				rc = send_peer_notification(pid);
+				if (0 == rc) {
+					/* Cleanup unexpected termination */
+					log_debug("[%d] cleanup after unexpected termination\n", pid);
+					unlink(buf);
+					if (snprintf(buf, sizeof(buf) - 1, "%s/%s.%d.sock",
+							VMA_AGENT_PATH, VMA_AGENT_BASE_NAME, pid) > 0) {
+						unlink(buf);
+					}
+				} else if (-ESRCH == rc) {
+					/* No need in peer notification */
+					log_debug("[%d] no need in peer notification\n", pid);
+					rc = 0;
+				}
+			} else {
+				log_debug("[%d] skip the event\n", pid);
+			}
+		}
+
+		/* Move to the next event */
+		data =  (struct inotify_event *)((uintptr_t)data + sizeof(*data) + data->len);
+	}
+
+	return rc;
+}
+#endif

--- a/tools/daemon/notify.c
+++ b/tools/daemon/notify.c
@@ -50,7 +50,6 @@
 #endif
 
 
-#include "vma/util/agent.h"
 #include "hash.h"
 #include "daemon.h"
 

--- a/tools/daemon/store.c
+++ b/tools/daemon/store.c
@@ -1,0 +1,75 @@
+/*
+ * Copyright (c) 2016 Mellanox Technologies, Ltd. All rights reserved.
+ *
+ * This software is available to you under a choice of one of two
+ * licenses.  You may choose to be licensed under the terms of the GNU
+ * General Public License (GPL) Version 2, available from the file
+ * COPYING in the main directory of this source tree, or the
+ * BSD license below:
+ *
+ *     Redistribution and use in source and binary forms, with or
+ *     without modification, are permitted provided that the following
+ *     conditions are met:
+ *
+ *      - Redistributions of source code must retain the above
+ *        copyright notice, this list of conditions and the following
+ *        disclaimer.
+ *
+ *      - Redistributions in binary form must reproduce the above
+ *        copyright notice, this list of conditions and the following
+ *        disclaimer in the documentation and/or other materials
+ *        provided with the distribution.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+ * BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ * ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+
+#ifdef HAVE_CONFIG_H
+#include "config.h"
+#endif
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <stdint.h>
+#include <sys/time.h>
+
+
+#include "hash.h"
+#include "daemon.h"
+
+
+int open_store(void);
+void close_store(void);
+
+static void free_store_pid(void *ptr);
+
+
+int open_store(void)
+{
+	daemon_cfg.ht = hash_create(&free_store_pid, daemon_cfg.opt.max_pid_num);
+
+	return (NULL == daemon_cfg.ht ? -EFAULT : 0);
+}
+
+void close_store(void)
+{
+	hash_destroy(daemon_cfg.ht);
+}
+
+static void free_store_pid(void *ptr)
+{
+	struct store_pid *value;
+
+	if (ptr) {
+		value = (struct store_pid *)ptr;
+		hash_destroy(value->ht);
+		free(value);
+	}
+}


### PR DESCRIPTION
Introduced functionality that notifies a peer about unexpected
termination of one of the processes.
This scenario is called a “half-open connection” because one side
realizes the connection was lost but the other side believes it is
still active.
Brief implementation overview:
- Start VMA daemon with root privileges and open UNIX datagram socket for listening;
- Every VMA launch notifies the daemon about new process;
- VMA process sends packet with data in case TCP offloaded socket state change;
- Daemon collects information about TCP connections from all VMA processes;
- Daemon detects abnormal close using fanotify() technique;
- Daemon uses raw socket packet to send RST to peers using collected information;