### PR TITLE
issue: 943551 Fix received UDP vlan over bond (fail_over_mac=1) print…

### DIFF
--- a/src/vma/sock/sockinfo.cpp
+++ b/src/vma/sock/sockinfo.cpp
@@ -435,7 +435,7 @@ bool sockinfo::attach_receiver(flow_tuple_with_local_if &flow_key)
 	// Allocate resources on specific interface (create ring)
 	net_device_resources_t* p_nd_resources = create_nd_resources((const ip_address)flow_key.get_local_if());
 	if (NULL == p_nd_resources) {
-		si_logerr("Failed to get net device resources %s", flow_key.to_str());
+		// any error which occurred inside create_nd_resources() was already printed. No need to reprint errors here
 		return false;
 	}
 


### PR DESCRIPTION
…s an error

attach_receiver() failed registering as observer for local ip <vlan local IP>
Error message is a false alarm as it is a repetition of an existing debug message
Error message was removed

Signed-off-by: Ophir Munk <ophirmu@mellanox.com>