### PR TITLE
issue: 933236 Improve debian remove package procedure

### DIFF
--- a/debian/postinst
+++ b/debian/postinst
@@ -20,4 +20,4 @@ fi
 if type systemctl >/dev/null 2>&1; then
     systemctl --system daemon-reload
 fi
-/etc/init.d/vma start
+/etc/init.d/vma start || true

--- a/debian/postrm
+++ b/debian/postrm
@@ -1,3 +1,2 @@
 #!/bin/bash
-rm -rf /etc/init.d/vma
 /sbin/ldconfig

--- a/debian/prerm
+++ b/debian/prerm
@@ -1,3 +1,13 @@
 #!/bin/bash
 
 /etc/init.d/vma stop || true
+if [ -e /sbin/chkconfig ]; then
+    /sbin/chkconfig --del vma
+elif [ -e /usr/sbin/update-rc.d ]; then
+    /usr/sbin/update-rc.d -f vma remove
+else
+    /usr/lib/lsb/remove_initd /etc/init.d/vma
+fi
+if type systemctl >/dev/null 2>&1; then
+    systemctl --system daemon-reload
+fi


### PR DESCRIPTION
This change correct debian uninstallation proceudre to allow
cleanuping all installed files.
Before this changes reinstallation was failed due to existing
files remained after previous installation.

Signed-off-by: Igor Ivanov <igori@mellanox.com>