### PR TITLE
issue: 825055 "Dummy Send" for improving low msg rate latency

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -353,6 +353,22 @@ AC_TRY_LINK(
   AC_MSG_RESULT([no])
 ])
 
+AC_MSG_CHECKING([if IBV_EXP_WR_NOP is defined])
+AC_TRY_LINK(
+#include <infiniband/verbs_exp.h>
+,
+[
+  int access = (int)IBV_EXP_WR_NOP;
+  access = access;
+],
+[
+  AC_MSG_RESULT([yes])
+  AC_DEFINE(DEFINED_IBV_EXP_WR_NOP, 1, [Define to 1 if IBV_EXP_WR_NOP is defined])
+],
+[
+  AC_MSG_RESULT([no])
+])
+
 AC_MSG_CHECKING([if IBV_EXP_ACCESS_ALLOCATE_MR is defined])
 AC_TRY_LINK(
 #include <infiniband/verbs_exp.h>

--- a/src/stats/stats_printer.cpp
+++ b/src/stats/stats_printer.cpp
@@ -234,10 +234,6 @@ void print_full_stats(socket_stats_t* p_si_stats, mc_grp_info_t* p_mc_grp_info, 
 		fprintf(filename, "Tx Dummy messages : %d\n", p_si_stats->counters.n_tx_dummy);
 		b_any_activiy = true;
 	}
-	if (p_si_stats->counters.n_tx_dummy_drops) {
-		fprintf(filename, "Tx Dummy messages dropped: %d\n", p_si_stats->counters.n_tx_dummy_drops);
-		b_any_activiy = true;
-	}
 	if (p_si_stats->counters.n_rx_bytes || p_si_stats->counters.n_rx_packets || p_si_stats->counters.n_rx_eagain || p_si_stats->counters.n_rx_errors)
 	{
 		fprintf(filename, "Rx Offload: %u KB / %u / %u / %u [bytes/packets/eagains/errors]%s\n",  p_si_stats->counters.n_rx_bytes/BYTES_TRAFFIC_UNIT,  p_si_stats->counters.n_rx_packets, p_si_stats->counters.n_rx_eagain,  p_si_stats->counters.n_rx_errors, post_fix);

--- a/src/stats/stats_printer.cpp
+++ b/src/stats/stats_printer.cpp
@@ -230,6 +230,14 @@ void print_full_stats(socket_stats_t* p_si_stats, mc_grp_info_t* p_mc_grp_info, 
 		fprintf(filename, "Tx OS info: %u KB / %u / %u / %u [bytes/packets/eagains/errors]%s\n",  p_si_stats->counters.n_tx_os_bytes/BYTES_TRAFFIC_UNIT,  p_si_stats->counters.n_tx_os_packets, p_si_stats->counters.n_tx_os_eagain, p_si_stats->counters.n_tx_os_errors, post_fix);
 		b_any_activiy = true;
 	}
+	if (p_si_stats->counters.n_tx_dummy) {
+		fprintf(filename, "Tx Dummy messages : %d\n", p_si_stats->counters.n_tx_dummy);
+		b_any_activiy = true;
+	}
+	if (p_si_stats->counters.n_tx_dummy_drops) {
+		fprintf(filename, "Tx Dummy messages dropped: %d\n", p_si_stats->counters.n_tx_dummy_drops);
+		b_any_activiy = true;
+	}
 	if (p_si_stats->counters.n_rx_bytes || p_si_stats->counters.n_rx_packets || p_si_stats->counters.n_rx_eagain || p_si_stats->counters.n_rx_errors)
 	{
 		fprintf(filename, "Rx Offload: %u KB / %u / %u / %u [bytes/packets/eagains/errors]%s\n",  p_si_stats->counters.n_rx_bytes/BYTES_TRAFFIC_UNIT,  p_si_stats->counters.n_rx_packets, p_si_stats->counters.n_rx_eagain,  p_si_stats->counters.n_rx_errors, post_fix);

--- a/src/vma/dev/qp_mgr.cpp
+++ b/src/vma/dev/qp_mgr.cpp
@@ -127,10 +127,7 @@ int qp_mgr::configure(struct ibv_comp_channel* p_rx_comp_event_channel)
 
 	// Check device capabilities for dummy send support
 #ifdef DEFINED_IBV_EXP_WR_NOP
-	struct ibv_exp_device_attr device_attr;
-	memset(&device_attr, 0, sizeof(device_attr));
-	device_attr.comp_mask = IBV_EXP_DEVICE_ATTR_EXP_CAP_FLAGS;
-	m_hw_dummy_send_support = !ibv_exp_query_device(m_p_ib_ctx_handler->get_ibv_context() ,&device_attr) && (device_attr.exp_device_cap_flags & IBV_EXP_DEVICE_NOP);
+	m_hw_dummy_send_support = m_p_ib_ctx_handler->get_ibv_device_attr().exp_device_cap_flags & IBV_EXP_DEVICE_NOP;
 #endif
 	qp_logdbg("HW Dummy send support for QP = %d", m_hw_dummy_send_support);
 

--- a/src/vma/dev/qp_mgr.h
+++ b/src/vma/dev/qp_mgr.h
@@ -119,6 +119,10 @@ public:
 	ib_ctx_handler* 	get_ib_ctx_handler() const { return m_p_ib_ctx_handler; }
 	uint32_t		get_rx_max_wr_num();
 
+	// This function can be replaced with a parameter during ring creation.
+	// chain of calls may serve as cache warm for dummy send feature.
+	inline bool		get_hw_dummy_send_support() {return m_hw_dummy_send_support; }
+
 	// create a AH cleaner object which will be linked to the following post send (if any)
 	void                    ah_cleanup(struct ibv_ah* ah);
 
@@ -146,6 +150,8 @@ protected:
 
 	uint32_t 		m_rx_num_wr;
 	uint32_t 		m_tx_num_wr;
+
+	bool  			m_hw_dummy_send_support;
 
 	const uint32_t 		m_n_sysvar_rx_num_wr_to_post_recv;
 	const uint32_t 		m_n_sysvar_tx_num_wr_to_signal;

--- a/src/vma/dev/ring.h
+++ b/src/vma/dev/ring.h
@@ -281,6 +281,7 @@ public:
 	int			get_num_resources() const { return m_n_num_resources; };
 	int*			get_rx_channel_fds() const { return m_p_n_rx_channel_fds; };
 	virtual int		get_max_tx_inline() = 0;
+	virtual bool 		get_hw_dummy_send_support(ring_user_id_t id, vma_ibv_send_wr* p_send_wqe) = 0;
 	virtual int		request_notification(cq_type_t cq_type, uint64_t poll_sn) = 0;
 	virtual bool		reclaim_recv_buffers(descq_t *rx_reuse) = 0;
 	virtual int		drain_and_proccess(cq_type_t cq_type) = 0;

--- a/src/vma/dev/ring_bond.cpp
+++ b/src/vma/dev/ring_bond.cpp
@@ -239,7 +239,8 @@ void ring_bond::send_lwip_buffer(ring_user_id_t id, vma_ibv_send_wr* p_send_wqe,
 	}
 }
 
-bool ring_bond::get_hw_dummy_send_support(ring_user_id_t id, vma_ibv_send_wr* p_send_wqe) {
+bool ring_bond::get_hw_dummy_send_support(ring_user_id_t id, vma_ibv_send_wr* p_send_wqe)
+{
 	mem_buf_desc_t* p_mem_buf_desc = (mem_buf_desc_t*)(p_send_wqe->wr_id);
 	ring_simple* active_ring = m_active_rings[id];
 

--- a/src/vma/dev/ring_bond.cpp
+++ b/src/vma/dev/ring_bond.cpp
@@ -239,6 +239,22 @@ void ring_bond::send_lwip_buffer(ring_user_id_t id, vma_ibv_send_wr* p_send_wqe,
 	}
 }
 
+bool ring_bond::get_hw_dummy_send_support(ring_user_id_t id, vma_ibv_send_wr* p_send_wqe) {
+	mem_buf_desc_t* p_mem_buf_desc = (mem_buf_desc_t*)(p_send_wqe->wr_id);
+	ring_simple* active_ring = m_active_rings[id];
+
+	if (likely(active_ring && p_mem_buf_desc->p_desc_owner == active_ring)) {
+		return active_ring->get_hw_dummy_send_support(id, p_send_wqe);
+	} else {
+		active_ring = m_bond_rings[id];
+		if (likely(p_mem_buf_desc->p_desc_owner == active_ring)) {
+			return active_ring->get_hw_dummy_send_support(id, p_send_wqe);
+		} else {
+			return false;
+		}
+	}
+}
+
 int ring_bond::get_max_tx_inline()
 {
 	return m_min_devices_tx_inline;

--- a/src/vma/dev/ring_bond.h
+++ b/src/vma/dev/ring_bond.h
@@ -65,6 +65,7 @@ public:
 	virtual bool		is_active_member(mem_buf_desc_owner* rng, ring_user_id_t id);
 	virtual ring_user_id_t	generate_id();
 	virtual ring_user_id_t	generate_id(const address_t src_mac, const address_t dst_mac, uint16_t eth_proto, uint16_t encap_proto, uint32_t src_ip, uint32_t dst_ip, uint16_t src_port, uint16_t dst_port);
+	virtual bool 		get_hw_dummy_send_support(ring_user_id_t id, vma_ibv_send_wr* p_send_wqe);
 
 protected:
 	virtual void		create_slave_list(in_addr_t local_if, ring_resource_creation_info_t* p_ring_info, bool active_slaves[], uint16_t partition) = 0;

--- a/src/vma/dev/ring_simple.cpp
+++ b/src/vma/dev/ring_simple.cpp
@@ -1182,6 +1182,14 @@ inline int ring_simple::send_buffer(vma_ibv_send_wr* p_send_wqe, bool b_block)
 	return ret;
 }
 
+bool ring_simple::get_hw_dummy_send_support(ring_user_id_t id, vma_ibv_send_wr* p_send_wqe)
+{
+	NOT_IN_USE(id);
+	NOT_IN_USE(p_send_wqe);
+
+	return m_p_qp_mgr->get_hw_dummy_send_support();
+}
+
 void ring_simple::send_ring_buffer(ring_user_id_t id, vma_ibv_send_wr* p_send_wqe, bool b_block)
 {
 	NOT_IN_USE(id);

--- a/src/vma/dev/ring_simple.h
+++ b/src/vma/dev/ring_simple.h
@@ -75,6 +75,7 @@ public:
 	virtual ring_user_id_t	generate_id();
 	virtual ring_user_id_t	generate_id(const address_t src_mac, const address_t dst_mac, uint16_t eth_proto, uint16_t encap_proto, uint32_t src_ip, uint32_t dst_ip, uint16_t src_port, uint16_t dst_port);
 	transport_type_t	get_transport_type() const { return m_transport_type; }
+	virtual bool 		get_hw_dummy_send_support(ring_user_id_t id, vma_ibv_send_wr* p_send_wqe);
 
 	friend class cq_mgr;
 	friend class qp_mgr;

--- a/src/vma/dev/wqe_send_handler.h
+++ b/src/vma/dev/wqe_send_handler.h
@@ -47,6 +47,16 @@ public:
 	void init_wqe(vma_ibv_send_wr &wqe_to_init, struct ibv_sge* sge_list, uint32_t num_sge);
 	void init_inline_wqe(vma_ibv_send_wr &wqe_to_init, struct ibv_sge* sge_list, uint32_t num_sge);
 
+	inline vma_ibv_wr_opcode set_dummy_opcode(vma_ibv_send_wr &wqe) {
+		vma_ibv_wr_opcode last_opcode = vma_send_wr_opcode(wqe);
+		vma_send_wr_opcode(wqe) = VMA_IBV_WR_NOP;
+		return last_opcode;
+	}
+
+	inline void unset_dummy_opcode(vma_ibv_send_wr &wqe, vma_ibv_wr_opcode opcode) {
+		vma_send_wr_opcode(wqe) = opcode;
+	}
+
 #ifndef VMA_NO_HW_CSUM
 	inline void  enable_hw_csum (vma_ibv_send_wr &send_wqe) { vma_send_wr_send_flags(send_wqe) |= VMA_IBV_SEND_IP_CSUM; }
 	inline void disable_hw_csum (vma_ibv_send_wr &send_wqe) { vma_send_wr_send_flags(send_wqe) &= ~VMA_IBV_SEND_IP_CSUM; }

--- a/src/vma/dev/wqe_send_handler.h
+++ b/src/vma/dev/wqe_send_handler.h
@@ -47,14 +47,10 @@ public:
 	void init_wqe(vma_ibv_send_wr &wqe_to_init, struct ibv_sge* sge_list, uint32_t num_sge);
 	void init_inline_wqe(vma_ibv_send_wr &wqe_to_init, struct ibv_sge* sge_list, uint32_t num_sge);
 
-	inline vma_ibv_wr_opcode set_dummy_opcode(vma_ibv_send_wr &wqe) {
+	inline vma_ibv_wr_opcode set_opcode(vma_ibv_send_wr &wqe, vma_ibv_wr_opcode opcode) {
 		vma_ibv_wr_opcode last_opcode = vma_send_wr_opcode(wqe);
-		vma_send_wr_opcode(wqe) = VMA_IBV_WR_NOP;
-		return last_opcode;
-	}
-
-	inline void unset_dummy_opcode(vma_ibv_send_wr &wqe, vma_ibv_wr_opcode opcode) {
 		vma_send_wr_opcode(wqe) = opcode;
+		return last_opcode;
 	}
 
 #ifndef VMA_NO_HW_CSUM

--- a/src/vma/lwip/tcp.h
+++ b/src/vma/lwip/tcp.h
@@ -51,7 +51,7 @@ void register_sys_now(sys_now_fn fn);
 extern u16_t lwip_tcp_mss;
 
 #if LWIP_3RD_PARTY_L3
-typedef err_t (*ip_output_fn)(struct pbuf *p, void* p_conn, int is_rexmit);
+typedef err_t (*ip_output_fn)(struct pbuf *p, void* p_conn, int is_rexmit, u8_t is_dummy);
           
 void register_ip_output(ip_output_fn fn);
 
@@ -506,7 +506,7 @@ err_t            tcp_shutdown(struct tcp_pcb *pcb, int shut_rx, int shut_tx);
 #define TCP_WRITE_FLAG_MORE 0x02
 
 err_t            tcp_write   (struct tcp_pcb *pcb, const void *dataptr, u32_t len,
-                              u8_t apiflags);
+                              u8_t apiflags, u8_t is_dummy);
 
 void             tcp_setprio (struct tcp_pcb *pcb, u8_t prio);
 

--- a/src/vma/lwip/tcp_impl.h
+++ b/src/vma/lwip/tcp_impl.h
@@ -301,8 +301,11 @@ struct tcp_seg {
 #define TF_SEG_DATA_CHECKSUMMED (u8_t)0x04U /* ALL data (not the header) is
                                                checksummed into 'chksum' */
 #define TF_SEG_OPTS_WNDSCALE	(u8_t)0x08U /* Include window scaling option */
+#define TF_SEG_OPTS_DUMMY_MSG	(u8_t)0x010U /* Include dummy send option */
   struct tcp_hdr *tcphdr;  /* the TCP header */
 };
+
+#define LWIP_IS_DUMMY_SEGMENT(seg) (seg->flags & TF_SEG_OPTS_DUMMY_MSG)
 
 #if LWIP_TCP_TIMESTAMPS
 #define LWIP_TCP_OPT_LEN_TS     10

--- a/src/vma/lwip/tcp_impl.h
+++ b/src/vma/lwip/tcp_impl.h
@@ -301,7 +301,7 @@ struct tcp_seg {
 #define TF_SEG_DATA_CHECKSUMMED (u8_t)0x04U /* ALL data (not the header) is
                                                checksummed into 'chksum' */
 #define TF_SEG_OPTS_WNDSCALE	(u8_t)0x08U /* Include window scaling option */
-#define TF_SEG_OPTS_DUMMY_MSG	(u8_t)0x010U /* Include dummy send option */
+#define TF_SEG_OPTS_DUMMY_MSG	(u8_t)0x10U /* Include dummy send option */
   struct tcp_hdr *tcphdr;  /* the TCP header */
 };
 

--- a/src/vma/lwip/tcp_out.c
+++ b/src/vma/lwip/tcp_out.c
@@ -510,7 +510,7 @@ tcp_write(struct tcp_pcb *pcb, const void *arg, u32_t len, u8_t apiflags, u8_t i
     u16_t max_len = mss_local - optlen;
     u16_t seglen = left > max_len ? max_len : left;
 
-    LWIP_ERROR("tcp_write: dummy packet should not be split", !(is_dummy && pos), break;);
+    LWIP_ASSERT("tcp_write: dummy packet should not be split", !(is_dummy && pos));
 
     if (apiflags & TCP_WRITE_FLAG_COPY) {
       /* If copy is set, memory should be allocated and data copied
@@ -1045,7 +1045,7 @@ tcp_output(struct tcp_pcb *pcb)
   while (seg){
     /* Split the segment in case of a small window */
     if (( pcb->flags & (TF_NODELAY | TF_INFR)) && (wnd) && ((seg->len + seg->seqno - pcb->lastack) > wnd)) {
-      LWIP_ERROR("tcp_output: no window for dummy packet", !LWIP_IS_DUMMY_SEGMENT(seg), break;);
+      LWIP_ASSERT("tcp_output: no window for dummy packet", !LWIP_IS_DUMMY_SEGMENT(seg));
       tcp_split_segment(pcb, seg, wnd);
     }
 
@@ -1088,7 +1088,7 @@ tcp_output(struct tcp_pcb *pcb)
 
        // Send ack now if the packet is a dummy packet
        if (LWIP_IS_DUMMY_SEGMENT(seg) && (pcb->flags & (TF_ACK_DELAY | TF_ACK_NOW))) {
-      	  tcp_send_empty_ack(pcb);
+         tcp_send_empty_ack(pcb);
        }
 
        if (get_tcp_state(pcb) != SYN_SENT) {

--- a/src/vma/lwip/tcp_out.c
+++ b/src/vma/lwip/tcp_out.c
@@ -333,10 +333,11 @@ tcp_write_checks(struct tcp_pcb *pcb, u32_t len)
  * @param apiflags combination of following flags :
  * - TCP_WRITE_FLAG_COPY (0x01) data will be copied into memory belonging to the stack
  * - TCP_WRITE_FLAG_MORE (0x02) for TCP connection, PSH flag will be set on last segment sent,
+ * @param is_dummy indicates if the packet is a dummy packet
  * @return ERR_OK if enqueued, another err_t on error
  */
 err_t
-tcp_write(struct tcp_pcb *pcb, const void *arg, u32_t len, u8_t apiflags)
+tcp_write(struct tcp_pcb *pcb, const void *arg, u32_t len, u8_t apiflags, u8_t is_dummy)
 {
   struct pbuf *concat_p = NULL;
   struct tcp_seg *seg = NULL, *prev_seg = NULL, *queue = NULL;
@@ -359,7 +360,7 @@ tcp_write(struct tcp_pcb *pcb, const void *arg, u32_t len, u8_t apiflags)
   mss_local = mss_local ? mss_local : pcb->mss;
 
   int byte_queued = pcb->snd_nxt - pcb->lastack;
-  if ( len < pcb->mss)
+  if ( len < pcb->mss && !is_dummy)
           pcb->snd_sml_add = (pcb->unacked ? pcb->unacked->len : 0) + byte_queued;
 
 #if LWIP_NETIF_TX_SINGLE_PBUF
@@ -367,8 +368,10 @@ tcp_write(struct tcp_pcb *pcb, const void *arg, u32_t len, u8_t apiflags)
   apiflags |= TCP_WRITE_FLAG_COPY;
 #endif /* LWIP_NETIF_TX_SINGLE_PBUF */
 
-  LWIP_DEBUGF(TCP_OUTPUT_DEBUG, ("tcp_write(pcb=%p, data=%p, len=%"U16_F", apiflags=%"U16_F")\n",
-    (void *)pcb, arg, len, (u16_t)apiflags));
+  optflags |= is_dummy ? TF_SEG_OPTS_DUMMY_MSG : 0;
+
+  LWIP_DEBUGF(TCP_OUTPUT_DEBUG, ("tcp_write(pcb=%p, data=%p, len=%"U16_F", apiflags=%"U16_F", is_dummy=%"U16_F")\n",
+    (void *)pcb, arg, len, (u16_t)apiflags, (u16_t)is_dummy));
   LWIP_ERROR("tcp_write: arg == NULL (programmer violates API)", 
              arg != NULL, return ERR_ARG;);
 
@@ -380,7 +383,7 @@ tcp_write(struct tcp_pcb *pcb, const void *arg, u32_t len, u8_t apiflags)
 
 #if LWIP_TCP_TIMESTAMPS
   if ((pcb->flags & TF_TIMESTAMP)) {
-    optflags = TF_SEG_OPTS_TS;
+    optflags |= TF_SEG_OPTS_TS;
     /* ensure that segments can hold at least one data byte... */
     mss_local = LWIP_MAX(mss_local, LWIP_TCP_OPT_LEN_TS + 1);
   }
@@ -506,6 +509,8 @@ tcp_write(struct tcp_pcb *pcb, const void *arg, u32_t len, u8_t apiflags)
     u32_t left = len - pos;
     u16_t max_len = mss_local - optlen;
     u16_t seglen = left > max_len ? max_len : left;
+
+    LWIP_ERROR("tcp_write: dummy packet should not be split", !(is_dummy && pos), break;);
 
     if (apiflags & TCP_WRITE_FLAG_COPY) {
       /* If copy is set, memory should be allocated and data copied
@@ -840,7 +845,7 @@ tcp_send_empty_ack(struct tcp_pcb *pcb)
     opts += 3;
   }
 #endif 
-  pcb->ip_output(p, pcb, 0);
+  pcb->ip_output(p, pcb, 0, 0);
   tcp_tx_pbuf_free(pcb, p);
 
   (void)opts; /* Fix warning -Wunused-but-set-variable */
@@ -1040,6 +1045,7 @@ tcp_output(struct tcp_pcb *pcb)
   while (seg){
     /* Split the segment in case of a small window */
     if (( pcb->flags & (TF_NODELAY | TF_INFR)) && (wnd) && ((seg->len + seg->seqno - pcb->lastack) > wnd)) {
+      LWIP_ERROR("tcp_output: no window for dummy packet", !LWIP_IS_DUMMY_SEGMENT(seg), break;);
       tcp_split_segment(pcb, seg, wnd);
     }
 
@@ -1051,11 +1057,13 @@ tcp_output(struct tcp_pcb *pcb)
       /* Stop sending if the nagle algorithm would prevent it
        * Don't stop:
        * - if tcp_write had a memory error before (prevent delayed ACK timeout) or
+       * - if this is not a dummy segment
        * - if FIN was already enqueued for this PCB (SYN is always alone in a segment -
        *   either seg->next != NULL or pcb->unacked == NULL;
        *   RST is no sent using tcp_write/tcp_output.
        */
        if((tcp_do_output_nagle(pcb) == 0) &&
+          !LWIP_IS_DUMMY_SEGMENT(seg) &&
           ((pcb->flags & (TF_NAGLEMEMERR | TF_FIN)) == 0)){
          if ( pcb->snd_sml_snt > (pcb->unacked ? pcb->unacked->len : 0) ) {
            break;
@@ -1078,6 +1086,11 @@ tcp_output(struct tcp_pcb *pcb)
 
        pcb->unsent = seg->next;
 
+       // Send ack now if the packet is a dummy packet
+       if (LWIP_IS_DUMMY_SEGMENT(seg) && (pcb->flags & (TF_ACK_DELAY | TF_ACK_NOW))) {
+      	  tcp_send_empty_ack(pcb);
+       }
+
        if (get_tcp_state(pcb) != SYN_SENT) {
          TCPH_SET_FLAG(seg->tcphdr, TCP_ACK);
          pcb->flags &= ~(TF_ACK_DELAY | TF_ACK_NOW);
@@ -1088,37 +1101,45 @@ tcp_output(struct tcp_pcb *pcb)
        #endif /* TCP_OVERSIZE_DBGCHECK */
        tcp_output_segment(seg, pcb);
        snd_nxt = seg->seqno + TCP_TCPLEN(seg);
-       if (TCP_SEQ_LT(pcb->snd_nxt, snd_nxt)) {
+       if (TCP_SEQ_LT(pcb->snd_nxt, snd_nxt) && !LWIP_IS_DUMMY_SEGMENT(seg)) {
          pcb->snd_nxt = snd_nxt;
        }
        /* put segment on unacknowledged list if length > 0 */
        if (TCP_TCPLEN(seg) > 0) {
          seg->next = NULL;
-         /* unacked list is empty? */
-         if (pcb->unacked == NULL) {
-           pcb->unacked = seg;
-           pcb->last_unacked = seg;
-           /* unacked list is not empty? */
+         // unroll dummy segment
+         if (LWIP_IS_DUMMY_SEGMENT(seg)) {
+           pcb->snd_lbb -= seg->len;
+           pcb->snd_buf += seg->len;
+           pcb->snd_queuelen -= pbuf_clen(seg->p);
+           tcp_tx_seg_free(pcb, seg);
          } else {
-           /* In the case of fast retransmit, the packet should not go to the tail
-           * of the unacked queue, but rather somewhere before it. We need to check for
-           * this case. -STJ Jul 27, 2004 */
-           useg =  pcb->last_unacked;
-           if (TCP_SEQ_LT(seg->seqno, useg->seqno)) {
-             /* add segment to before tail of unacked list, keeping the list sorted */
-             struct tcp_seg **cur_seg = &(pcb->unacked);
-             while (*cur_seg &&
-               TCP_SEQ_LT((*cur_seg)->seqno, seg->seqno)) {
-               cur_seg = &((*cur_seg)->next );
-             }
-             LWIP_ASSERT("Value of last_unacked is invalid",
-                         *cur_seg != pcb->last_unacked->next);
-             seg->next = (*cur_seg);
-             (*cur_seg) = seg;
-           } else {
-             /* add segment to tail of unacked list */
-             useg->next = seg;
+           /* unacked list is empty? */
+           if (pcb->unacked == NULL) {
+             pcb->unacked = seg;
              pcb->last_unacked = seg;
+             /* unacked list is not empty? */
+           } else {
+             /* In the case of fast retransmit, the packet should not go to the tail
+             * of the unacked queue, but rather somewhere before it. We need to check for
+             * this case. -STJ Jul 27, 2004 */
+             useg =  pcb->last_unacked;
+             if (TCP_SEQ_LT(seg->seqno, useg->seqno)) {
+               /* add segment to before tail of unacked list, keeping the list sorted */
+               struct tcp_seg **cur_seg = &(pcb->unacked);
+               while (*cur_seg &&
+                 TCP_SEQ_LT((*cur_seg)->seqno, seg->seqno)) {
+                 cur_seg = &((*cur_seg)->next );
+               }
+               LWIP_ASSERT("Value of last_unacked is invalid",
+                           *cur_seg != pcb->last_unacked->next);
+               seg->next = (*cur_seg);
+               (*cur_seg) = seg;
+             } else {
+               /* add segment to tail of unacked list */
+               useg->next = seg;
+               pcb->last_unacked = seg;
+             }
            }
          }
          /* do not queue empty segments on the unacked list */
@@ -1169,8 +1190,9 @@ tcp_output_segment(struct tcp_seg *seg, struct tcp_pcb *pcb)
 	  seg->tcphdr->wnd = htons(TCPWND_MIN16(RCV_WND_SCALE(pcb, pcb->rcv_ann_wnd)));
   }
 
-  pcb->rcv_ann_right_edge = pcb->rcv_nxt + pcb->rcv_ann_wnd;
-
+  if (!LWIP_IS_DUMMY_SEGMENT(seg)) {
+    pcb->rcv_ann_right_edge = pcb->rcv_nxt + pcb->rcv_ann_wnd;
+  }
   /* Add any requested options.  NB MSS option is only set on SYN
      packets, so ignore it here */
   LWIP_ASSERT("seg->tcphdr not aligned", ((mem_ptr_t)(seg->tcphdr + 1) % 4) == 0);
@@ -1188,7 +1210,9 @@ tcp_output_segment(struct tcp_seg *seg, struct tcp_pcb *pcb)
   }
 
 #if LWIP_TCP_TIMESTAMPS
-  pcb->ts_lastacksent = pcb->rcv_nxt;
+  if (!LWIP_IS_DUMMY_SEGMENT(seg)) {
+    pcb->ts_lastacksent = pcb->rcv_nxt;
+  }
 
   if (seg->flags & TF_SEG_OPTS_TS) {
     tcp_build_timestamp_option(pcb, opts);
@@ -1203,15 +1227,17 @@ tcp_output_segment(struct tcp_seg *seg, struct tcp_pcb *pcb)
   }
 
   /* Set retransmission timer running if it is not currently enabled */
-  if(pcb->rtime == -1) {
-    pcb->rtime = 0;
-  }
+  if (!LWIP_IS_DUMMY_SEGMENT(seg)) {
+    if(pcb->rtime == -1) {
+      pcb->rtime = 0;
+    }
 
-  if (pcb->rttest == 0) {
-    pcb->rttest = tcp_ticks;
-    pcb->rtseq = seg->seqno;
+    if (pcb->rttest == 0) {
+      pcb->rttest = tcp_ticks;
+      pcb->rtseq = seg->seqno;
 
-    LWIP_DEBUGF(TCP_RTO_DEBUG, ("tcp_output_segment: rtseq %"U32_F"\n", pcb->rtseq));
+      LWIP_DEBUGF(TCP_RTO_DEBUG, ("tcp_output_segment: rtseq %"U32_F"\n", pcb->rtseq));
+    }
   }
   LWIP_DEBUGF(TCP_OUTPUT_DEBUG, ("tcp_output_segment: %"U32_F":%"U32_F"\n",
           htonl(seg->tcphdr->seqno), htonl(seg->tcphdr->seqno) +
@@ -1232,7 +1258,7 @@ tcp_output_segment(struct tcp_seg *seg, struct tcp_pcb *pcb)
   ip_output_hinted(seg->p, &(pcb->local_ip), &(pcb->remote_ip), pcb->ttl, pcb->tos,
       IP_PROTO_TCP, &(pcb->addr_hint));
 #elif LWIP_3RD_PARTY_L3
-  pcb->ip_output(seg->p, pcb, seg->seqno < pcb->snd_nxt);
+  pcb->ip_output(seg->p, pcb, seg->seqno < pcb->snd_nxt, LWIP_IS_DUMMY_SEGMENT(seg));
 #else /* LWIP_NETIF_HWADDRHINT*/
   ip_output(seg->p, &(pcb->local_ip), &(pcb->remote_ip), pcb->ttl, pcb->tos, IP_PROTO_TCP);
 #endif /* LWIP_NETIF_HWADDRHINT*/
@@ -1290,7 +1316,7 @@ tcp_rst(u32_t seqno, u32_t ackno, u16_t local_port, u16_t remote_port, struct tc
 
   TCP_STATS_INC(tcp.xmit);
    /* Send output with hardcoded TTL since we have no access to the pcb */
-  if(pcb) pcb->ip_output(p, pcb, 0);
+  if(pcb) pcb->ip_output(p, pcb, 0, 0);
   /* external_ip_output(p, NULL, local_ip, remote_ip, TCP_TTL, 0, IP_PROTO_TCP) */;
   tcp_tx_pbuf_free(pcb, p);
   LWIP_DEBUGF(TCP_RST_DEBUG, ("tcp_rst: seqno %"U32_F" ackno %"U32_F".\n", seqno, ackno));
@@ -1463,7 +1489,7 @@ tcp_keepalive(struct tcp_pcb *pcb)
   ip_output_hinted(p, &pcb->local_ip, &pcb->remote_ip, pcb->ttl, 0, IP_PROTO_TCP,
     &(pcb->addr_hint));
 #elif LWIP_3RD_PARTY_L3
-  pcb->ip_output(p, pcb, 0);
+  pcb->ip_output(p, pcb, 0, 0);
 #else /* LWIP_NETIF_HWADDRHINT*/
   ip_output(p, &pcb->local_ip, &pcb->remote_ip, pcb->ttl, 0, IP_PROTO_TCP);
 #endif /* LWIP_NETIF_HWADDRHINT*/
@@ -1543,7 +1569,7 @@ tcp_zero_window_probe(struct tcp_pcb *pcb)
   ip_output_hinted(p, &pcb->local_ip, &pcb->remote_ip, pcb->ttl, 0, IP_PROTO_TCP,
     &(pcb->addr_hint));
 #elif LWIP_3RD_PARTY_L3
-  pcb->ip_output(p, pcb, 0);
+  pcb->ip_output(p, pcb, 0, 0);
 #else /* LWIP_NETIF_HWADDRHINT*/
   ip_output(p, &pcb->local_ip, &pcb->remote_ip, pcb->ttl, 0, IP_PROTO_TCP);
 #endif /* LWIP_NETIF_HWADDRHINT*/

--- a/src/vma/proto/dst_entry.h
+++ b/src/vma/proto/dst_entry.h
@@ -163,9 +163,9 @@ protected:
 	{
 		if (unlikely(b_dummy)) {
 			if (m_p_ring->get_hw_dummy_send_support(id, p_send_wqe)) {
-				vma_ibv_wr_opcode last_opcode = m_p_send_wqe_handler->set_dummy_opcode(*p_send_wqe);
+				vma_ibv_wr_opcode last_opcode = m_p_send_wqe_handler->set_opcode(*p_send_wqe, VMA_IBV_WR_NOP);
 				m_p_ring->send_ring_buffer(id, p_send_wqe, b_block);
-				m_p_send_wqe_handler->unset_dummy_opcode(*p_send_wqe, last_opcode);
+				m_p_send_wqe_handler->set_opcode(*p_send_wqe, last_opcode);
 			} else {
 				/* free the buffer if dummy send is not supported */
 				mem_buf_desc_t* p_mem_buf_desc = (mem_buf_desc_t*)(p_send_wqe->wr_id);

--- a/src/vma/proto/dst_entry.h
+++ b/src/vma/proto/dst_entry.h
@@ -66,8 +66,8 @@ public:
 	virtual void 	notify_cb();
 
 	virtual bool 	prepare_to_send(bool skip_rules=false);
-	virtual ssize_t slow_send(const iovec* p_iov, size_t sz_iov, bool b_blocked = true, bool is_rexmit = false, int flags = 0, socket_fd_api* sock = 0, tx_call_t call_type = TX_UNDEF) = 0 ;
-	virtual ssize_t fast_send(const struct iovec* p_iov, const ssize_t sz_iov, bool b_blocked = true, bool is_rexmit = false, bool dont_inline = false) = 0;
+	virtual ssize_t slow_send(const iovec* p_iov, size_t sz_iov, bool is_dummy, bool b_blocked = true, bool is_rexmit = false, int flags = 0, socket_fd_api* sock = 0, tx_call_t call_type = TX_UNDEF) = 0 ;
+	virtual ssize_t fast_send(const struct iovec* p_iov, const ssize_t sz_iov, bool is_dummy, bool b_blocked = true, bool is_rexmit = false, bool dont_inline = false) = 0;
 
 	bool		try_migrate_ring(lock_base& socket_lock);
 
@@ -158,6 +158,24 @@ protected:
 
 	void			do_ring_migration(lock_base& socket_lock);
 	inline void		set_tx_buff_list_pending(bool is_pending = true) {m_b_tx_mem_buf_desc_list_pending = is_pending;}
+
+	inline void		send_ring_buffer(ring_user_id_t id, vma_ibv_send_wr* p_send_wqe, bool b_block, bool b_dummy)
+	{
+		if (unlikely(b_dummy)) {
+			if (m_p_ring->get_hw_dummy_send_support(id, p_send_wqe)) {
+				vma_ibv_wr_opcode last_opcode = m_p_send_wqe_handler->set_dummy_opcode(*p_send_wqe);
+				m_p_ring->send_ring_buffer(id, p_send_wqe, b_block);
+				m_p_send_wqe_handler->unset_dummy_opcode(*p_send_wqe, last_opcode);
+			} else {
+				/* free the buffer if dummy send is not supported */
+				mem_buf_desc_t* p_mem_buf_desc = (mem_buf_desc_t*)(p_send_wqe->wr_id);
+				m_p_ring->mem_buf_tx_release(p_mem_buf_desc, true);
+			}
+		} else {
+			m_p_ring->send_ring_buffer(id, p_send_wqe, b_block);
+		}
+	}
+
 };
 
 

--- a/src/vma/proto/dst_entry_tcp.h
+++ b/src/vma/proto/dst_entry_tcp.h
@@ -74,9 +74,9 @@ private:
 	{
 		if (unlikely(b_dummy)) {
 			if (m_p_ring->get_hw_dummy_send_support(id, p_send_wqe)) {
-				vma_ibv_wr_opcode last_opcode = m_p_send_wqe_handler->set_dummy_opcode(*p_send_wqe);
+				vma_ibv_wr_opcode last_opcode = m_p_send_wqe_handler->set_opcode(*p_send_wqe, VMA_IBV_WR_NOP);
 				m_p_ring->send_lwip_buffer(id, p_send_wqe, b_block);
-				m_p_send_wqe_handler->unset_dummy_opcode(*p_send_wqe, last_opcode);
+				m_p_send_wqe_handler->set_opcode(*p_send_wqe, last_opcode);
 			}
 			/* no need to free the buffer if dummy send is not supported, as for lwip buffers we have 2 ref counts, */
 			/* one for caller, and one for completion. for completion, we ref count in    */

--- a/src/vma/proto/dst_entry_tcp.h
+++ b/src/vma/proto/dst_entry_tcp.h
@@ -49,8 +49,8 @@ public:
 	dst_entry_tcp(in_addr_t dst_ip, uint16_t dst_port, uint16_t src_port, int owner_fd);
 	virtual ~dst_entry_tcp();
 
-	virtual ssize_t fast_send(const struct iovec* p_iov, const ssize_t sz_iov, bool b_blocked = true, bool is_rexmit = false, bool dont_inline = false);
-	ssize_t slow_send(const iovec* p_iov, size_t sz_iov, bool b_blocked = true, bool is_rexmit = false, int flags = 0, socket_fd_api* sock = 0, tx_call_t call_type = TX_UNDEF);
+	virtual ssize_t fast_send(const struct iovec* p_iov, const ssize_t sz_iov, bool is_dummy, bool b_blocked = true, bool is_rexmit = false, bool dont_inline = false);
+	ssize_t slow_send(const iovec* p_iov, size_t sz_iov, bool is_dummy, bool b_blocked = true, bool is_rexmit = false, int flags = 0, socket_fd_api* sock = 0, tx_call_t call_type = TX_UNDEF);
 	ssize_t slow_send_neigh(const iovec* p_iov, size_t sz_iov);
 
 	mem_buf_desc_t* get_buffer(bool b_blocked = false);
@@ -69,6 +69,24 @@ protected:
 
 private:
 	const uint32_t       m_n_sysvar_tx_bufs_batch_tcp;
+
+	inline void		send_lwip_buffer(ring_user_id_t id, vma_ibv_send_wr* p_send_wqe, bool b_block, bool b_dummy)
+	{
+		if (unlikely(b_dummy)) {
+			if (m_p_ring->get_hw_dummy_send_support(id, p_send_wqe)) {
+				vma_ibv_wr_opcode last_opcode = m_p_send_wqe_handler->set_dummy_opcode(*p_send_wqe);
+				m_p_ring->send_lwip_buffer(id, p_send_wqe, b_block);
+				m_p_send_wqe_handler->unset_dummy_opcode(*p_send_wqe, last_opcode);
+			}
+			/* no need to free the buffer if dummy send is not supported, as for lwip buffers we have 2 ref counts, */
+			/* one for caller, and one for completion. for completion, we ref count in    */
+			/* send_lwip_buffer(). Since we are not going in, the caller will free the    */
+			/* buffer. */
+		} else {
+			m_p_ring->send_lwip_buffer(id, p_send_wqe, b_block);
+		}
+	}
+
 };
 
 #endif /* DST_ENTRY_TCP_H */

--- a/src/vma/proto/dst_entry_udp.cpp
+++ b/src/vma/proto/dst_entry_udp.cpp
@@ -76,7 +76,7 @@ void dst_entry_udp::configure_headers()
 	dst_entry::configure_headers();
 }
 
-ssize_t dst_entry_udp::fast_send(const iovec* p_iov, const ssize_t sz_iov, bool b_blocked /*=true*/, bool is_rexmit /*=false*/, bool dont_inline /*=false*/)
+ssize_t dst_entry_udp::fast_send(const iovec* p_iov, const ssize_t sz_iov, bool is_dummy, bool b_blocked /*=true*/, bool is_rexmit /*=false*/, bool dont_inline /*=false*/)
 {
 	NOT_IN_USE(is_rexmit);
 
@@ -139,7 +139,7 @@ ssize_t dst_entry_udp::fast_send(const iovec* p_iov, const ssize_t sz_iov, bool 
 		}
 		p_mem_buf_desc->p_next_desc = NULL;
 		m_inline_send_wqe.wr_id = (uintptr_t)p_mem_buf_desc;
-		m_p_ring->send_ring_buffer(m_id, m_p_send_wqe, b_blocked);
+		send_ring_buffer(m_id, m_p_send_wqe, b_blocked, is_dummy);
 
 		if (unlikely(m_p_tx_mem_buf_desc_list == NULL)) {
 			m_p_tx_mem_buf_desc_list = m_p_ring->mem_buf_tx_get(m_id, b_blocked, m_n_sysvar_tx_bufs_batch_udp);
@@ -261,7 +261,7 @@ ssize_t dst_entry_udp::fast_send(const iovec* p_iov, const ssize_t sz_iov, bool 
 			p_mem_buf_desc->p_next_desc = NULL;
 
 			// We don't check the return valuse of post send when we reach the HW we consider that we completed our job
-			m_p_ring->send_ring_buffer(m_id, m_p_send_wqe, b_blocked);
+			send_ring_buffer(m_id, m_p_send_wqe, b_blocked, is_dummy);
 
 			p_mem_buf_desc = tmp;
 
@@ -278,7 +278,7 @@ ssize_t dst_entry_udp::fast_send(const iovec* p_iov, const ssize_t sz_iov, bool 
 	return sz_data_payload;
 }
 
-ssize_t dst_entry_udp::slow_send(const iovec* p_iov, size_t sz_iov, bool b_blocked /*= true*/, bool is_rexmit /*= false*/, int flags /*= 0*/, socket_fd_api* sock /*= 0*/, tx_call_t call_type /*= 0*/)
+ssize_t dst_entry_udp::slow_send(const iovec* p_iov, size_t sz_iov, bool is_dummy, bool b_blocked /*= true*/, bool is_rexmit /*= false*/, int flags /*= 0*/, socket_fd_api* sock /*= 0*/, tx_call_t call_type /*= 0*/)
 {
 	NOT_IN_USE(is_rexmit);
 
@@ -301,7 +301,7 @@ ssize_t dst_entry_udp::slow_send(const iovec* p_iov, size_t sz_iov, bool b_block
 			ret_val = pass_buff_to_neigh(p_iov, sz_iov);
 		}
 		else {
-			ret_val = fast_send(p_iov, sz_iov, b_blocked);
+			ret_val = fast_send(p_iov, sz_iov, is_dummy, b_blocked);
 		}
 	}
 

--- a/src/vma/proto/dst_entry_udp.h
+++ b/src/vma/proto/dst_entry_udp.h
@@ -42,8 +42,8 @@ public:
 	dst_entry_udp(in_addr_t dst_ip, uint16_t dst_port, uint16_t src_port, int owner_fd);
 	virtual ~dst_entry_udp();
 
-	virtual ssize_t 	slow_send(const iovec* p_iov, size_t sz_iov, bool b_blocked = true, bool is_rexmit = false, int flags = 0, socket_fd_api* sock = 0, tx_call_t call_type = TX_UNDEF);
-	virtual ssize_t 	fast_send(const struct iovec* p_iov, const ssize_t sz_iov, bool b_blocked = true, bool is_rexmit = false, bool dont_inline = false);
+	virtual ssize_t 	slow_send(const iovec* p_iov, size_t sz_iov, bool is_dummy, bool b_blocked = true, bool is_rexmit = false, int flags = 0, socket_fd_api* sock = 0, tx_call_t call_type = TX_UNDEF);
+	virtual ssize_t 	fast_send(const struct iovec* p_iov, const ssize_t sz_iov, bool is_dummy, bool b_blocked = true, bool is_rexmit = false, bool dont_inline = false);
 
 protected:
 	virtual transport_t 	get_transport(sockaddr_in to);

--- a/src/vma/sock/sock-redirect.cpp
+++ b/src/vma/sock/sock-redirect.cpp
@@ -1245,7 +1245,8 @@ ssize_t send(int __fd, __const void *__buf, size_t __nbytes, int __flags)
 	}
 
 	// Ignore dummy messages for OS
-	if (unlikely(__flags & DUMMY_WARM_MSG)) {
+	if (unlikely(IS_DUMMY_PACKET(__flags))) {
+		errno = EINVAL;
 		return -1;
 	} else {
 		return orig_os_api.send(__fd, __buf, __nbytes, __flags);
@@ -1274,7 +1275,8 @@ ssize_t sendmsg(int __fd, __const struct msghdr *__msg, int __flags)
 	}
 
 	// Ignore dummy messages for OS
-	if (unlikely(__flags & DUMMY_WARM_MSG)) {
+	if (unlikely(IS_DUMMY_PACKET(__flags))) {
+		errno = EINVAL;
 		return -1;
 	} else {
 		return orig_os_api.sendmsg(__fd, __msg, __flags);
@@ -1322,7 +1324,8 @@ int sendmmsg(int __fd, struct mmsghdr *__mmsghdr, unsigned int __vlen, int __fla
 	}
 
 	// Ignore dummy messages for OS
-	if (unlikely(__flags & DUMMY_WARM_MSG)) {
+	if (unlikely(IS_DUMMY_PACKET(__flags))) {
+		errno = EINVAL;
 		return -1;
 	} else {
 		return orig_os_api.sendmmsg(__fd, __mmsghdr, __vlen, __flags);
@@ -1354,7 +1357,8 @@ ssize_t sendto(int __fd, __const void *__buf, size_t __nbytes, int __flags,
 	}
 
 	// Ignore dummy messages for OS
-	if (unlikely(__flags & DUMMY_WARM_MSG)) {
+	if (unlikely(IS_DUMMY_PACKET(__flags))) {
+		errno = EINVAL;
 		return -1;
 	} else {
 		return orig_os_api.sendto(__fd, __buf, __nbytes, __flags, __to, __tolen);

--- a/src/vma/sock/sock-redirect.cpp
+++ b/src/vma/sock/sock-redirect.cpp
@@ -1244,7 +1244,12 @@ ssize_t send(int __fd, __const void *__buf, size_t __nbytes, int __flags)
 		return p_socket_object->tx(TX_SEND, piov, 1, __flags);
 	}
 
-	return orig_os_api.send(__fd, __buf, __nbytes, __flags);
+	// Ignore dummy messages for OS
+	if (unlikely(__flags & DUMMY_WARM_MSG)) {
+		return -1;
+	} else {
+		return orig_os_api.send(__fd, __buf, __nbytes, __flags);
+	}
 }
 
 /* Sends a message as described by MESSAGE to socket FD.
@@ -1268,7 +1273,12 @@ ssize_t sendmsg(int __fd, __const struct msghdr *__msg, int __flags)
 		return p_socket_object->tx(TX_SENDMSG, __msg->msg_iov, __msg->msg_iovlen, __flags, (__CONST_SOCKADDR_ARG)__msg->msg_name, (socklen_t)__msg->msg_namelen);
 	}
 
-	return orig_os_api.sendmsg(__fd, __msg, __flags);
+	// Ignore dummy messages for OS
+	if (unlikely(__flags & DUMMY_WARM_MSG)) {
+		return -1;
+	} else {
+		return orig_os_api.sendmsg(__fd, __msg, __flags);
+	}
 }
 
 /* Send multiple messages as described by MESSAGE from socket FD.
@@ -1311,7 +1321,12 @@ int sendmmsg(int __fd, struct mmsghdr *__mmsghdr, unsigned int __vlen, int __fla
 		return num_of_msg;
 	}
 
-	return orig_os_api.sendmmsg(__fd, __mmsghdr, __vlen, __flags);
+	// Ignore dummy messages for OS
+	if (unlikely(__flags & DUMMY_WARM_MSG)) {
+		return -1;
+	} else {
+		return orig_os_api.sendmmsg(__fd, __mmsghdr, __vlen, __flags);
+	}
 }
 
 /* Send N bytes of BUF on socket FD to peer at address ADDR (which is
@@ -1338,7 +1353,12 @@ ssize_t sendto(int __fd, __const void *__buf, size_t __nbytes, int __flags,
 		return p_socket_object->tx(TX_SENDTO, piov, 1, __flags, __to, __tolen);
 	}
 
-	return orig_os_api.sendto(__fd, __buf, __nbytes, __flags, __to, __tolen);
+	// Ignore dummy messages for OS
+	if (unlikely(__flags & DUMMY_WARM_MSG)) {
+		return -1;
+	} else {
+		return orig_os_api.sendto(__fd, __buf, __nbytes, __flags, __to, __tolen);
+	}
 }
 
 

--- a/src/vma/sock/socket_fd_api.cpp
+++ b/src/vma/sock/socket_fd_api.cpp
@@ -294,7 +294,8 @@ ssize_t socket_fd_api::tx_os(const tx_call_t call_type,
 	errno = 0;
 
 	// Ignore dummy messages for OS
-	if (unlikely(__flags & DUMMY_WARM_MSG)) {
+	if (unlikely(IS_DUMMY_PACKET(__flags))) {
+		errno = EINVAL;
 		return -1;
 	}
 

--- a/src/vma/sock/socket_fd_api.cpp
+++ b/src/vma/sock/socket_fd_api.cpp
@@ -292,6 +292,12 @@ ssize_t socket_fd_api::tx_os(const tx_call_t call_type,
 			     const socklen_t __tolen)
 {
 	errno = 0;
+
+	// Ignore dummy messages for OS
+	if (unlikely(__flags & DUMMY_WARM_MSG)) {
+		return -1;
+	}
+
 	switch (call_type) {
 	case TX_WRITE:
 		__log_info_func("calling os transmit with orig write");

--- a/src/vma/sock/sockinfo.cpp
+++ b/src/vma/sock/sockinfo.cpp
@@ -721,6 +721,14 @@ void sockinfo::statistics_print(vlog_levels_t log_level /* = VLOG_DEBUG */)
 		vlog_printf(log_level, "Tx OS info : %d KB / %d / %d [bytes/packets/errors]\n", m_p_socket_stats->counters.n_tx_os_bytes/1024, m_p_socket_stats->counters.n_tx_os_packets, m_p_socket_stats->counters.n_tx_os_errors);
 		b_any_activity = true;
 	}
+	if (m_p_socket_stats->counters.n_tx_dummy) {
+		vlog_printf(log_level, "Tx Dummy messages : %d\n", m_p_socket_stats->counters.n_tx_dummy);
+		b_any_activity = true;
+	}
+	if (m_p_socket_stats->counters.n_tx_dummy_drops) {
+		vlog_printf(log_level, "Tx Dummy messages dropped: %d\n", m_p_socket_stats->counters.n_tx_dummy_drops);
+		b_any_activity = true;
+	}
 	if (m_p_socket_stats->counters.n_rx_bytes || m_p_socket_stats->counters.n_rx_packets || m_p_socket_stats->counters.n_rx_errors || m_p_socket_stats->counters.n_rx_eagain || m_p_socket_stats->n_rx_ready_pkt_count) {
 		vlog_printf(log_level, "Rx Offload : %d KB / %d / %d / %d [bytes/packets/eagains/errors]\n", m_p_socket_stats->counters.n_rx_bytes/1024, m_p_socket_stats->counters.n_rx_packets, m_p_socket_stats->counters.n_rx_eagain, m_p_socket_stats->counters.n_rx_errors);
 

--- a/src/vma/sock/sockinfo.cpp
+++ b/src/vma/sock/sockinfo.cpp
@@ -725,10 +725,6 @@ void sockinfo::statistics_print(vlog_levels_t log_level /* = VLOG_DEBUG */)
 		vlog_printf(log_level, "Tx Dummy messages : %d\n", m_p_socket_stats->counters.n_tx_dummy);
 		b_any_activity = true;
 	}
-	if (m_p_socket_stats->counters.n_tx_dummy_drops) {
-		vlog_printf(log_level, "Tx Dummy messages dropped: %d\n", m_p_socket_stats->counters.n_tx_dummy_drops);
-		b_any_activity = true;
-	}
 	if (m_p_socket_stats->counters.n_rx_bytes || m_p_socket_stats->counters.n_rx_packets || m_p_socket_stats->counters.n_rx_errors || m_p_socket_stats->counters.n_rx_eagain || m_p_socket_stats->n_rx_ready_pkt_count) {
 		vlog_printf(log_level, "Rx Offload : %d KB / %d / %d / %d [bytes/packets/eagains/errors]\n", m_p_socket_stats->counters.n_rx_bytes/1024, m_p_socket_stats->counters.n_rx_packets, m_p_socket_stats->counters.n_rx_eagain, m_p_socket_stats->counters.n_rx_errors);
 

--- a/src/vma/sock/sockinfo_udp.cpp
+++ b/src/vma/sock/sockinfo_udp.cpp
@@ -1588,7 +1588,7 @@ ssize_t sockinfo_udp::tx(const tx_call_t call_type, const struct iovec* p_iov, c
 {
 	int ret;
 	bool is_dropped = false;
-	bool is_dummy = __flags & DUMMY_WARM_MSG;
+	bool is_dummy = IS_DUMMY_PACKET(__flags);
 	dst_entry* p_dst_entry = m_p_connected_dst_entry; // Default for connected() socket but we'll update it on a specific sendTO(__to) call
 
 	si_udp_logfunc("");

--- a/src/vma/sock/sockinfo_udp.h
+++ b/src/vma/sock/sockinfo_udp.h
@@ -236,7 +236,7 @@ private:
 	void 		save_stats_threadid_tx(); // ThreadId will only saved if logger is at least in DEBUG(4) level
 
 	void 		save_stats_rx_offload(int bytes);
-	void 		save_stats_tx_offload(int bytes, bool is_droped);
+	void 		save_stats_tx_offload(int bytes, bool is_droped, bool is_dummy);
 
 	int 		rx_wait_helper(int &poll_count, bool is_blocking);
 	

--- a/src/vma/util/verbs_extra.h
+++ b/src/vma/util/verbs_extra.h
@@ -144,7 +144,7 @@ typedef int            vma_ibv_cq_init_attr;
 #define VMA_IBV_WR_SEND				IBV_WR_SEND
 #define vma_ibv_wr_opcode			ibv_wr_opcode
 #define vma_send_wr_opcode(wr)			(wr).opcode
-#define VMA_IBV_WR_NOP				0
+#define VMA_IBV_WR_NOP				(vma_ibv_wr_opcode)(0)
 #define vma_ibv_post_send(qp, wr, bad_wr)	ibv_post_send(qp, wr, bad_wr)
 typedef struct ibv_send_wr			vma_ibv_send_wr;
 //ibv_reg_mr
@@ -247,7 +247,7 @@ typedef int            vma_ibv_cq_init_attr;
 #ifdef DEFINED_IBV_EXP_WR_NOP
 #define VMA_IBV_WR_NOP				IBV_EXP_WR_NOP
 #else
-#define VMA_IBV_WR_NOP				0
+#define VMA_IBV_WR_NOP				(vma_ibv_wr_opcode)(0)
 #endif
 
 #define vma_ibv_post_send(qp, wr, bad_wr)	ibv_exp_post_send(qp, wr, bad_wr)

--- a/src/vma/util/verbs_extra.h
+++ b/src/vma/util/verbs_extra.h
@@ -142,7 +142,9 @@ typedef int            vma_ibv_cq_init_attr;
 #define vma_ibv_send_flags			ibv_send_flags
 #define vma_send_wr_send_flags(wr)		(wr).send_flags
 #define VMA_IBV_WR_SEND				IBV_WR_SEND
+#define vma_ibv_wr_opcode			ibv_wr_opcode
 #define vma_send_wr_opcode(wr)			(wr).opcode
+#define VMA_IBV_WR_NOP				0
 #define vma_ibv_post_send(qp, wr, bad_wr)	ibv_post_send(qp, wr, bad_wr)
 typedef struct ibv_send_wr			vma_ibv_send_wr;
 //ibv_reg_mr
@@ -239,7 +241,15 @@ typedef int            vma_ibv_cq_init_attr;
 #define vma_ibv_send_flags			ibv_exp_send_flags
 #define vma_send_wr_send_flags(wr)		(wr).exp_send_flags
 #define VMA_IBV_WR_SEND				IBV_EXP_WR_SEND
+#define vma_ibv_wr_opcode			ibv_exp_wr_opcode
 #define vma_send_wr_opcode(wr)			(wr).exp_opcode
+
+#ifdef DEFINED_IBV_EXP_WR_NOP
+#define VMA_IBV_WR_NOP				IBV_EXP_WR_NOP
+#else
+#define VMA_IBV_WR_NOP				0
+#endif
+
 #define vma_ibv_post_send(qp, wr, bad_wr)	ibv_exp_post_send(qp, wr, bad_wr)
 typedef struct ibv_exp_send_wr			vma_ibv_send_wr;
 //ibv_reg_mr

--- a/src/vma/util/vma_stats.h
+++ b/src/vma/util/vma_stats.h
@@ -210,6 +210,8 @@ typedef struct {
 	uint32_t		n_tx_os_errors;
 	uint32_t		n_tx_os_eagain;
 	uint32_t		n_tx_migrations;
+	uint32_t		n_tx_dummy;
+	uint32_t		n_tx_dummy_drops;
 } socket_counters_t;
 
 typedef struct {

--- a/src/vma/util/vma_stats.h
+++ b/src/vma/util/vma_stats.h
@@ -211,7 +211,6 @@ typedef struct {
 	uint32_t		n_tx_os_eagain;
 	uint32_t		n_tx_migrations;
 	uint32_t		n_tx_dummy;
-	uint32_t		n_tx_dummy_drops;
 } socket_counters_t;
 
 typedef struct {

--- a/src/vma/vma_extra.h
+++ b/src/vma/vma_extra.h
@@ -47,7 +47,8 @@
 /*
  * Flags for Dummy send API
  */
-#define DUMMY_WARM_MSG MSG_SYN // equals to 0x400
+#define VMA_SND_FLAGS_DUMMY MSG_SYN // equals to 0x400
+#define IS_DUMMY_PACKET(flags) (flags & VMA_SND_FLAGS_DUMMY)
 
 /* 
  * Return values for the receive packet notify callback function

--- a/src/vma/vma_extra.h
+++ b/src/vma/vma_extra.h
@@ -44,6 +44,10 @@
 #define MSG_VMA_ZCOPY_FORCE	0x01000000 // don't fallback to bcopy
 #define	MSG_VMA_ZCOPY		0x00040000 // return: zero copy was done
 
+/*
+ * Flags for Dummy send API
+ */
+#define DUMMY_WARM_MSG MSG_SYN // equals to 0x400
 
 /* 
  * Return values for the receive packet notify callback function


### PR DESCRIPTION
This feature is to add new API to allow application to call a dummy send
flow which will warm up the CPU caches on the send fast path.
Enable using DUMMY_WARM_MSG in the flags field of send(), sendto(), sendmsg().

Signed-off-by: Liran Oz <lirano@mellanox.com>