### PR TITLE
issue: 911076 Fix rcvmsg failure with MSG_VMA_ZCOPY_FORCE on OS socket

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -432,10 +432,10 @@ Default value is 0
 
 VMA_RX_UDP_POLL_OS_RATIO
 The above param will define the ratio between VMA CQ poll and OS FD poll.
-This will result in a signle poll of the not-offloaded sockets every
-VMA_RX_UDP_POLL_OS_RATIO offlaoded socket (CQ) polls. No matter if the CQ poll 
+This will result in a single poll of the not-offloaded sockets every
+VMA_RX_UDP_POLL_OS_RATIO offloaded socket (CQ) polls. No matter if the CQ poll 
 was a hit or miss. No matter if the socket is blocking or non-blocking.
-When disabled, only offlaoded sockets are polled.
+When disabled, only offloaded sockets are polled.
 This parameter replaces the two old parameters: VMA_RX_POLL_OS_RATIO and 
 VMA_RX_SKIP_OS
 Disable with 0

--- a/src/vma/sock/pipeinfo.cpp
+++ b/src/vma/sock/pipeinfo.cpp
@@ -198,7 +198,7 @@ ssize_t pipeinfo::rx(const rx_call_t call_type, iovec* p_iov, ssize_t sz_iov,
                      int* p_flags, sockaddr *__from, socklen_t *__fromlen, struct msghdr *__msg)
 {
 	pi_logfunc("");
-	ssize_t ret = socket_fd_api::rx_os(call_type, p_iov, sz_iov, p_flags, __from, __fromlen, __msg);
+	ssize_t ret = socket_fd_api::rx_os(call_type, p_iov, sz_iov, *p_flags, __from, __fromlen, __msg);
 	save_stats_rx_os(ret);
 	return ret;
 }

--- a/src/vma/sock/socket_fd_api.cpp
+++ b/src/vma/sock/socket_fd_api.cpp
@@ -255,7 +255,7 @@ void socket_fd_api::statistics_print(vlog_levels_t log_level /* = VLOG_DEBUG */)
 #endif
 
 ssize_t socket_fd_api::rx_os(const rx_call_t call_type, iovec* p_iov,
-			     ssize_t sz_iov, int* p_flags, sockaddr *__from,
+			     ssize_t sz_iov, const int flags, sockaddr *__from,
 			     socklen_t *__fromlen, struct msghdr *__msg)
 {
 	errno = 0;
@@ -271,16 +271,16 @@ ssize_t socket_fd_api::rx_os(const rx_call_t call_type, iovec* p_iov,
 	case RX_RECV:
 		__log_info_func("calling os receive with orig recv");
 		return orig_os_api.recv(m_fd, p_iov[0].iov_base, p_iov[0].iov_len,
-		                        *p_flags);
+		                        flags);
 
 	case RX_RECVFROM:
 		__log_info_func("calling os receive with orig recvfrom");
 		return orig_os_api.recvfrom(m_fd, p_iov[0].iov_base, p_iov[0].iov_len,
-		                            *p_flags, __from, __fromlen);
+		                            flags, __from, __fromlen);
 
 	case RX_RECVMSG: {
 		__log_info_func("calling os receive with orig recvmsg");
-		return orig_os_api.recvmsg(m_fd, __msg, *p_flags);
+		return orig_os_api.recvmsg(m_fd, __msg, flags);
 		}
 	}
 	return (ssize_t) -1;

--- a/src/vma/sock/socket_fd_api.h
+++ b/src/vma/sock/socket_fd_api.h
@@ -230,7 +230,7 @@ protected:
 
 	// Calling OS receive
 	ssize_t rx_os(const rx_call_t call_type, iovec* p_iov, ssize_t sz_iov,
-		      int* p_flags, sockaddr *__from, socklen_t *__fromlen, struct msghdr *__msg);
+		      const int flags, sockaddr *__from, socklen_t *__fromlen, struct msghdr *__msg);
 
 
 private:

--- a/src/vma/sock/sockinfo_tcp.cpp
+++ b/src/vma/sock/sockinfo_tcp.cpp
@@ -1489,7 +1489,7 @@ ssize_t sockinfo_tcp::rx(const rx_call_t call_type, iovec* p_iov, ssize_t sz_iov
 #ifdef VMA_TIME_MEASURE
 		INC_GO_TO_OS_RX_COUNT;
 #endif
-		ret = socket_fd_api::rx_os(call_type, p_iov, sz_iov, &in_flags, __from, __fromlen, __msg);
+		ret = socket_fd_api::rx_os(call_type, p_iov, sz_iov, in_flags, __from, __fromlen, __msg);
 		save_stats_rx_os(ret);
 		return ret;
 	}

--- a/src/vma/sock/sockinfo_udp.cpp
+++ b/src/vma/sock/sockinfo_udp.cpp
@@ -1328,6 +1328,8 @@ wait:
 	 */
 os:
 	if (in_flags & MSG_VMA_ZCOPY_FORCE) {
+		// Enable the next non-blocked read to check the OS 
+		m_rx_udp_poll_os_ratio_counter = m_n_sysvar_rx_udp_poll_os_ratio;
 		errno = EIO;
 		ret = -1;
 		goto out;
@@ -1338,7 +1340,8 @@ os:
 #endif
 
 	in_flags &= ~MSG_VMA_ZCOPY;
-	ret = socket_fd_api::rx_os(call_type, p_iov, sz_iov, &in_flags, __from, __fromlen, __msg);
+	ret = socket_fd_api::rx_os(call_type, p_iov, sz_iov, in_flags, __from, __fromlen, __msg);
+	*p_flags = in_flags;
 	save_stats_rx_os(ret);
 	if (ret > 0) {
 		// This will cause the next non-blocked read to check the OS again.


### PR DESCRIPTION
1. Enable OS socket read following a failed OS call with MSG_VMA_ZCOPY_FORCE
2. Remove MSG_VMA_ZCOPY bit flag when calling the OS

Signed-off-by: Ophir Munk <ophirmu@mellanox.com>