### PR TITLE
issue: 925571 Add textual vma spec support and new latency spec

### DIFF
--- a/src/vma/main.cpp
+++ b/src/vma/main.cpp
@@ -75,7 +75,6 @@
 
 #include "vma/util/instrumentation.h"
 #include "vma/util/agent.h"
-#include "vma/util/sys_vars.h"
 
 void check_netperf_flags();
 

--- a/src/vma/main.cpp
+++ b/src/vma/main.cpp
@@ -75,6 +75,7 @@
 
 #include "vma/util/instrumentation.h"
 #include "vma/util/agent.h"
+#include "vma/util/sys_vars.h"
 
 void check_netperf_flags();
 
@@ -411,35 +412,8 @@ void print_vma_global_settings()
 		vlog_printf(log_level,"Node: %s\n", sys_info.nodename);
 	}
 
-	vlog_printf(log_level,"---------------------------------------------------------------------------\n");
-
-	switch (safe_mce_sys().mce_spec) {
-	case MCE_SPEC_SOCKPERF_LL_10:
-		vlog_printf(VLOG_INFO, " Sockperf ping-pong Low Latency Profile Spec\n");
-		break;
-	case MCE_SPEC_29WEST_LBM_29:
-		vlog_printf(VLOG_INFO, " 29West LBM Logic Spec\n");
-		break;
-	case MCE_SPEC_WOMBAT_FH_LBM_554:
-		vlog_printf(VLOG_INFO, " Wombat FH LBM Logic Spec\n");
-		break;
-	case MCE_SPEC_RTI_784:
-		vlog_printf(VLOG_INFO, " RTI Logic Spec\n");
-		break;
-	case MCE_SPEC_MCD_623:
-		vlog_printf(VLOG_INFO, " Memcached Logic Spec\n");
-		break;
-	case MCE_SPEC_MCD_IRQ_624:
-		vlog_printf(VLOG_INFO, " Memcached Interrupt Mode Logic Spec\n");
-		break;
-	case MCE_SPEC_LL_6973:
-		vlog_printf(VLOG_INFO, "6973 Low Latency Profile Spec\n");
-		break;
-	default:
-		break;
-	}
-	if (safe_mce_sys().mce_spec != 0) {
-		vlog_printf(VLOG_INFO, FORMAT_NUMBER, "Spec", safe_mce_sys().mce_spec, SYS_VAR_SPEC);
+	if (safe_mce_sys().mce_spec != MCE_SPEC_NONE) {
+		vlog_printf(VLOG_INFO, FORMAT_STRING, "Spec", vma_spec::to_str((vVMA_spec_t)safe_mce_sys().mce_spec), SYS_VAR_SPEC);
 
 		if (safe_mce_sys().mce_spec == MCE_SPEC_29WEST_LBM_29 || safe_mce_sys().mce_spec == MCE_SPEC_WOMBAT_FH_LBM_554) {
 			vlog_printf(VLOG_INFO, FORMAT_NUMBER, "Param 1:", safe_mce_sys().mce_spec_param1, SYS_VAR_SPEC_PARAM1);

--- a/src/vma/sock/pipeinfo.cpp
+++ b/src/vma/sock/pipeinfo.cpp
@@ -221,7 +221,7 @@ ssize_t pipeinfo::tx(const tx_call_t call_type, const iovec* p_iov, const ssize_
 	switch (call_type) {
 	case  TX_WRITE:
 
-		if ((safe_mce_sys().mce_spec == MCE_SPEC_29WEST_LBM_29 || safe_mce_sys().mce_spec == MCE_SPEC_WOMBAT_FH_LBM_554) &&
+		if ((safe_mce_sys().mce_spec == MCE_SPEC_29WEST_LBM_29 || safe_mce_sys().mce_spec == MCE_SPEC_WOMBAT_FH_LBM_554) && 
 		    (p_iov[0].iov_len == 1) && (((char*)p_iov[0].iov_base)[0] == '\0')) {
 
 			// We will pass one pipe write in every T usec

--- a/src/vma/sock/pipeinfo.cpp
+++ b/src/vma/sock/pipeinfo.cpp
@@ -221,7 +221,7 @@ ssize_t pipeinfo::tx(const tx_call_t call_type, const iovec* p_iov, const ssize_
 	switch (call_type) {
 	case  TX_WRITE:
 
-		if ((safe_mce_sys().mce_spec == MCE_SPEC_29WEST_LBM_29 || safe_mce_sys().mce_spec == MCE_SPEC_WOMBAT_FH_LBM_554) && 
+		if ((safe_mce_sys().mce_spec == MCE_SPEC_29WEST_LBM_29 || safe_mce_sys().mce_spec == MCE_SPEC_WOMBAT_FH_LBM_554) &&
 		    (p_iov[0].iov_len == 1) && (((char*)p_iov[0].iov_base)[0] == '\0')) {
 
 			// We will pass one pipe write in every T usec

--- a/src/vma/util/sys_vars.cpp
+++ b/src/vma/util/sys_vars.cpp
@@ -164,6 +164,60 @@ int mce_sys_var::list_to_cpuset(char *cpulist, cpu_set_t *cpu_set)
 
 }
 
+const char *vma_spec::names_none[]    	     = {"none", NULL};
+const char *vma_spec::spec_names_latency[]   = {"latency", "l", "L", "1", NULL};
+const char *vma_spec::spec_names_ulatency[]  = {"ultra-latency", "ul", "uL", "UL", "10", NULL};
+const char *vma_spec::spec_names_29west[]    = {"29west", "29WEST", "29", NULL};
+const char *vma_spec::spec_names_wombat_fh[] = {"wombat_fh", "WOMBAT_FH", "554", NULL};
+const char *vma_spec::spec_names_rti[]       = {"rti", "RTI", "784", NULL};
+const char *vma_spec::spec_names_mcd[]       = {"mcd", "MCD", "623", NULL};
+const char *vma_spec::spec_names_mcd_irq[]   = {"mcd-irq", "MCD-IRQ", "624", NULL};
+const char *vma_spec::spec_names_6973[]      = {"6973", NULL};
+
+// must be by order because "to_str" relies on that!
+const vma_spec_names vma_spec::specs[] = {
+		{MCE_SPEC_NONE, 		  "NONE",     			(const char ** )vma_spec::names_none},
+		{MCE_SPEC_SOCKPERF_LATENCY,    	  "Latency",   			(const char ** )vma_spec::spec_names_latency},
+		{MCE_SPEC_SOCKPERF_ULTRA_LATENCY, "Ultra Latency", 		(const char ** )vma_spec::spec_names_ulatency},
+		{MCE_SPEC_29WEST_LBM_29,    	  "29West LBM Logic",    	(const char ** )vma_spec::spec_names_29west},
+		{MCE_SPEC_WOMBAT_FH_LBM_554,      "Wombat FH LBM Logic",    	(const char ** )vma_spec::spec_names_wombat_fh},
+		{MCE_SPEC_RTI_784,    		  "RTI Logic",    		(const char ** )vma_spec::spec_names_rti},
+		{MCE_SPEC_MCD_623,    		  "Memcached Logic",    	(const char ** )vma_spec::spec_names_mcd},
+		{MCE_SPEC_MCD_IRQ_624,    	  "Memcached Interrupt Mode",	(const char ** )vma_spec::spec_names_mcd_irq},
+		{MCE_SPEC_LL_6973,    		  "6973 Low Latency Profile", 	(const char ** )vma_spec::spec_names_6973},
+};
+
+// convert str to vVMA_spec_t; upon error - returns the given 'def_value'
+vVMA_spec_t vma_spec::from_str(const char* str, vVMA_spec_t def_value)
+{
+	size_t num_levels = sizeof(specs) / sizeof(specs[0]);
+	for (size_t i = 0; i < num_levels; ++i) {
+		const char ** input_name = specs[i].input_names;
+		while (*input_name) {
+			if (strcasecmp(str, *input_name) == 0)
+				return specs[i].level;
+			input_name++;
+		}
+	}
+
+	return def_value; // not found. use given def_value
+}
+
+// convert int to vVMA_spec_t; upon error - returns the given 'def_value'
+vVMA_spec_t vma_spec::from_int(const int int_spec, vVMA_spec_t def_value)
+{
+	if (int_spec >= MCE_SPEC_NONE && int_spec <= MCE_VMA__ALL) {
+		return static_cast<vVMA_spec_t>(int_spec);
+	}
+	return def_value; // not found. use given def_value
+}
+
+const char * vma_spec::to_str(vVMA_spec_t level)
+{
+	static int base = MCE_SPEC_NONE;
+	return specs[level - base].output_name;
+}
+
 int mce_sys_var::hex_to_cpuset(char *start, cpu_set_t *cpu_set)
 {
 	const char *end;
@@ -408,7 +462,7 @@ void mce_sys_var::get_env_params()
 	mtu			= MCE_DEFAULT_MTU;
 	lwip_mss		= MCE_DEFAULT_MSS;
 	lwip_cc_algo_mod	= MCE_DEFAULT_LWIP_CC_ALGO_MOD;
-	mce_spec		= 0;
+	mce_spec		= MCE_SPEC_NONE;
 	mce_spec_param1		= 1;
 	mce_spec_param2		= 1;
 	
@@ -424,12 +478,41 @@ void mce_sys_var::get_env_params()
 	vma_time_measure_num_samples = MCE_DEFAULT_TIME_MEASURE_NUM_SAMPLES;
 #endif
 
-	if ((env_ptr = getenv(SYS_VAR_SPEC)) != NULL)
-		mce_spec = (uint32_t)atoi(env_ptr);
+	if ((env_ptr = getenv(SYS_VAR_SPEC)) != NULL){
+		mce_spec = (uint32_t)vma_spec::from_str(env_ptr, MCE_SPEC_NONE);
+	}
 
 	switch (mce_spec) {
+	case MCE_SPEC_SOCKPERF_LATENCY:
+		tx_num_wr         	= 256; //MCE_DEFAULT_TX_NUM_WRE
+		tx_num_wr_to_signal     = 4;   //MCE_DEFAULT_TX_NUM_WRE_TO_SIGNAL
+		tx_prefetch_bytes 	= 256; //MCE_DEFAULT_TX_PREFETCH_BYTES
+		tx_bufs_batch_udp	= 1;   //MCE_DEFAULT_TX_BUFS_BATCH_UDP
+		tx_bufs_batch_tcp	= 1;   //MCE_DEFAULT_TX_BUFS_BATCH_TCP;
+		rx_bufs_batch           = 4;   //MCE_DEFAULT_RX_BUFS_BATCH
+		rx_num_wr               = 256; //MCE_DEFAULT_RX_NUM_WRE
+		rx_num_wr_to_post_recv  = 4;   //MCE_DEFAULT_RX_NUM_WRE_TO_POST_RECV
+		rx_poll_num             = -1;  //MCE_DEFAULT_RX_NUM_POLLS
+		rx_prefetch_bytes 	= 256; //MCE_DEFAULT_RX_PREFETCH_BYTES
+		rx_prefetch_bytes_before_poll = 256; //MCE_DEFAULT_RX_PREFETCH_BYTES_BEFORE_POLL
+		select_poll_num         = -1;  //MCE_DEFAULT_SELECT_NUM_POLLS
+		avoid_sys_calls_on_tcp_fd = true; //MCE_DEFAULT_AVOID_SYS_CALLS_ON_TCP_FD
+		gro_streams_max		= 0; //MCE_DEFAULT_GRO_STREAMS_MAX
+		cq_keep_qp_full		= false; //MCE_DEFAULT_CQ_KEEP_QP_FULL
+		thread_mode 		= THREAD_MODE_SINGLE; //MCE_DEFAULT_THREAD_MODE;
+		mem_alloc_type 		= ALLOC_TYPE_HUGEPAGES; //MCE_DEFAULT_MEM_ALLOC_TYPE;
+		strcpy(internal_thread_affinity_str, "0"); //MCE_DEFAULT_INTERNAL_THREAD_AFFINITY_STR;
+		select_skip_os_fd_check = 4;         //MCE_DEFAULT_SELECT_SKIP_OS
+		rx_udp_poll_os_ratio    = 100; 	     //MCE_DEFAULT_RX_UDP_POLL_OS_RATIO
+		tx_num_segs_tcp         = 1000000;   //MCE_DEFAULT_TX_NUM_SEGS_TCP
+		rx_num_bufs             = 200000;    //MCE_DEFAULT_RX_NUM_BUFS
+		tx_num_bufs             = 200000;    //MCE_DEFAULT_TX_NUM_BUFS
+		progress_engine_interval_msec = 100; //MCE_DEFAULT_PROGRESS_ENGINE_INTERVAL_MSEC;
+		select_poll_os_ratio          = 100; //MCE_DEFAULT_SELECT_POLL_OS_RATIO
+		select_poll_os_force	= 1; 	     //MCE_DEFAULT_SELECT_POLL_OS_FORCE
+		break;
 
-	case MCE_SPEC_SOCKPERF_LL_10:
+	case MCE_SPEC_SOCKPERF_ULTRA_LATENCY:
 		tx_num_segs_tcp         = 512; //MCE_DEFAULT_TX_NUM_SEGS_TCP (1000000)
 		tx_num_bufs             = 512; //MCE_DEFAULT_TX_NUM_BUFS (200000)
 		tx_num_wr               = 256; //MCE_DEFAULT_TX_NUM_WRE (3000)
@@ -510,7 +593,7 @@ void mce_sys_var::get_env_params()
 		buffer_batching_mode      = BUFFER_BATCHING_NONE; //MCE_DEFAULT_BUFFER_BATCHING_MODE(BUFFER_BATCHING_WITH_RECLAIM), Disable handling control packets on a separate thread
 		break;
 		
-	case 0:
+	case MCE_SPEC_NONE:
 	default:
 		break;
 	}

--- a/src/vma/util/sys_vars.cpp
+++ b/src/vma/util/sys_vars.cpp
@@ -92,6 +92,71 @@ void mce_sys_var::print_vma_load_failure_msg()
 	vlog_printf(VLOG_ERROR,"***************************************************************************\n");
 }
 
+
+
+namespace vma_spec {
+	typedef struct {
+		vVMA_spec_t level;
+		const char *  output_name;
+		const char ** input_names;
+	}vma_spec_names;
+
+	static const char *names_none[]    	   = {"none", "0",NULL};
+	static const char *spec_names_ulatency[]  = {"ultra-latency", "10", NULL};
+	static const char *spec_names_latency[]   = {"latency", "15", NULL};
+	static const char *spec_names_29west[]    = {"29west", "29", NULL};
+	static const char *spec_names_wombat_fh[] = {"wombat_fh", "554", NULL};
+	static const char *spec_names_mcd[]       = {"mcd", "623", NULL};
+	static const char *spec_names_mcd_irq[]   = {"mcd-irq", "624", NULL};
+	static const char *spec_names_rti[]       = {"rti", "784", NULL};
+	static const char *spec_names_6973[]      = {"6973", NULL};
+
+	// must be by order because "to_str" relies on that!
+	static const vma_spec_names specs[] = {
+		{MCE_SPEC_NONE, 		  	"NONE",     			(const char ** )names_none},
+		{MCE_SPEC_SOCKPERF_ULTRA_LATENCY_10, 	"Ultra Latency", 		(const char ** )spec_names_ulatency},
+		{MCE_SPEC_SOCKPERF_LATENCY_15,    	"Latency",   			(const char ** )spec_names_latency},
+		{MCE_SPEC_29WEST_LBM_29,    	  	"29West LBM Logic",    		(const char ** )spec_names_29west},
+		{MCE_SPEC_WOMBAT_FH_LBM_554,      	"Wombat FH LBM Logic",    	(const char ** )spec_names_wombat_fh},
+		{MCE_SPEC_MCD_623,    		  	"Memcached Logic",    		(const char ** )spec_names_mcd},
+		{MCE_SPEC_MCD_IRQ_624,    	  	"Memcached Interrupt Mode",	(const char ** )spec_names_mcd_irq},
+		{MCE_SPEC_RTI_784,    		  	"RTI Logic",    		(const char ** )spec_names_rti},
+		{MCE_SPEC_LL_6973,    		  	"6973 Low Latency Profile", 	(const char ** )spec_names_6973},
+	};
+
+	// convert str to vVMA_spec_t; upon error - returns the given 'def_value'
+	vVMA_spec_t from_str(const char* str, vVMA_spec_t def_value)
+	{
+		size_t num_levels = sizeof(specs) / sizeof(specs[0]);
+		for (size_t i = 0; i < num_levels; ++i) {
+			const char ** input_name = specs[i].input_names;
+			while (*input_name) {
+				if (strcasecmp(str, *input_name) == 0)
+					return specs[i].level;
+				input_name++;
+			}
+		}
+
+		return def_value; // not found. use given def_value
+	}
+
+	// convert int to vVMA_spec_t; upon error - returns the given 'def_value'
+	vVMA_spec_t from_int(const int int_spec, vVMA_spec_t def_value)
+	{
+		if (int_spec >= MCE_SPEC_NONE && int_spec <= MCE_VMA__ALL) {
+			return static_cast<vVMA_spec_t>(int_spec);
+		}
+		return def_value; // not found. use given def_value
+	}
+
+	const char * to_str(vVMA_spec_t level)
+	{
+		static int base = MCE_SPEC_NONE;
+		return specs[level - base].output_name;
+	}
+
+}
+
 int mce_sys_var::list_to_cpuset(char *cpulist, cpu_set_t *cpu_set)
 {
 	char comma[] = ",";
@@ -162,60 +227,6 @@ int mce_sys_var::list_to_cpuset(char *cpulist, cpu_set_t *cpu_set)
 
         return 0;
 
-}
-
-const char *vma_spec::names_none[]    	     = {"none", NULL};
-const char *vma_spec::spec_names_latency[]   = {"latency", "l", "L", "1", NULL};
-const char *vma_spec::spec_names_ulatency[]  = {"ultra-latency", "ul", "uL", "UL", "10", NULL};
-const char *vma_spec::spec_names_29west[]    = {"29west", "29WEST", "29", NULL};
-const char *vma_spec::spec_names_wombat_fh[] = {"wombat_fh", "WOMBAT_FH", "554", NULL};
-const char *vma_spec::spec_names_rti[]       = {"rti", "RTI", "784", NULL};
-const char *vma_spec::spec_names_mcd[]       = {"mcd", "MCD", "623", NULL};
-const char *vma_spec::spec_names_mcd_irq[]   = {"mcd-irq", "MCD-IRQ", "624", NULL};
-const char *vma_spec::spec_names_6973[]      = {"6973", NULL};
-
-// must be by order because "to_str" relies on that!
-const vma_spec_names vma_spec::specs[] = {
-		{MCE_SPEC_NONE, 		  "NONE",     			(const char ** )vma_spec::names_none},
-		{MCE_SPEC_SOCKPERF_LATENCY,    	  "Latency",   			(const char ** )vma_spec::spec_names_latency},
-		{MCE_SPEC_SOCKPERF_ULTRA_LATENCY, "Ultra Latency", 		(const char ** )vma_spec::spec_names_ulatency},
-		{MCE_SPEC_29WEST_LBM_29,    	  "29West LBM Logic",    	(const char ** )vma_spec::spec_names_29west},
-		{MCE_SPEC_WOMBAT_FH_LBM_554,      "Wombat FH LBM Logic",    	(const char ** )vma_spec::spec_names_wombat_fh},
-		{MCE_SPEC_RTI_784,    		  "RTI Logic",    		(const char ** )vma_spec::spec_names_rti},
-		{MCE_SPEC_MCD_623,    		  "Memcached Logic",    	(const char ** )vma_spec::spec_names_mcd},
-		{MCE_SPEC_MCD_IRQ_624,    	  "Memcached Interrupt Mode",	(const char ** )vma_spec::spec_names_mcd_irq},
-		{MCE_SPEC_LL_6973,    		  "6973 Low Latency Profile", 	(const char ** )vma_spec::spec_names_6973},
-};
-
-// convert str to vVMA_spec_t; upon error - returns the given 'def_value'
-vVMA_spec_t vma_spec::from_str(const char* str, vVMA_spec_t def_value)
-{
-	size_t num_levels = sizeof(specs) / sizeof(specs[0]);
-	for (size_t i = 0; i < num_levels; ++i) {
-		const char ** input_name = specs[i].input_names;
-		while (*input_name) {
-			if (strcasecmp(str, *input_name) == 0)
-				return specs[i].level;
-			input_name++;
-		}
-	}
-
-	return def_value; // not found. use given def_value
-}
-
-// convert int to vVMA_spec_t; upon error - returns the given 'def_value'
-vVMA_spec_t vma_spec::from_int(const int int_spec, vVMA_spec_t def_value)
-{
-	if (int_spec >= MCE_SPEC_NONE && int_spec <= MCE_VMA__ALL) {
-		return static_cast<vVMA_spec_t>(int_spec);
-	}
-	return def_value; // not found. use given def_value
-}
-
-const char * vma_spec::to_str(vVMA_spec_t level)
-{
-	static int base = MCE_SPEC_NONE;
-	return specs[level - base].output_name;
 }
 
 int mce_sys_var::hex_to_cpuset(char *start, cpu_set_t *cpu_set)
@@ -483,36 +494,7 @@ void mce_sys_var::get_env_params()
 	}
 
 	switch (mce_spec) {
-	case MCE_SPEC_SOCKPERF_LATENCY:
-		tx_num_wr         	= 256; //MCE_DEFAULT_TX_NUM_WRE
-		tx_num_wr_to_signal     = 4;   //MCE_DEFAULT_TX_NUM_WRE_TO_SIGNAL
-		tx_prefetch_bytes 	= 256; //MCE_DEFAULT_TX_PREFETCH_BYTES
-		tx_bufs_batch_udp	= 1;   //MCE_DEFAULT_TX_BUFS_BATCH_UDP
-		tx_bufs_batch_tcp	= 1;   //MCE_DEFAULT_TX_BUFS_BATCH_TCP;
-		rx_bufs_batch           = 4;   //MCE_DEFAULT_RX_BUFS_BATCH
-		rx_num_wr               = 256; //MCE_DEFAULT_RX_NUM_WRE
-		rx_num_wr_to_post_recv  = 4;   //MCE_DEFAULT_RX_NUM_WRE_TO_POST_RECV
-		rx_poll_num             = -1;  //MCE_DEFAULT_RX_NUM_POLLS
-		rx_prefetch_bytes 	= 256; //MCE_DEFAULT_RX_PREFETCH_BYTES
-		rx_prefetch_bytes_before_poll = 256; //MCE_DEFAULT_RX_PREFETCH_BYTES_BEFORE_POLL
-		select_poll_num         = -1;  //MCE_DEFAULT_SELECT_NUM_POLLS
-		avoid_sys_calls_on_tcp_fd = true; //MCE_DEFAULT_AVOID_SYS_CALLS_ON_TCP_FD
-		gro_streams_max		= 0; //MCE_DEFAULT_GRO_STREAMS_MAX
-		cq_keep_qp_full		= false; //MCE_DEFAULT_CQ_KEEP_QP_FULL
-		thread_mode 		= THREAD_MODE_SINGLE; //MCE_DEFAULT_THREAD_MODE;
-		mem_alloc_type 		= ALLOC_TYPE_HUGEPAGES; //MCE_DEFAULT_MEM_ALLOC_TYPE;
-		strcpy(internal_thread_affinity_str, "0"); //MCE_DEFAULT_INTERNAL_THREAD_AFFINITY_STR;
-		select_skip_os_fd_check = 4;         //MCE_DEFAULT_SELECT_SKIP_OS
-		rx_udp_poll_os_ratio    = 100; 	     //MCE_DEFAULT_RX_UDP_POLL_OS_RATIO
-		tx_num_segs_tcp         = 1000000;   //MCE_DEFAULT_TX_NUM_SEGS_TCP
-		rx_num_bufs             = 200000;    //MCE_DEFAULT_RX_NUM_BUFS
-		tx_num_bufs             = 200000;    //MCE_DEFAULT_TX_NUM_BUFS
-		progress_engine_interval_msec = 100; //MCE_DEFAULT_PROGRESS_ENGINE_INTERVAL_MSEC;
-		select_poll_os_ratio          = 100; //MCE_DEFAULT_SELECT_POLL_OS_RATIO
-		select_poll_os_force	= 1; 	     //MCE_DEFAULT_SELECT_POLL_OS_FORCE
-		break;
-
-	case MCE_SPEC_SOCKPERF_ULTRA_LATENCY:
+	case MCE_SPEC_SOCKPERF_ULTRA_LATENCY_10:
 		tx_num_segs_tcp         = 512; //MCE_DEFAULT_TX_NUM_SEGS_TCP (1000000)
 		tx_num_bufs             = 512; //MCE_DEFAULT_TX_NUM_BUFS (200000)
 		tx_num_wr               = 256; //MCE_DEFAULT_TX_NUM_WRE (3000)
@@ -538,6 +520,28 @@ void mce_sys_var::get_env_params()
 		thread_mode		= THREAD_MODE_SINGLE;
 		mem_alloc_type          = ALLOC_TYPE_HUGEPAGES;
 		strcpy(internal_thread_affinity_str, "0"); //MCE_DEFAULT_INTERNAL_THREAD_AFFINITY_STR;
+		break;
+
+	case MCE_SPEC_SOCKPERF_LATENCY_15:
+		tx_num_wr         	= 256; //MCE_DEFAULT_TX_NUM_WRE (3000)
+		tx_num_wr_to_signal     = 4;   //MCE_DEFAULT_TX_NUM_WRE_TO_SIGNAL(64)
+		tx_bufs_batch_udp	= 1;   //MCE_DEFAULT_TX_BUFS_BATCH_UDP (8)
+		tx_bufs_batch_tcp	= 1;   //MCE_DEFAULT_TX_BUFS_BATCH_TCP (16)
+		rx_bufs_batch           = 4;   //MCE_DEFAULT_RX_BUFS_BATCH (64)
+		rx_num_wr               = 256; //MCE_DEFAULT_RX_NUM_WRE (16000)
+		rx_num_wr_to_post_recv  = 4;   //MCE_DEFAULT_RX_NUM_WRE_TO_POST_RECV (64)
+		rx_poll_num             = -1;  //MCE_DEFAULT_RX_NUM_POLLS (100000)
+		rx_prefetch_bytes_before_poll = 256; //MCE_DEFAULT_RX_PREFETCH_BYTES_BEFORE_POLL (0)
+		select_poll_num         = -1;  //MCE_DEFAULT_SELECT_NUM_POLLS (100000)
+		avoid_sys_calls_on_tcp_fd = true; //MCE_DEFAULT_AVOID_SYS_CALLS_ON_TCP_FD (false)
+		gro_streams_max		= 0; //MCE_DEFAULT_GRO_STREAMS_MAX (32)
+		cq_keep_qp_full		= false; //MCE_DEFAULT_CQ_KEEP_QP_FULL (true)
+		thread_mode 		= THREAD_MODE_SINGLE; //MCE_DEFAULT_THREAD_MODE (THREAD_MODE_MULTI)
+		mem_alloc_type 		= ALLOC_TYPE_HUGEPAGES; //MCE_DEFAULT_MEM_ALLOC_TYPE (ALLOC_TYPE_CONTIG)
+		strcpy(internal_thread_affinity_str, "0"); //MCE_DEFAULT_INTERNAL_THREAD_AFFINITY_STR ("-1")
+		progress_engine_interval_msec = 100; //MCE_DEFAULT_PROGRESS_ENGINE_INTERVAL_MSEC (10)
+		select_poll_os_ratio          = 100; //MCE_DEFAULT_SELECT_POLL_OS_RATIO (10)
+		select_poll_os_force	      = 1;   //MCE_DEFAULT_SELECT_POLL_OS_FORCE (0)
 		break;
 
 	case MCE_SPEC_29WEST_LBM_29:

--- a/src/vma/util/sys_vars.h
+++ b/src/vma/util/sys_vars.h
@@ -46,13 +46,13 @@
 
 typedef enum {
 	MCE_SPEC_NONE = 0,
-	MCE_SPEC_SOCKPERF_LATENCY,
-	MCE_SPEC_SOCKPERF_ULTRA_LATENCY,
+	MCE_SPEC_SOCKPERF_ULTRA_LATENCY_10,
+	MCE_SPEC_SOCKPERF_LATENCY_15,
 	MCE_SPEC_29WEST_LBM_29,
 	MCE_SPEC_WOMBAT_FH_LBM_554,
-	MCE_SPEC_RTI_784,
 	MCE_SPEC_MCD_623,
 	MCE_SPEC_MCD_IRQ_624,
+	MCE_SPEC_RTI_784,
 	MCE_SPEC_LL_6973,
 
 	MCE_VMA__ALL /* last element */
@@ -192,37 +192,15 @@ static inline const char* internal_thread_tcp_timer_handling_str(internal_thread
 	return "unsupported";
 }
 
-///////////////////
-typedef struct {
-	vVMA_spec_t level;
-	const char *  output_name;
-	const char ** input_names;
-}vma_spec_names;
-
-class vma_spec
-{
-public:
+namespace vma_spec {
 	// convert str to vVMA_spec_t; upon error - returns the given 'def_value'
-	static vVMA_spec_t from_str(const char* str, vVMA_spec_t def_value);
+	vVMA_spec_t from_str(const char* str, vVMA_spec_t def_value = MCE_SPEC_NONE);
 
 	// convert int to vVMA_spec_t; upon error - returns the given 'def_value'
-	static vVMA_spec_t from_int(const int int_spec, vVMA_spec_t def_value);
+	vVMA_spec_t from_int(const int int_spec, vVMA_spec_t def_value = MCE_SPEC_NONE);
 
-	static const char * to_str(vVMA_spec_t level);
-
-	static const char *names_none[];
-	static const char *spec_names_latency[];
-	static const char *spec_names_ulatency[];
-	static const char *spec_names_29west[];
-	static const char *spec_names_wombat_fh[];
-	static const char *spec_names_rti[];
-	static const char *spec_names_mcd[];
-	static const char *spec_names_mcd_irq[];
-	static const char *spec_names_6973[];
-
-	// must be by order because "to_str" relies on that!
-	static const vma_spec_names specs[];
-};
+	const char * to_str(vVMA_spec_t level);
+}
 
 ////////////////////////////////////////////////////////////////////////////////
 class vma_exception_handling

--- a/src/vma/util/sys_vars.h
+++ b/src/vma/util/sys_vars.h
@@ -44,18 +44,19 @@
 #include "verbs_extra.h"
 #include "vma/util/sysctl_reader.h"
 
-
 typedef enum {
-	MCE_SPEC_DEFAULT = 0,
-	MCE_SPEC_SOCKPERF_LL_10 = 10,
-	MCE_SPEC_29WEST_LBM_29 = 29,
-	MCE_SPEC_WOMBAT_FH_LBM_554 = 554,
-	MCE_SPEC_RTI_784 = 784,
-	MCE_SPEC_NETEFFECT_63 = 63,
-	MCE_SPEC_MCD_623 = 623,
-	MCE_SPEC_MCD_IRQ_624 = 624,
-	MCE_SPEC_LL_6973 = 6973,
-} mce_spec_t;
+	MCE_SPEC_NONE = 0,
+	MCE_SPEC_SOCKPERF_LATENCY,
+	MCE_SPEC_SOCKPERF_ULTRA_LATENCY,
+	MCE_SPEC_29WEST_LBM_29,
+	MCE_SPEC_WOMBAT_FH_LBM_554,
+	MCE_SPEC_RTI_784,
+	MCE_SPEC_MCD_623,
+	MCE_SPEC_MCD_IRQ_624,
+	MCE_SPEC_LL_6973,
+
+	MCE_VMA__ALL /* last element */
+} vVMA_spec_t;
 
 typedef enum {
 	ALLOC_TYPE_ANON = 0,
@@ -190,6 +191,38 @@ static inline const char* internal_thread_tcp_timer_handling_str(internal_thread
 	}
 	return "unsupported";
 }
+
+///////////////////
+typedef struct {
+	vVMA_spec_t level;
+	const char *  output_name;
+	const char ** input_names;
+}vma_spec_names;
+
+class vma_spec
+{
+public:
+	// convert str to vVMA_spec_t; upon error - returns the given 'def_value'
+	static vVMA_spec_t from_str(const char* str, vVMA_spec_t def_value);
+
+	// convert int to vVMA_spec_t; upon error - returns the given 'def_value'
+	static vVMA_spec_t from_int(const int int_spec, vVMA_spec_t def_value);
+
+	static const char * to_str(vVMA_spec_t level);
+
+	static const char *names_none[];
+	static const char *spec_names_latency[];
+	static const char *spec_names_ulatency[];
+	static const char *spec_names_29west[];
+	static const char *spec_names_wombat_fh[];
+	static const char *spec_names_rti[];
+	static const char *spec_names_mcd[];
+	static const char *spec_names_mcd_irq[];
+	static const char *spec_names_6973[];
+
+	// must be by order because "to_str" relies on that!
+	static const vma_spec_names specs[];
+};
 
 ////////////////////////////////////////////////////////////////////////////////
 class vma_exception_handling


### PR DESCRIPTION
	Added textual support for VMA_SPEC parameter
	* VMA_SPEC=10 is now VMA_SPEC=ultra-latency.
	* Numeric parameters are still supported
	Added new latency spec [VMA_SPEC=latency]

Signed-off-by: Daniel Libenson <daneilli@mellanox.com>