### PR TITLE
issue: 842842 Move udp rx hw timestamp conversion from cq_mgr into so…

### DIFF
--- a/src/vma/dev/cq_mgr.cpp
+++ b/src/vma/dev/cq_mgr.cpp
@@ -600,7 +600,7 @@ mem_buf_desc_t* cq_mgr::process_cq_element_rx(vma_ibv_wc* p_wce)
 		//this is not a deadcode if timestamping is defined in verbs API
 		// coverity[dead_error_condition]
 		if (vma_wc_flags(*p_wce) & VMA_IBV_WC_WITH_TIMESTAMP) {
-			m_p_ib_ctx_handler->convert_hw_time_to_system_time(vma_wc_timestamp(*p_wce) ,&p_mem_buf_desc->path.rx.hw_timestamp);
+			p_mem_buf_desc->path.rx.hw_raw_timestamp = vma_wc_timestamp(*p_wce);
 		}
 
 		VALGRIND_MAKE_MEM_DEFINED(p_mem_buf_desc->p_buffer, p_mem_buf_desc->sz_data);
@@ -667,6 +667,7 @@ void cq_mgr::reclaim_recv_buffer_helper(mem_buf_desc_t* buff)
 				temp->path.rx.sw_timestamp.tv_sec = 0;
 				temp->path.rx.hw_timestamp.tv_nsec = 0;
 				temp->path.rx.hw_timestamp.tv_sec = 0;
+				temp->path.rx.hw_raw_timestamp = 0;
 				free_lwip_pbuf(&temp->lwip_pbuf);
 				m_rx_pool.push_back(temp);
 			}

--- a/src/vma/dev/cq_mgr.h
+++ b/src/vma/dev/cq_mgr.h
@@ -168,9 +168,7 @@ public:
 
 	void 	modify_cq_moderation(uint32_t period, uint32_t count);
 
-	inline void convert_hw_time_to_system_time(uint64_t packet_hw_time, struct timespec* packet_systime) {
-		m_p_ib_ctx_handler->convert_hw_time_to_system_time(packet_hw_time, packet_systime);
-	}
+	inline void convert_hw_time_to_system_time(uint64_t hwtime, struct timespec* systime) { m_p_ib_ctx_handler->convert_hw_time_to_system_time(hwtime, systime); }
 
 private:
 	ring_simple*		m_p_ring;

--- a/src/vma/dev/cq_mgr.h
+++ b/src/vma/dev/cq_mgr.h
@@ -168,6 +168,10 @@ public:
 
 	void 	modify_cq_moderation(uint32_t period, uint32_t count);
 
+	inline void convert_hw_time_to_system_time(uint64_t packet_hw_time, struct timespec* packet_systime) {
+		m_p_ib_ctx_handler->convert_hw_time_to_system_time(packet_hw_time, packet_systime);
+	}
+
 private:
 	ring_simple*		m_p_ring;
 	ib_ctx_handler*			m_p_ib_ctx_handler;

--- a/src/vma/dev/ib_ctx_handler.h
+++ b/src/vma/dev/ib_ctx_handler.h
@@ -63,9 +63,7 @@ public:
 	void                    handle_event_DEVICE_FATAL();
 	ts_conversion_mode_t    get_ctx_time_converter_status();
 
-	inline void convert_hw_time_to_system_time(uint64_t packet_hw_time, struct timespec* packet_systime) {
-		ctx_time_converter.convert_hw_time_to_system_time(packet_hw_time, packet_systime);
-	}
+	inline void convert_hw_time_to_system_time(uint64_t hwtime, struct timespec* systime) { ctx_time_converter.convert_hw_time_to_system_time(hwtime, systime); }
 
 private:
 	struct ibv_context*     m_p_ibv_context;

--- a/src/vma/dev/ib_ctx_time_converter.cpp
+++ b/src/vma/dev/ib_ctx_time_converter.cpp
@@ -188,10 +188,10 @@ bool ib_ctx_time_converter::sync_clocks(struct timespec* ts, uint64_t* hw_clock)
 
 #endif
 
-void ib_ctx_time_converter::convert_hw_time_to_system_time(uint64_t packet_hw_time, struct timespec* packet_systime) {
+void ib_ctx_time_converter::convert_hw_time_to_system_time(uint64_t hwtime, struct timespec* systime) {
 
 	ctx_timestamping_params_t* current_parameters_set = &m_ctx_convert_parmeters[m_ctx_parmeters_id];
-	if (current_parameters_set->hca_core_clock && packet_hw_time) {
+	if (current_parameters_set->hca_core_clock && hwtime) {
 
 		struct timespec hw_to_timespec, sync_systime;
 		uint64_t hw_time_diff, hca_core_clock, sync_hw_clock;
@@ -200,13 +200,13 @@ void ib_ctx_time_converter::convert_hw_time_to_system_time(uint64_t packet_hw_ti
 		sync_hw_clock = current_parameters_set->sync_hw_clock;
 		sync_systime = current_parameters_set->sync_systime;
 
-		hw_time_diff = packet_hw_time - sync_hw_clock; // sync_hw_clock should be zero when m_conversion_mode is CONVERSION_MODE_RAW_OR_FAIL or CONVERSION_MODE_DISABLE
+		hw_time_diff = hwtime - sync_hw_clock; // sync_hw_clock should be zero when m_conversion_mode is CONVERSION_MODE_RAW_OR_FAIL or CONVERSION_MODE_DISABLE
 
 		hw_to_timespec.tv_sec = hw_time_diff / hca_core_clock;
 		hw_time_diff -= hw_to_timespec.tv_sec * hca_core_clock;
 		hw_to_timespec.tv_nsec = (hw_time_diff * NSEC_PER_SEC) / hca_core_clock;
 
-		ts_add(&sync_systime, &hw_to_timespec, packet_systime);
+		ts_add(&sync_systime, &hw_to_timespec, systime);
 	}
 }
 

--- a/src/vma/dev/ib_ctx_time_converter.h
+++ b/src/vma/dev/ib_ctx_time_converter.h
@@ -58,7 +58,7 @@ public:
 	ib_ctx_time_converter(struct ibv_context* ctx, ts_conversion_mode_t ctx_time_converter_mode);
 	virtual ~ib_ctx_time_converter();
 
-	void                      convert_hw_time_to_system_time(uint64_t packet_hw_time, struct timespec* packet_systime);
+	void                      convert_hw_time_to_system_time(uint64_t hwtime, struct timespec* systime);
 	void                      handle_timer_expired(void* user_data);
 
 	uint64_t                  get_hca_core_clock();

--- a/src/vma/dev/ring_simple.h
+++ b/src/vma/dev/ring_simple.h
@@ -76,6 +76,10 @@ public:
 	virtual ring_user_id_t	generate_id(const address_t src_mac, const address_t dst_mac, uint16_t eth_proto, uint16_t encap_proto, uint32_t src_ip, uint32_t dst_ip, uint16_t src_port, uint16_t dst_port);
 	transport_type_t	get_transport_type() const { return m_transport_type; }
 
+	inline void convert_hw_time_to_system_time(uint64_t packet_hw_time, struct timespec* packet_systime) {
+		m_p_cq_mgr_rx->convert_hw_time_to_system_time(packet_hw_time, packet_systime);
+	}
+
 	friend class cq_mgr;
 	friend class qp_mgr;
 	friend class rfs;

--- a/src/vma/dev/ring_simple.h
+++ b/src/vma/dev/ring_simple.h
@@ -75,10 +75,7 @@ public:
 	virtual ring_user_id_t	generate_id();
 	virtual ring_user_id_t	generate_id(const address_t src_mac, const address_t dst_mac, uint16_t eth_proto, uint16_t encap_proto, uint32_t src_ip, uint32_t dst_ip, uint16_t src_port, uint16_t dst_port);
 	transport_type_t	get_transport_type() const { return m_transport_type; }
-
-	inline void convert_hw_time_to_system_time(uint64_t packet_hw_time, struct timespec* packet_systime) {
-		m_p_cq_mgr_rx->convert_hw_time_to_system_time(packet_hw_time, packet_systime);
-	}
+	inline void 		convert_hw_time_to_system_time(uint64_t hwtime, struct timespec* systime) { m_p_cq_mgr_rx->convert_hw_time_to_system_time(hwtime, systime); }
 
 	friend class cq_mgr;
 	friend class qp_mgr;

--- a/src/vma/proto/mem_buf_desc.h
+++ b/src/vma/proto/mem_buf_desc.h
@@ -123,6 +123,7 @@ public:
 
 			struct timespec sw_timestamp;
 			struct timespec	hw_timestamp;
+			uint64_t	hw_raw_timestamp;
 
 			void* 		context;
 		} rx;

--- a/src/vma/proto/mem_buf_desc.h
+++ b/src/vma/proto/mem_buf_desc.h
@@ -122,8 +122,10 @@ public:
 			size_t		sz_payload;
 
 			struct timespec sw_timestamp;
-			struct timespec	hw_timestamp;
-			uint64_t	hw_raw_timestamp;
+			union {
+				struct timespec	hw_timestamp;
+				uint64_t	hw_raw_timestamp;
+			};
 
 			void* 		context;
 		} rx;

--- a/src/vma/sock/sockinfo_udp.cpp
+++ b/src/vma/sock/sockinfo_udp.cpp
@@ -49,6 +49,7 @@
 #include "vma/sock/fd_collection.h"
 #include "vma/event/event_handler_manager.h"
 #include "vma/dev/buffer_pool.h"
+#include "vma/dev/ring_simple.h"
 #include "vma/proto/route_table_mgr.h"
 #include "vma/proto/rule_table_mgr.h"
 #include "vma/proto/dst_entry_tcp.h"

--- a/src/vma/sock/sockinfo_udp.cpp
+++ b/src/vma/sock/sockinfo_udp.cpp
@@ -1839,6 +1839,15 @@ bool sockinfo_udp::rx_input_cb(mem_buf_desc_t* p_desc, void* pv_fd_ready_array)
 		!p_desc->path.rx.sw_timestamp.tv_sec) {
 		clock_gettime(CLOCK_REALTIME, &(p_desc->path.rx.sw_timestamp));
 	}
+
+	// convert hw timestamp to system time
+	if (m_n_tsing_flags & SOF_TIMESTAMPING_RAW_HARDWARE) {
+		ring_simple* base_ring = (ring_simple*) p_desc->p_desc_owner;
+		if (base_ring) {
+			base_ring->convert_hw_time_to_system_time(p_desc->path.rx.hw_raw_timestamp, &p_desc->path.rx.hw_timestamp);
+		}
+	}
+
 	vma_recv_callback_retval_t callback_retval = VMA_PACKET_RECV;
 	if (m_rx_callback) {
 		mem_buf_desc_t *tmp;

--- a/src/vma/sock/sockinfo_udp.h
+++ b/src/vma/sock/sockinfo_udp.h
@@ -46,7 +46,6 @@
 #include "vma/util/sys_vars.h"
 #include "vma/proto/mem_buf_desc.h"
 #include "vma/proto/dst_entry_udp.h"
-#include "vma/dev/ring_simple.h"
 
 #include "pkt_rcvr_sink.h"
 #include "pkt_sndr_source.h"

--- a/src/vma/sock/sockinfo_udp.h
+++ b/src/vma/sock/sockinfo_udp.h
@@ -46,6 +46,7 @@
 #include "vma/util/sys_vars.h"
 #include "vma/proto/mem_buf_desc.h"
 #include "vma/proto/dst_entry_udp.h"
+#include "vma/dev/ring_simple.h"
 
 #include "pkt_rcvr_sink.h"
 #include "pkt_sndr_source.h"


### PR DESCRIPTION
…ckinfo_udp

Currently, The time conversion for each incoming packet is made in the cq_mgr.
i.e, the conversion is made no only for UDP sockets who didn't enable the option
but also for TCP sockets.
Each conversion includes some mathematical calculations and cache misses
which cause performance degradation.
To improve performance, we should make this conversion only for UDP
sockets which enabled the option.

Signed-off-by: Liran Oz <lirano@mellanox.com>