### PR TITLE
issue: 931123 VMA receive multicast packets while socket is bound to …

### DIFF
--- a/src/vma/sock/sockinfo_udp.cpp
+++ b/src/vma/sock/sockinfo_udp.cpp
@@ -1788,7 +1788,7 @@ inline bool sockinfo_udp::inspect_uc_packet(mem_buf_desc_t* p_desc)
 	}
 
 	// The address specified in bind() has a filtering role, i.e. sockets should discard datagrams which sent to an unbound ip address.
-	if (unlikely(m_bound.get_in_addr() != p_desc->rx.dst.sin_addr.s_addr) && !m_bound.is_anyaddr()) {
+	if (unlikely((m_bound.get_in_addr() != p_desc->rx.dst.sin_addr.s_addr) && !m_bound.is_anyaddr())) {
 		si_udp_logfunc("rx packet discarded - not socket's bound ip (pkt addr: [%d:%d:%d:%d], bound ip:[%s])",
 				NIPQUAD(p_desc->rx.dst.sin_addr.s_addr), m_bound.to_str_in_addr());
 		return false;
@@ -1806,7 +1806,6 @@ inline bool sockinfo_udp::inspect_uc_packet(mem_buf_desc_t* p_desc)
 		si_udp_logfunc("rx packet discarded - fd closed");
 		return false;
 	}
-
 	return true;
 }
 

--- a/src/vma/sock/sockinfo_udp.cpp
+++ b/src/vma/sock/sockinfo_udp.cpp
@@ -2311,12 +2311,16 @@ int sockinfo_udp::mc_change_membership(const mc_pending_pram *p_mc_pram)
 		// The address specified in bind() has a filtering role.
 		// i.e. sockets should discard datagrams which sent to an unbound ip address.
 		if (!m_bound.is_anyaddr() && mc_grp != m_bound.get_in_addr()) {
-			return -1; // Socket was bound to a different ip address
+			// Ignore for socketXtreme beacause m_bound is used as part of the legacy implementation
+			if (!safe_mce_sys().enable_socketxtreme) {
+				return -1; // Socket was bound to a different ip address
+			}
 		}
 
 		flow_tuple_with_local_if flow_key(mc_grp, m_bound.get_in_port(), m_connected.get_in_addr(), m_connected.get_in_port(), PROTO_UDP, mc_if);
 		if (!attach_receiver(flow_key)) {
-			return -1; // we will get RX from OS
+			// we will get RX from OS
+			return -1;
 		}
 		vma_stats_mc_group_add(mc_grp, m_p_socket_stats);
 		original_os_setsockopt_helper( &mreq_src, pram_size, p_mc_pram->optname);
@@ -2327,7 +2331,8 @@ int sockinfo_udp::mc_change_membership(const mc_pending_pram *p_mc_pram)
 	{
 		flow_tuple_with_local_if flow_key(mc_grp, m_bound.get_in_port(), 0, 0, PROTO_UDP, mc_if);
 		if (!attach_receiver(flow_key)) {
-			return -1; // we will get RX from OS
+			// we will get RX from OS
+			return -1;
 		}
 		vma_stats_mc_group_add(mc_grp, m_p_socket_stats);
 		pram_size = sizeof(ip_mreq_source);

--- a/src/vma/sock/sockinfo_udp.cpp
+++ b/src/vma/sock/sockinfo_udp.cpp
@@ -2311,7 +2311,7 @@ int sockinfo_udp::mc_change_membership(const mc_pending_pram *p_mc_pram)
 		// The address specified in bind() has a filtering role.
 		// i.e. sockets should discard datagrams which sent to an unbound ip address.
 		if (!m_bound.is_anyaddr() && mc_grp != m_bound.get_in_addr()) {
-			// Ignore for socketXtreme beacause m_bound is used as part of the legacy implementation
+			// Ignore for socketXtreme because m_bound is used as part of the legacy implementation
 			if (!safe_mce_sys().enable_socketxtreme) {
 				return -1; // Socket was bound to a different ip address
 			}


### PR DESCRIPTION
…different

ip address

The address specified in bind() has a filtering role, i.e. sockets
should discard datagrams which sent to an unbound ip address.

Signed-off-by: Liran Oz <lirano@mellanox.com>