### PR TITLE
issue: 955209 vma_extra.h: zero-copy example specifies using

### DIFF
--- a/src/vma/vma_extra.h
+++ b/src/vma/vma_extra.h
@@ -752,10 +752,10 @@ myapp_processes_packet_func(
 {
 	myapp_processes_packet_func(.....);
 
-	// Return zero copied datagram buffer back to VMA
+	// Return zero copied packet buffer back to VMA
 	// Would be better to collect a bunch of buffers and return them all at once
 	// which will save locks inside VMA
-	vma_api->free_datagrams(s, &packet_id, 1);
+	vma_api->free_packets(s, &packet_id, 1);
 }
 
 


### PR DESCRIPTION
free_datagrams() instead of free_packets()

Signed-off-by: Liran Oz <lirano@mellanox.com>