### PR TITLE
issue: 946914 epoll_create() - libvma behavior incompatible with OS

### DIFF
--- a/src/vma/sock/sock-redirect.cpp
+++ b/src/vma/sock/sock-redirect.cpp
@@ -1798,6 +1798,12 @@ int epoll_create(int __size)
 
 	do_global_ctors();
 
+	if (__size <= 0 ) {
+		vlog_printf(VLOG_DEBUG, "%s: invalid size (size=%d) - must be a positive integer\n", __func__, __size);
+		errno = EINVAL;
+		return -1;
+	}
+
 	int epfd = orig_os_api.epoll_create(__size + 1);  // +1 for the cq epfd
 	vlog_printf(VLOG_DEBUG, "ENTER: %s(size=%d) = %d\n",__func__, __size, epfd);
 


### PR DESCRIPTION
OS does not support creating epoll fd's using epoll_create() with zero size.
The current libvma implemention of epoll_create() calls
os.epoll_create(size + 1) - hence, while the size is 0, there is no error.
We should handle this like the OS does : return -1 and set the errno to EINVAL.

Signed-off-by: Liran Oz <lirano@mellanox.com>