### PR TITLE
issue: 564154 - support dynamic buffer pool

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -119,14 +119,14 @@ Example:
  VMA DETAILS: Ring limit per interface       0 (no limit)               [VMA_RING_LIMIT_PER_INTERFACE]
  VMA DETAILS: TCP max syn rate               0 (no limit)               [VMA_TCP_MAX_SYN_RATE]
  VMA DETAILS: Tx Mem Segs TCP                1000000                    [VMA_TX_SEGS_TCP]
- VMA DETAILS: Tx Mem Bufs                    200000                     [VMA_TX_BUFS]
+ VMA DETAILS: Tx Mem Bufs                    200000:0:200000:0          [VMA_TX_BUFS]
  VMA DETAILS: Tx QP WRE                      3000                       [VMA_TX_WRE]
  VMA DETAILS: Tx QP WRE Batching             64                         [VMA_TX_WRE_BATCHING]
  VMA DETAILS: Tx Max QP INLINE               220                        [VMA_TX_MAX_INLINE]
  VMA DETAILS: Tx MC Loopback                 Enabled                    [VMA_TX_MC_LOOPBACK]
  VMA DETAILS: Tx non-blocked eagains         Disabled                   [VMA_TX_NONBLOCKED_EAGAINS]
  VMA DETAILS: Tx Prefetch Bytes              256                        [VMA_TX_PREFETCH_BYTES]
- VMA DETAILS: Rx Mem Bufs                    200000                     [VMA_RX_BUFS]
+ VMA DETAILS: Rx Mem Bufs                    200000:0:200000:0          [VMA_RX_BUFS]
  VMA DETAILS: Rx QP WRE                      16000                      [VMA_RX_WRE]
  VMA DETAILS: Rx QP WRE BATCHING             64                         [VMA_RX_WRE_BATCHING]
  VMA DETAILS: Rx Byte Min Limit              65536                      [VMA_RX_BYTES_MIN]
@@ -322,8 +322,17 @@ Number of TCP LWIP segments allocation for each VMA process.
 Default value is 1000000
 
 VMA_TX_BUFS
-Number of global Tx data buffer elements allocation.
-Default value is 200000
+<init:quanta:max:threshold>
+Number of global Tx data buffer elements allocation divided to initial amount of elements to be
+allocated at first, number of additional elements to allocate when required, maximum limit of
+elements in case of additional dynamic allocations and minimum threshold of free elements
+to triger asynchroniuosly addtional allocation. When buffer pool is exhausted and more are
+requested - additional pools are allocated synchroniously.
+Can also accept a single integer as an argument, in which case it will be used
+as init and max, and quanta and threshold will be set to 0.
+If bad values are given (such as init/max == 0 or max<init), will revert to default values.
+Default value is 200000:0:200000:0 (200000 buffers are allocated initially and no additional
+buffers will be allocated).
 
 VMA_TX_WRE
 Number of Work Request Elements allocated in all transmit QP's.
@@ -411,9 +420,17 @@ Use a value of 0 for unlimited number of rings.
 Default value is 0 (no limit)
 
 VMA_RX_BUFS
-Number Rx data buffer elements allocation for the processes. These data buffers
-will be used by all QPs on all HCAs as determined by the VMA_QP_LOGIC.
-Default value is 200000
+<init:quanta:max:threshold>
+Number of global Rx data buffer elements allocation divided to initial amount of elements to be
+allocated at first, number of additional elements to allocate when required, maximum limit of
+elements in case of additional dynamic allocations and minimum threshold of free elements to
+trigger asynchroniuosly addtional allocation. When buffer pool is exhausted and more are
+requested - additional pools are allocated synchroniously.
+Can also accept a single integer as an argument, in which case it will be used
+as init and max, and quanta and threshold will be set to 0.
+If bad values are given (such as init/max == 0 or max<init), will revert to default values.
+Default value is 200000:0:200000:0 (200000 buffers are allocated initially and no additional
+buffers will be allocated)
 
 VMA_RX_WRE
 Number of Work Request Elements allocated in all receive QP's. 

--- a/src/stats/stats_reader.cpp
+++ b/src/stats/stats_reader.cpp
@@ -253,8 +253,8 @@ void update_delta_bpool_stat(bpool_stats_t* p_curr_bpool_stats, bpool_stats_t* p
 {
 	int delay = INTERVAL;
 	if (p_curr_bpool_stats && p_prev_bpool_stats) {
-		p_prev_bpool_stats->n_buffer_pool_size = p_curr_bpool_stats->n_buffer_pool_size;
-		p_prev_bpool_stats->n_buffer_pool_no_bufs = (p_curr_bpool_stats->n_buffer_pool_no_bufs - p_prev_bpool_stats->n_buffer_pool_no_bufs) / delay;
+		p_prev_bpool_stats->n_buffer_pool_size_free = p_curr_bpool_stats->n_buffer_pool_size_free;
+		p_prev_bpool_stats->n_buffer_pool_size_total = (p_curr_bpool_stats->n_buffer_pool_size_total - p_prev_bpool_stats->n_buffer_pool_size_total) / delay;
 	}
 }
 
@@ -322,14 +322,9 @@ void print_bpool_stats(bpool_instance_block_t* p_bpool_inst_arr)
 		if (p_bpool_inst_arr && p_bpool_inst_arr[i].b_enabled) {
 			p_bpool_stats = &p_bpool_inst_arr[i].bpool_stats;
 			printf("======================================================\n");
-			if (p_bpool_stats->is_rx)
-				printf("\tBUFFER_POOL(RX)=[%u]\n", i);
-			else if (p_bpool_stats->is_tx)
-				printf("\tBUFFER_POOL(TX)=[%u]\n", i);
-			else
-				printf("\tBUFFER_POOL=[%u]\n", i);
-			printf(FORMAT_CQ_STATS_32bit, "Size:", p_bpool_stats->n_buffer_pool_size);
-			printf(FORMAT_CQ_STATS_32bit, "No buffers error:", p_bpool_stats->n_buffer_pool_no_bufs);
+			printf("\tBUFFER_POOL(%s)=[%u]\n", p_bpool_stats->is_rx ? "RX" : "TX", i);
+			printf(FORMAT_CQ_STATS_32bit, "Free Buffers:", p_bpool_stats->n_buffer_pool_size_free);
+			printf(FORMAT_CQ_STATS_32bit, "Total Buffers:", p_bpool_stats->n_buffer_pool_size_total);
 		}
 	}
 	printf("======================================================\n");
@@ -1288,8 +1283,8 @@ void zero_cq_stats(cq_stats_t* p_cq_stats)
 
 void zero_bpool_stats(bpool_stats_t* p_bpool_stats)
 {
-	p_bpool_stats->n_buffer_pool_size = 0;
-	p_bpool_stats->n_buffer_pool_no_bufs = 0;
+	p_bpool_stats->n_buffer_pool_size_free = 0;
+	p_bpool_stats->n_buffer_pool_size_total = 0;
 }
 
 void zero_counters(sh_mem_t* p_sh_mem)

--- a/src/vma/Makefile.am
+++ b/src/vma/Makefile.am
@@ -69,6 +69,7 @@ libvma_la_LIBADD = \
 libvma_la_SOURCES := \
 	dev/ah_cleaner.cpp \
 	dev/buffer_pool.cpp \
+	dev/dynamic_buffer_pool.cpp \
 	dev/cq_mgr.cpp \
 	dev/qp_mgr.cpp \
 	dev/gro_mgr.cpp \
@@ -153,6 +154,7 @@ libvma_la_SOURCES := \
 	\
 	dev/ah_cleaner.h \
 	dev/buffer_pool.h \
+	dev/dynamic_buffer_pool.h \
 	dev/cq_mgr.h \
 	dev/gro_mgr.h \
 	dev/ib_ctx_handler_collection.h \

--- a/src/vma/dev/buffer_pool.h
+++ b/src/vma/dev/buffer_pool.h
@@ -112,8 +112,8 @@ private:
 	// pointer to data block
 	void		*m_data_block;
 	
-        // contiguous pages allocation indicator
-        bool m_is_contig_alloc;
+    // contiguous pages allocation indicator
+    bool m_is_contig_alloc;
 
 	// Shared memory ID, if allocated in hugetlb
 	int		m_shmid;
@@ -131,9 +131,6 @@ private:
 	mem_buf_desc_t *m_p_head;
 	size_t		m_n_buffers;
 	size_t		m_n_buffers_created;
-
-	bpool_stats_t* 	m_p_bpool_stat;
-	bpool_stats_t 	m_bpool_stat_static;
 
 	/**
 	 * Allocate data block in hugetlb memory
@@ -167,9 +164,5 @@ private:
 	 */
 	void		free_bpool_resources();
 };
-
-extern buffer_pool* g_buffer_pool_rx;
-extern buffer_pool* g_buffer_pool_tx;
-
 
 #endif

--- a/src/vma/dev/cq_mgr.cpp
+++ b/src/vma/dev/cq_mgr.cpp
@@ -45,7 +45,7 @@
 #include "vma/util/instrumentation.h"
 #include <vma/sock/sock-redirect.h>
 
-#include "buffer_pool.h"
+#include "dynamic_buffer_pool.h"
 #include "qp_mgr.h"
 #include "ring_simple.h"
 
@@ -539,14 +539,14 @@ void cq_mgr::process_cq_element_log_helper(mem_buf_desc_t* p_mem_buf_desc, vma_i
 			cq_logdbg("wce: bad rx_csum");
 		cq_logdbg("wce: opcode=%#x, byte_len=%#d, src_qp=%#x, wc_flags=%#x", vma_wc_opcode(*p_wce), p_wce->byte_len, p_wce->src_qp, vma_wc_flags(*p_wce));
 		cq_logdbg("wce: pkey_index=%#x, slid=%#x, sl=%#x, dlid_path_bits=%#x, imm_data=%#x", p_wce->pkey_index, p_wce->slid, p_wce->sl, p_wce->dlid_path_bits, p_wce->imm_data);
-		cq_logdbg("mem_buf_desc: lkey=%#x, p_buffer=%p, sz_buffer=%#x", p_mem_buf_desc->lkey, p_mem_buf_desc->p_buffer, p_mem_buf_desc->sz_buffer);
+		cq_logdbg("mem_buf_desc: p_buffer=%p, sz_buffer=%#x",p_mem_buf_desc->p_buffer, p_mem_buf_desc->sz_buffer);
 	} else if (p_wce->status != IBV_WC_WR_FLUSH_ERR) {
 		cq_logwarn("wce: wr_id=%#x, status=%#x, vendor_err=%#x, qp_num=%#x", p_wce->wr_id, p_wce->status, p_wce->vendor_err, p_wce->qp_num);
 		cq_loginfo("wce: opcode=%#x, byte_len=%#d, src_qp=%#x, wc_flags=%#x", vma_wc_opcode(*p_wce), p_wce->byte_len, p_wce->src_qp, vma_wc_flags(*p_wce));
 		cq_loginfo("wce: pkey_index=%#x, slid=%#x, sl=%#x, dlid_path_bits=%#x, imm_data=%#x", p_wce->pkey_index, p_wce->slid, p_wce->sl, p_wce->dlid_path_bits, p_wce->imm_data);
 
 		if (p_mem_buf_desc) {
-			cq_logwarn("mem_buf_desc: lkey=%#x, p_buffer=%p, sz_buffer=%#x", p_mem_buf_desc->lkey, p_mem_buf_desc->p_buffer, p_mem_buf_desc->sz_buffer);
+			cq_logwarn("mem_buf_desc: p_buffer=%p, sz_buffer=%#x",p_mem_buf_desc->p_buffer, p_mem_buf_desc->sz_buffer);
 		}
 	}
 	BULLSEYE_EXCLUDE_BLOCK_END

--- a/src/vma/dev/dynamic_buffer_pool.cpp
+++ b/src/vma/dev/dynamic_buffer_pool.cpp
@@ -1,0 +1,262 @@
+/*
+ * Copyright (C) Mellanox Technologies Ltd. 2001-2013.  ALL RIGHTS RESERVED.
+ *
+ * This software product is a proprietary product of Mellanox Technologies Ltd.
+ * (the "Company") and all right, title, and interest in and to the software product,
+ * including all associated intellectual property rights, are and shall
+ * remain exclusively with the Company.
+ *
+ * This software is made available under either the GPL v2 license or a commercial license.
+ * If you wish to obtain a commercial license, please contact Mellanox at support@mellanox.com.
+ */
+
+
+#include "dynamic_buffer_pool.h"
+#include "vlogger/vlogger.h"
+#include "vma/event/event_handler_manager.h"
+
+dynamic_buffer_pool *g_buffer_pool_rx = NULL;
+dynamic_buffer_pool *g_buffer_pool_tx = NULL;
+
+dynamic_buffer_pool::dynamic_buffer_pool(size_t init_buffers_count, size_t buffer_size,
+		size_t quanta_buffers_count, size_t max_buffers, size_t free_buffers_min_threshold,
+		bool is_rx, pbuf_free_custom_fn custom_free_function):
+		m_lock_spin("dynamic_buffer_pool"),
+		m_n_dyn_buffers(0), m_n_dyn_buffers_created(0), m_buffer_size(buffer_size),
+		m_quanta_buffers_count(quanta_buffers_count),
+		m_max_buffers(max_buffers), m_min_threshold(free_buffers_min_threshold),
+		m_custom_free_function(custom_free_function), m_curr_bpool(NULL),
+		m_need_alloc(false), m_curr_bp_is_max(false), m_rx_stat(is_rx), m_p_bpool_stat(NULL)
+{
+	m_p_bpool_stat = &m_bpool_stat_static;
+	memset(m_p_bpool_stat , 0, sizeof(*m_p_bpool_stat));
+	vma_stats_instance_create_bpool_block(m_p_bpool_stat);
+	m_p_bpool_stat->is_rx = is_rx ? true : false; // prettier than: "...->is_rx = is_rx"
+
+	allocate_addtional_buffers(init_buffers_count);
+	m_p_timer_handler = new dynamic_bpool_timer_handler(this);
+}
+
+dynamic_buffer_pool::~dynamic_buffer_pool()
+{
+	// update current buffer pools
+	delete m_p_timer_handler;
+	vma_stats_instance_remove_bpool_block(m_p_bpool_stat);
+
+	std::deque<buffer_pool*>::iterator iter_bps;
+	buffer_pool* bp;
+	for (iter_bps = m_bpools_dque.begin(); iter_bps != m_bpools_dque.end(); ++iter_bps) {
+		bp = (*iter_bps);
+		delete bp;
+	}
+	m_bpools_dque.clear();
+}
+
+mem_buf_desc_t *dynamic_buffer_pool::get_buffers(size_t count, uint32_t lkey)
+{
+	mem_buf_desc_t *desc=NULL;
+
+	/* if not enough buffers and buffers were returned to a bpool then we need to update curr bp
+	 * to be the bp with max free buffs.
+	 */
+	if (count > m_curr_bpool->get_free_count() && !m_curr_bp_is_max) {
+		update_max_free_bpool();
+	}
+	desc = m_curr_bpool->get_buffers(count, lkey);
+
+	/* no more buffers, pool exhausted before event_handler could allocate more */
+	if (unlikely(!desc)) {
+		/* default - return NULL and wait for timer to allocate more buffers.*/
+		vlog_printf(VLOG_DEBUG, "Buffer pools exhausted. %d buffers. Maximum limit=%d , total buffers=%d, free buffers=%d\n", count, m_max_buffers, m_n_dyn_buffers_created, m_n_dyn_buffers);
+		return NULL;
+	}
+	m_n_dyn_buffers -= count;
+	m_p_bpool_stat->n_buffer_pool_size_free -= count;
+
+	return desc;
+}
+
+void dynamic_buffer_pool::put_buffers(descq_t *buffers, size_t count)
+{
+	mem_buf_desc_t *buff_list;
+	while (count > 0 && !buffers->empty()) {
+		buff_list = buffers->back();
+		buffers->pop_back();
+		put_buffers(buff_list);
+		--count;
+	}
+}
+
+int dynamic_buffer_pool::put_buffers(mem_buf_desc_t *buff_list)
+{
+	mem_buf_desc_t *curr, *next;
+	buffer_pool* bpool;
+	int count=0;
+
+	if (!buff_list)
+		return 0;
+
+	// return buffers lists belonging to the same bpool
+	while (buff_list) {
+		curr=buff_list;
+		bpool=buff_list->p_bpool;
+		next=curr->p_next_desc;
+		while ((next) && (next->p_bpool == bpool)) {
+			curr=next;
+			next=next->p_next_desc;
+		}
+		curr->p_next_desc=NULL;
+		if (next)
+			next->p_prev_desc=NULL;
+
+		count+=bpool->put_buffers(buff_list);
+		buff_list=next;
+	}
+
+	if (m_curr_bp_is_max)
+		m_curr_bp_is_max=false;
+
+	m_n_dyn_buffers += count;
+	m_p_bpool_stat->n_buffer_pool_size_free += count;
+
+	return count;
+}
+
+
+
+int dynamic_buffer_pool::allocate_addtional_buffers(size_t count)
+{
+	//auto_unlocker lock(m_lock_spin);
+	m_need_alloc=false;
+
+	if (count + m_n_dyn_buffers_created > m_max_buffers) {
+		vlog_printf(VLOG_DEBUG, "Cannot allocate additional %d buffers. Maximum limit=%d , total buffers=%d, free buffers=%d\n", count, m_max_buffers, m_n_dyn_buffers_created, m_n_dyn_buffers);
+		return -1;
+	}
+	//buffer_pool::buffer_pool(size_t buffer_count, size_t buf_size, ib_ctx_handler *p_ib_ctx_h, mem_buf_desc_owner *owner, pbuf_free_custom_fn custom_free_function) :
+	//m_lock_spin("buffer_pool"), m_is_contig_alloc(true), m_shmid(-1), m_lkey(0), m_p_ib_ctx_h(p_ib_ctx_h),
+	//m_p_head(NULL), m_n_buffers(0), m_n_buffers_created(buffer_count)
+
+	m_curr_bpool = new buffer_pool(count, m_buffer_size, NULL, NULL, m_custom_free_function);
+	if (!m_curr_bpool){
+		vlog_printf(VLOG_ERROR, "No memory. Cannot allocate additional %d buffers. Maximum limit=%d , total buffers=%d, free buffers=%d\n", count, m_max_buffers, m_n_dyn_buffers_created, m_n_dyn_buffers);
+		return -1;
+	}
+	m_bpools_dque.push_back(m_curr_bpool);
+
+	m_n_dyn_buffers_created += count;
+	m_n_dyn_buffers += count;
+	m_p_bpool_stat->n_buffer_pool_size_free += count;
+	m_p_bpool_stat->n_buffer_pool_size_total += count;
+
+	update_max_free_bpool();
+
+	vlog_printf(VLOG_INFO, "Allocated %d buffers. Maximum limit=%d , total buffers=%d, free buffers=%d\n", count, m_max_buffers, m_n_dyn_buffers_created, m_n_dyn_buffers);
+
+	return 0;
+}
+
+void dynamic_buffer_pool::update_max_free_bpool()
+{
+	std::deque<buffer_pool*>::iterator iter_bps;
+	buffer_pool* p_bp;
+	for (iter_bps = m_bpools_dque.begin(); iter_bps != m_bpools_dque.end(); ++iter_bps) {
+		p_bp=(*iter_bps);
+		if (p_bp->get_free_count()> m_curr_bpool->get_free_count()) {
+			m_curr_bpool = p_bp;
+		}
+	}
+	m_curr_bp_is_max=true;
+}
+
+
+/** Free-callback function to free a 'struct pbuf_custom_ref', called by
+ * pbuf_free. */
+void dynamic_buffer_pool::free_rx_lwip_pbuf_custom(struct pbuf *p_buff)
+{
+	g_buffer_pool_rx->put_buffers_thread_safe((mem_buf_desc_t *)p_buff);
+}
+
+void dynamic_buffer_pool::free_tx_lwip_pbuf_custom(struct pbuf *p_buff)
+{
+	g_buffer_pool_tx->put_buffers_thread_safe((mem_buf_desc_t *)p_buff);
+}
+
+void dynamic_bpool_timer_handler::handle_timer_expired(void* a)
+{
+	NOT_IN_USE(a);
+	if (m_p_pool_obj->m_lock_spin.trylock())
+		return;
+
+	if (m_p_pool_obj->m_n_dyn_buffers < m_p_pool_obj->m_min_threshold) {
+		vlog_printf(VLOG_INFO, "pool allocation signaled: dyn_rx_n_buffers=%d cur_rx_buffers=%d\n",
+				m_p_pool_obj->get_free_count(), m_p_pool_obj->get_curr_free_count());
+		m_p_pool_obj->allocate_addtional_buffers(m_p_pool_obj->m_quanta_buffers_count);
+	}
+	m_p_pool_obj->m_lock_spin.unlock();
+}
+
+int dynamic_buffer_pool::put_buffers_thread_safe(mem_buf_desc_t *buff_list)
+{
+	auto_unlocker lock(m_lock_spin);
+	return put_buffers(buff_list);
+}
+
+void dynamic_buffer_pool::put_buffers_thread_safe(descq_t *buffers, size_t count)
+{
+	auto_unlocker lock(m_lock_spin);
+	put_buffers(buffers, count);
+}
+
+
+void dynamic_buffer_pool::put_buffers_after_deref(descq_t *pDeque)
+{
+	// Assume locked owner!!!
+	while (!pDeque->empty()) {
+		mem_buf_desc_t * list = pDeque->front();
+		pDeque->pop_front();
+		if (list->dec_ref_count() <= 1 && (list->lwip_pbuf.pbuf.ref-- <= 1)) {
+			put_buffers(list);
+		}
+	}
+}
+
+void dynamic_buffer_pool::put_buffers_after_deref_thread_safe(descq_t *pDeque)
+{
+	m_lock_spin.lock();
+	put_buffers_after_deref(pDeque);
+	m_lock_spin.unlock();
+}
+
+size_t dynamic_buffer_pool::get_free_count()
+{
+	return m_n_dyn_buffers;
+}
+
+size_t dynamic_buffer_pool::get_curr_free_count()
+{
+	return m_curr_bpool->get_free_count();
+}
+
+mem_buf_desc_t *dynamic_buffer_pool::get_buffers_thread_safe(size_t count, ib_ctx_handler *p_ib_ctx_h)
+{
+       uint32_t lkey = m_curr_bpool->find_lkey_by_ib_ctx(p_ib_ctx_h);
+
+       return get_buffers_thread_safe(count, lkey);
+}
+
+mem_buf_desc_t *dynamic_buffer_pool::get_buffers_thread_safe(size_t count, uint32_t lkey)
+{
+       mem_buf_desc_t *ret;
+
+       m_lock_spin.lock();
+       ret = get_buffers(count, lkey);
+       m_lock_spin.unlock();
+
+       return ret;
+}
+
+dynamic_bpool_timer_handler *dynamic_buffer_pool::get_timer_handler()
+{
+	return m_p_timer_handler;
+}

--- a/src/vma/dev/dynamic_buffer_pool.h
+++ b/src/vma/dev/dynamic_buffer_pool.h
@@ -1,0 +1,107 @@
+/*
+ * Copyright (C) Mellanox Technologies Ltd. 2001-2013.  ALL RIGHTS RESERVED.
+ *
+ * This software product is a proprietary product of Mellanox Technologies Ltd.
+ * (the "Company") and all right, title, and interest in and to the software product,
+ * including all associated intellectual property rights, are and shall
+ * remain exclusively with the Company.
+ *
+ * This software is made available under either the GPL v2 license or a commercial license.
+ * If you wish to obtain a commercial license, please contact Mellanox at support@mellanox.com.
+ */
+
+
+#ifndef DYNAMIC_BUFFER_POOL_H
+#define DYNAMIC_BUFFER_POOL_H
+
+#include "vma/dev/buffer_pool.h"
+#include "vma/event/timer_handler.h"
+#include <deque>
+
+class dynamic_buffer_pool;
+
+class dynamic_bpool_timer_handler : public timer_handler
+{
+public:
+	dynamic_bpool_timer_handler(dynamic_buffer_pool *pool_obj): m_p_pool_obj(pool_obj) {};
+	virtual void handle_timer_expired(void* a);
+
+private:
+	dynamic_buffer_pool *m_p_pool_obj;
+};
+
+/**
+ * A buffer pool with option to dynamically grow when a minimal threshold of free buffers is left.
+ * It starts with a single buffer_pool and provides an option to grow dynamically by allocating new buffer_pools once a minimal threshold of free buffers is reached.
+ * The user provides a callback to be called once the minimum free buffers threshold is reached and accordingly to decide what context and when to allocate additional buffers.
+ * The calls to get_buffers is never blocked on waiting for new buffers but returns with failure in case of lack of buffers.
+  */
+class dynamic_buffer_pool
+{
+	friend class dynamic_bpool_timer_handler;
+
+public:
+	dynamic_buffer_pool(size_t init_buffers_count, size_t buffer_size, size_t quanta_buffers_count, size_t max_buffers, size_t free_buffers_min_threshold,
+			bool is_rx, pbuf_free_custom_fn custom_free_function);
+	~dynamic_buffer_pool();
+
+	/**
+	 * Get buffers from the pool
+	 * @param count Number of buffers required.
+	 * @return List of buffers, or NULL if don't have enough buffers.
+	 */
+	mem_buf_desc_t*	get_buffers(size_t count, uint32_t lkey);
+
+	/**
+	 * Return buffers to the pool.
+	 */
+	void 		put_buffers(descq_t *buffers, size_t count);
+	int 		put_buffers(mem_buf_desc_t *buff_list);
+
+	static void 	free_rx_lwip_pbuf_custom(struct pbuf *p_buff);
+	static void 	free_tx_lwip_pbuf_custom(struct pbuf *p_buff);
+
+	int put_buffers_thread_safe(mem_buf_desc_t *buff_list);
+	void put_buffers_thread_safe(descq_t *buffers, size_t count);
+	void put_buffers_after_deref(descq_t *pDeque);
+	void put_buffers_after_deref_thread_safe(descq_t *pDeque);
+
+	size_t get_free_count();
+	size_t get_curr_free_count();
+
+	mem_buf_desc_t *get_buffers_thread_safe(size_t count, ib_ctx_handler *p_ib_ctx_h);
+	mem_buf_desc_t *get_buffers_thread_safe(size_t count, uint32_t lkey);
+	dynamic_bpool_timer_handler *get_timer_handler();
+
+private:
+	lock_spin       m_lock_spin;
+
+	size_t          m_n_dyn_buffers;
+	size_t          m_n_dyn_buffers_created;
+
+	const size_t m_buffer_size;
+	const size_t m_quanta_buffers_count;
+	const size_t m_max_buffers;
+	const size_t m_min_threshold;
+	const pbuf_free_custom_fn m_custom_free_function;
+
+	std::deque<buffer_pool*> m_bpools_dque;
+	buffer_pool* m_curr_bpool;
+	bool m_need_alloc;
+	bool m_curr_bp_is_max;
+	bool m_rx_stat;
+
+	bpool_stats_t* 	m_p_bpool_stat;
+	bpool_stats_t 	m_bpool_stat_static;
+
+	dynamic_bpool_timer_handler *m_p_timer_handler;
+
+	void 		update_max_free_bpool();
+	int allocate_addtional_buffers(size_t count);
+	bool get_need_alloc() { return m_need_alloc; }
+};
+
+extern dynamic_buffer_pool* g_buffer_pool_rx;
+extern dynamic_buffer_pool* g_buffer_pool_tx;
+
+#endif

--- a/src/vma/dev/ib_ctx_handler.cpp
+++ b/src/vma/dev/ib_ctx_handler.cpp
@@ -52,11 +52,18 @@
 #define ibch_logfunc            __log_info_func
 #define ibch_logfuncall         __log_info_funcall
 
+<<<<<<< HEAD
 
 
 ib_ctx_handler::ib_ctx_handler(struct ibv_context* ctx, ts_conversion_mode_t ctx_time_converter_mode) :
 	m_removed(false), m_conf_attr_rx_num_wre(0), m_conf_attr_tx_num_to_signal(0),
 	m_conf_attr_tx_max_inline(0), m_conf_attr_tx_num_wre(0), ctx_time_converter(ctx, ctx_time_converter_mode)
+=======
+ib_ctx_handler::ib_ctx_handler(struct ibv_context* ctx, size_t dev_index, ts_conversion_mode_t ctx_time_converter_mode) :
+	m_dev_index(dev_index), m_channel(0), m_removed(false), m_conf_attr_rx_num_wre(0),
+	m_conf_attr_tx_num_post_send_notify(0),	m_conf_attr_tx_max_inline(0), m_conf_attr_tx_num_wre(0),
+	ctx_time_converter(ctx, ctx_time_converter_mode)
+>>>>>>> 410c4f0... issue: 564154 - support dynamic buffer pool
 {
 	memset(&m_ibv_port_attr, 0, sizeof(m_ibv_port_attr));
 	m_p_ibv_context = ctx;

--- a/src/vma/dev/ib_ctx_handler.h
+++ b/src/vma/dev/ib_ctx_handler.h
@@ -43,7 +43,7 @@
 class ib_ctx_handler : public event_handler_ibverbs
 {
 public:
-	ib_ctx_handler(struct ibv_context* ctx, ts_conversion_mode_t ctx_time_converter_mode);
+	ib_ctx_handler(struct ibv_context* ctx, size_t dev_index, ts_conversion_mode_t ctx_time_converter_mode);
 	virtual ~ib_ctx_handler();
 	/*
 	 * on init or constructor:
@@ -53,7 +53,8 @@ public:
 	void                    set_dev_configuration();
 	ibv_mr*                 mem_reg(void *addr, size_t length, uint64_t access);
 	ibv_port_state          get_port_state(int port_num);
-	ibv_device*             get_ibv_device() { return m_p_ibv_device;}
+	ibv_device*             get_ibv_device() const { return m_p_ibv_device;}
+	size_t					get_dev_index() const { return m_dev_index; }
 	ibv_pd*			get_ibv_pd() { return m_p_ibv_pd;}
 	struct ibv_context*     get_ibv_context() { return m_p_ibv_context;}
 	vma_ibv_device_attr&    get_ibv_device_attr() { return m_ibv_device_attr;}
@@ -69,6 +70,7 @@ private:
 	struct ibv_context*     m_p_ibv_context;
 	struct ibv_port_attr    m_ibv_port_attr;
 	ibv_device*             m_p_ibv_device; // HCA handle
+	size_t                  m_dev_index; // for mr arr on buffer pool
 	vma_ibv_device_attr     m_ibv_device_attr;
 	ibv_pd*                 m_p_ibv_pd;
 	bool                    m_removed;

--- a/src/vma/dev/ib_ctx_handler_collection.cpp
+++ b/src/vma/dev/ib_ctx_handler_collection.cpp
@@ -98,7 +98,7 @@ void ib_ctx_handler_collection::map_ib_devices() //return num_devices, can use r
 
 	ibchc_logdbg("Mapping %d ibv devices", m_n_num_devices);
 	for (int i = 0; i < m_n_num_devices; i++) {
-		m_ib_ctx_map[pp_ibv_context_list[i]] = new ib_ctx_handler(pp_ibv_context_list[i], m_ctx_time_conversion_mode);
+		m_ib_ctx_map[pp_ibv_context_list[i]] = new ib_ctx_handler(pp_ibv_context_list[i], i, m_ctx_time_conversion_mode);
 	}
 
 	rdma_free_devices(pp_ibv_context_list);

--- a/src/vma/dev/qp_mgr.cpp
+++ b/src/vma/dev/qp_mgr.cpp
@@ -359,7 +359,7 @@ void qp_mgr::trigger_completion_for_all_sent_packets()
 		memset(p_buffer_iphdr, 0, sizeof(*p_buffer_iphdr));
 		sge[0].length = sizeof(ethhdr) + sizeof(iphdr);
 		sge[0].addr = (uintptr_t)(p_mem_buf_desc->p_buffer);
-		sge[0].lkey = m_p_ring->m_tx_lkey;
+		sge[0].lkey = p_mem_buf_desc->p_bpool->get_lkey_by_ctx(m_p_ib_ctx_handler);
 
 		struct ibv_ah *p_ah = NULL;
 		ibv_ah_attr ah_attr;
@@ -485,7 +485,7 @@ int qp_mgr::post_recv(mem_buf_desc_t* p_mem_buf_desc)
 		m_ibv_rx_wr_array[m_curr_rx_wr].wr_id  = (uintptr_t)p_mem_buf_desc;
 		m_ibv_rx_sg_array[m_curr_rx_wr].addr   = (uintptr_t)p_mem_buf_desc->p_buffer;
 		m_ibv_rx_sg_array[m_curr_rx_wr].length = p_mem_buf_desc->sz_buffer;
-		m_ibv_rx_sg_array[m_curr_rx_wr].lkey   = p_mem_buf_desc->lkey;
+		m_ibv_rx_sg_array[m_curr_rx_wr].lkey   = p_mem_buf_desc->p_bpool->get_lkey_by_ctx(m_p_ib_ctx_handler);
 
 #ifdef DEFINED_VMAPOLL
 		uint64_t index = m_rq_wqe_counter & (m_rx_num_wr - 1);

--- a/src/vma/dev/ring.h
+++ b/src/vma/dev/ring.h
@@ -307,6 +307,7 @@ public:
 	virtual int		poll_and_process_element_rx(uint64_t* p_cq_poll_sn, void* pv_fd_ready_array = NULL) = 0;
 	virtual void		adapt_cq_moderation() = 0;
 	virtual void		mem_buf_desc_completion_with_error_rx(mem_buf_desc_t* p_rx_wc_buf_desc) = 0; // Assume locked...
+	virtual const ib_ctx_handler* get_active_ctx_handle(ring_user_id_t id = 0) = 0;
 	// Tx completion handling at the qp_mgr level is just re listing the desc+data buffer in the free lists
 	virtual void		mem_buf_desc_completion_with_error_tx(mem_buf_desc_t* p_tx_wc_buf_desc) = 0; // Assume locked...
 	virtual void		mem_buf_desc_return_to_owner_rx(mem_buf_desc_t* p_mem_buf_desc, void* pv_fd_ready_array = NULL) = 0;

--- a/src/vma/dev/ring_bond.cpp
+++ b/src/vma/dev/ring_bond.cpp
@@ -628,6 +628,7 @@ ring_user_id_t ring_bond::generate_id(const address_t src_mac, const address_t d
 	return hash % m_n_num_resources;
 }
 
+<<<<<<< HEAD
 #ifdef DEFINED_VMAPOLL	
 int ring_bond::fast_poll_and_process_element_rx(vma_packets_t *vma_pkts)
 {
@@ -644,3 +645,10 @@ int ring_bond::vma_poll(struct vma_completion_t *vma_completions, unsigned int n
 	return 0;
 }
 #endif // DEFINED_VMAPOLL	
+=======
+const ib_ctx_handler* ring_bond::get_active_ctx_handle(ring_user_id_t id)
+{
+	return m_active_rings[id]->get_active_ctx_handle(id);
+}
+
+>>>>>>> 410c4f0... issue: 564154 - support dynamic buffer pool

--- a/src/vma/dev/ring_bond.h
+++ b/src/vma/dev/ring_bond.h
@@ -65,7 +65,9 @@ public:
 	virtual bool		is_active_member(mem_buf_desc_owner* rng, ring_user_id_t id);
 	virtual ring_user_id_t	generate_id();
 	virtual ring_user_id_t	generate_id(const address_t src_mac, const address_t dst_mac, uint16_t eth_proto, uint16_t encap_proto, uint32_t src_ip, uint32_t dst_ip, uint16_t src_port, uint16_t dst_port);
+
 	virtual bool 		get_hw_dummy_send_support(ring_user_id_t id, vma_ibv_send_wr* p_send_wqe);
+	virtual const ib_ctx_handler* get_active_ctx_handle(ring_user_id_t id = 0);
 
 #ifdef DEFINED_VMAPOLL		
 	virtual int		fast_poll_and_process_element_rx(vma_packets_t *vma_pkts);

--- a/src/vma/dev/ring_simple.cpp
+++ b/src/vma/dev/ring_simple.cpp
@@ -279,9 +279,10 @@ remain below as in master?
 	// save cq_mgr pointers
 	m_p_cq_mgr_rx = m_p_qp_mgr->get_rx_cq_mgr();
 	m_p_cq_mgr_tx = m_p_qp_mgr->get_tx_cq_mgr();
-
+	
+	m_p_ib_ctx = p_ring_info->p_ib_ctx;
 	m_tx_lkey = g_buffer_pool_tx->find_lkey_by_ib_ctx_thread_safe(p_ring_info->p_ib_ctx);
-
+	
 	request_more_tx_buffers(RING_TX_BUFS_COMPENSATE);
 	m_tx_num_bufs = m_tx_pool.size();
 

--- a/src/vma/dev/ring_simple.h
+++ b/src/vma/dev/ring_simple.h
@@ -82,8 +82,12 @@ public:
 	virtual ring_user_id_t	generate_id();
 	virtual ring_user_id_t	generate_id(const address_t src_mac, const address_t dst_mac, uint16_t eth_proto, uint16_t encap_proto, uint32_t src_ip, uint32_t dst_ip, uint16_t src_port, uint16_t dst_port);
 	transport_type_t	get_transport_type() const { return m_transport_type; }
+
 	virtual bool 		get_hw_dummy_send_support(ring_user_id_t id, vma_ibv_send_wr* p_send_wqe);
 	inline void 		convert_hw_time_to_system_time(uint64_t hwtime, struct timespec* systime) { m_p_cq_mgr_rx->convert_hw_time_to_system_time(hwtime, systime); }
+
+	virtual const ib_ctx_handler* get_active_ctx_handle(ring_user_id_t id = 0);
+
 
 	friend class cq_mgr;
 	friend class qp_mgr;
@@ -139,7 +143,7 @@ private:
 	int32_t			m_tx_num_wr_free;
 	bool			m_b_qp_tx_first_flushed_completion_handled;
 	uint32_t		m_missing_buf_ref_count;
-	uint32_t		m_tx_lkey; // this is the registered memory lkey for a given specific device for the buffer pool use
+	ib_ctx_handler*		m_p_ib_ctx;
 	uint16_t		m_partition; //vlan or pkey
 	gro_mgr			m_gro_mgr;
 	ring_stats_t		m_ring_stat_static;

--- a/src/vma/event/event_handler_manager.cpp
+++ b/src/vma/event/event_handler_manager.cpp
@@ -83,14 +83,15 @@ void* event_handler_manager::register_timer_event(int timeout_msec, timer_handle
 		return NULL;
 	}
 	BULLSEYE_EXCLUDE_BLOCK_END
-
 	// malloc here the timer list node in order to return it to the app
-	void* node = malloc(sizeof(struct timer_node_t)); 
+
+	void* node = malloc(sizeof(struct timer_node_t));
 	BULLSEYE_EXCLUDE_BLOCK_START
 	if (!node) {
 		evh_logdbg("malloc failure");
 		throw_vma_exception("malloc failure");
 	}
+
 	BULLSEYE_EXCLUDE_BLOCK_END
 	timer_node_t* timer_node = (timer_node_t*)node;
 	memset(timer_node, 0, sizeof(*timer_node));

--- a/src/vma/main.h
+++ b/src/vma/main.h
@@ -43,6 +43,7 @@ void print_vma_global_settings();
 void check_locked_mem();
 void set_env_params();
 void prepare_fork();
+bool parse_num_bufs_parameter(const char* num_bufs_param, uint32_t& n_bufs_init, uint32_t& n_bufs_max, uint32_t& n_bufs_min_threshold);
 
 extern "C" void sock_redirect_main(void);
 extern "C" void sock_redirect_exit(void);

--- a/src/vma/proto/dst_entry_tcp.cpp
+++ b/src/vma/proto/dst_entry_tcp.cpp
@@ -32,6 +32,7 @@
 
 
 
+#include "vma/dev/dynamic_buffer_pool.h"
 #include "dst_entry_tcp.h"
 #include <netinet/tcp.h>
 

--- a/src/vma/proto/igmp_handler.cpp
+++ b/src/vma/proto/igmp_handler.cpp
@@ -39,6 +39,7 @@
 #include "vma/proto/neighbour_table_mgr.h"
 #include "vma/dev/wqe_send_handler.h"
 #include "vma/dev/wqe_send_ib_handler.h"
+#include "vma/dev/buffer_pool.h"
 #include "vma/util/utils.h"
 #include "igmp_handler.h"
 
@@ -208,7 +209,7 @@ bool igmp_handler::tx_igmp_report()
 
 	m_sge.addr = (uintptr_t)(p_mem_buf_desc->p_buffer + (uint8_t)m_header.m_transport_header_tx_offset);
 	m_sge.length = m_header.m_total_hdr_len + sizeof(uint32_t /*m_ip_hdr_ext*/) + sizeof (igmphdr /*m_igmp_hdr*/);
-	m_sge.lkey = p_mem_buf_desc->lkey;
+	m_sge.lkey = p_mem_buf_desc->p_bpool->get_lkey_by_ctx(m_p_ring->get_active_ctx_handle(m_id));
 	p_mem_buf_desc->p_next_desc = NULL;
 	m_p_send_igmp_wqe.wr_id = (uintptr_t)p_mem_buf_desc;
 

--- a/src/vma/proto/ip_frag.h
+++ b/src/vma/proto/ip_frag.h
@@ -48,7 +48,7 @@
 #include <vma/util/vtypes.h>
 #include <vma/util/sys_vars.h>
 #include <vma/event/timer_handler.h>
-#include <vma/dev/buffer_pool.h>
+#include <vma/dev/dynamic_buffer_pool.h>
 
 class mem_buf_desc_t;
 class event_handler_manager;

--- a/src/vma/proto/mem_buf_desc.h
+++ b/src/vma/proto/mem_buf_desc.h
@@ -82,7 +82,7 @@ public:
 	uint8_t* const	p_buffer;
 	size_t const	sz_buffer; 	// this is the size of the buffer
 	size_t		sz_data;   	// this is the amount of data inside the buffer (sz_data <= sz_buffer)
-	uint32_t	lkey;      	// Buffers lkey for QP access
+	buffer_pool* p_bpool;	// desc's buffer pool
 private:
 	atomic_t	n_ref_count;	// number of interested receivers (sockinfo) [can be modified only in cq_mgr context]
 public:

--- a/src/vma/proto/neighbour.cpp
+++ b/src/vma/proto/neighbour.cpp
@@ -1447,7 +1447,7 @@ bool neigh_eth::post_send_arp(bool is_broadcast)
 
 	m_sge.addr = (uintptr_t)(p_mem_buf_desc->p_buffer + (uint8_t)h.m_transport_header_tx_offset);
 	m_sge.length = sizeof(eth_arp_hdr) + h.m_total_hdr_len;
-	m_sge.lkey = p_mem_buf_desc->lkey;
+	m_sge.lkey = p_mem_buf_desc->p_bpool->lkey;
 	p_mem_buf_desc->p_next_desc = NULL;
 	m_send_wqe.wr_id = (uintptr_t)p_mem_buf_desc;
 
@@ -1712,7 +1712,7 @@ bool neigh_ib::post_send_arp(bool is_broadcast)
 
 	m_sge.addr = (uintptr_t)(p_mem_buf_desc->p_buffer + (uint8_t)h.m_transport_header_tx_offset);
 	m_sge.length = sizeof(ib_arp_hdr) + h.m_total_hdr_len;
-	m_sge.lkey = p_mem_buf_desc->lkey;
+	m_sge.lkey = p_mem_buf_desc->p_bpool->lkey;
 	p_mem_buf_desc->p_next_desc = NULL;
 	m_send_wqe.wr_id = (uintptr_t)p_mem_buf_desc;
 

--- a/src/vma/sock/sockinfo.h
+++ b/src/vma/sock/sockinfo.h
@@ -47,6 +47,7 @@
 #include "vma/dev/net_device_table_mgr.h"
 #include "vma/dev/ring.h"
 #include "vma/dev/ring_allocation_logic.h"
+#include "vma/dev/dynamic_buffer_pool.h"
 
 #include "socket_fd_api.h"
 #include "pkt_rcvr_sink.h"

--- a/src/vma/sock/sockinfo_tcp.cpp
+++ b/src/vma/sock/sockinfo_tcp.cpp
@@ -2027,6 +2027,7 @@ int sockinfo_tcp::connect(const sockaddr *__to, socklen_t __tolen)
 		//todo consider setPassthrough and go to OS
 		destructor_helper();
 		errno = ECONNREFUSED;
+		printf_backtrace();
 		si_tcp_logerr("bad connect, err=%d", err);
 		unlock_tcp_con();
 		return -1;

--- a/src/vma/util/sys_vars.h
+++ b/src/vma/util/sys_vars.h
@@ -313,7 +313,10 @@ struct mce_sys_var {
 	int		tcp_max_syn_rate;
 
 	uint32_t 	tx_num_segs_tcp;
-	uint32_t 	tx_num_bufs;
+	uint32_t 	tx_num_bufs_init;
+	uint32_t	tx_num_bufs_quanta;
+	uint32_t 	tx_num_bufs_max;
+	uint32_t 	tx_num_bufs_min_threshold;
 	uint32_t 	tx_num_wr;
 	uint32_t	tx_num_wr_to_signal;
 	uint32_t 	tx_max_inline;
@@ -324,7 +327,10 @@ struct mce_sys_var {
 	uint32_t        tx_bufs_batch_udp;
 	uint32_t        tx_bufs_batch_tcp;
 
-	uint32_t 	rx_num_bufs;
+	uint32_t 	rx_num_bufs_init;
+	uint32_t	rx_num_bufs_quanta;
+	uint32_t 	rx_num_bufs_max;
+	uint32_t 	rx_num_bufs_min_threshold;
 	uint32_t        rx_bufs_batch;
 	uint32_t 	rx_num_wr;
 	uint32_t	rx_num_wr_to_post_recv;
@@ -396,6 +402,7 @@ struct mce_sys_var {
 
 	bool 		enable_ipoib;
 	uint32_t	timer_netlink_update_msec;
+	uint32_t	timer_bpool_aloc_msec;
 
 	//Neigh parameters
 	uint32_t 	neigh_uc_arp_quata;
@@ -413,6 +420,8 @@ private:
 	int list_to_cpuset(char *cpulist, cpu_set_t *cpu_set);
 	int hex_to_cpuset(char *start, cpu_set_t *cpu_set);
 	int env_to_cpuset(char *orig_start, cpu_set_t *cpu_set);
+	bool parse_num_bufs_parameter(const char* num_bufs_param, uint32_t& n_bufs_init, uint32_t& n_bufs_quanta, uint32_t& n_bufs_max, uint32_t& n_bufs_min_threshold)
+
 	void read_env_variable_with_pid(char* mce_sys_name, size_t mce_sys_max_size, char* env_ptr);
 
 	// prevent unautothrized creation of objects
@@ -527,7 +536,7 @@ extern mce_sys_var & safe_mce_sys();
 #define SYS_VAR_INTERNAL_THREAD_TCP_TIMER_HANDLING	"VMA_INTERNAL_THREAD_TCP_TIMER_HANDLING"
 
 #define SYS_VAR_NETLINK_TIMER_MSEC			"VMA_NETLINK_TIMER"
-
+#define SYS_VAR_BPOOL_TIMER_MSEC			"VMA_BPOOL_TIMER"
 #define SYS_VAR_NEIGH_UC_ARP_QUATA			"VMA_NEIGH_UC_ARP_QUATA"
 #define SYS_VAR_NEIGH_UC_ARP_DELAY_MSEC			"VMA_NEIGH_UC_ARP_DELAY_MSEC"
 #define SYS_VAR_NEIGH_NUM_ERR_RETRIES			"VMA_NEIGH_NUM_ERR_RETRIES"
@@ -535,6 +544,11 @@ extern mce_sys_var & safe_mce_sys();
 #define SYS_VAR_VMA_TIME_MEASURE_NUM_SAMPLES		"VMA_TIME_MEASURE_NUM_SAMPLES"
 #define SYS_VAR_VMA_TIME_MEASURE_DUMP_FILE		"VMA_TIME_MEASURE_DUMP_FILE"
 
+#define STRINGIZE_NX(A) #A
+#define STRINGIZE(A) STRINGIZE_NX(A)
+#define MCE_MEM_BUFS_PPCAT_NX(init, quanta, max, min) init:quanta:max:min
+#define MCE_MEM_BUFS_PPCAT(init, quanta, max, min) MCE_MEM_BUFS_PPCAT_NX(init, quanta, max, min)
+#define MCE_MEM_BUFS_FORMAT(init, quanta, max, min) STRINGIZE(MCE_MEM_BUFS_PPCAT(init, quanta, max, min))
 
 #define MCE_DEFAULT_LOG_FILE				("")
 #define MCE_DEFAULT_CONF_FILE				("/etc/libvma.conf")
@@ -553,7 +567,11 @@ extern mce_sys_var & safe_mce_sys();
 #define MCE_DEFAULT_RING_LIMIT_PER_INTERFACE            (0)
 #define MCE_DEFAULT_TCP_MAX_SYN_RATE                	(0)
 #define MCE_DEFAULT_TX_NUM_SEGS_TCP			(1000000)
-#define MCE_DEFAULT_TX_NUM_BUFS				(200000)
+#define MCE_DEFAULT_TX_NUM_BUFS_INIT			(200000)
+#define MCE_DEFAULT_TX_NUM_BUFS_QUANTA			(0)
+#define MCE_DEFAULT_TX_NUM_BUFS_MAX			MCE_DEFAULT_TX_NUM_BUFS_INIT
+#define MCE_DEFAULT_TX_NUM_BUFS_MIN_THRESHOLD		(0)
+#define MCE_DEFAULT_TX_NUM_BUFS				MCE_MEM_BUFS_FORMAT(MCE_DEFAULT_TX_NUM_BUFS_INIT, MCE_DEFAULT_TX_NUM_BUFS_QUANTA, MCE_DEFAULT_TX_NUM_BUFS_MAX, MCE_DEFAULT_TX_NUM_BUFS_MIN_THRESHOLD)
 #ifdef DEFINED_VMAPOLL
 #define MCE_DEFAULT_TX_NUM_WRE				(1024)
 #else
@@ -572,7 +590,11 @@ extern mce_sys_var & safe_mce_sys();
 #define MCE_DEFAULT_TX_BUFS_BATCH_UDP			(8)
 #define MCE_DEFAULT_TX_BUFS_BATCH_TCP			(16)
 #define MCE_DEFAULT_TX_NUM_SGE				(2)
-#define MCE_DEFAULT_RX_NUM_BUFS				(200000)
+#define MCE_DEFAULT_RX_NUM_BUFS_INIT			(200000)
+#define MCE_DEFAULT_RX_NUM_BUFS_QUANTA			(0)
+#define MCE_DEFAULT_RX_NUM_BUFS_MAX			MCE_DEFAULT_RX_NUM_BUFS_INIT
+#define MCE_DEFAULT_RX_NUM_BUFS_MIN_THRESHOLD		(0)
+#define MCE_DEFAULT_RX_NUM_BUFS				MCE_MEM_BUFS_FORMAT(MCE_DEFAULT_RX_NUM_BUFS_INIT, MCE_DEFAULT_RX_NUM_BUFS_QUANTA, MCE_DEFAULT_RX_NUM_BUFS_MAX, MCE_DEFAULT_RX_NUM_BUFS_MIN_THRESHOLD)
 #define MCE_DEFAULT_RX_BUFS_BATCH			(64)
 #ifdef DEFINED_VMAPOLL
 #define MCE_DEFAULT_RX_NUM_WRE				(1024)
@@ -651,6 +673,7 @@ extern mce_sys_var & safe_mce_sys();
 #define MCE_DEFAULT_INTERNAL_THREAD_CPUSET		("")
 #define MCE_DEFAULT_INTERNAL_THREAD_TCP_TIMER_HANDLING	(INTERNAL_THREAD_TCP_TIMER_HANDLING_DEFERRED)
 #define MCE_DEFAULT_NETLINK_TIMER_MSEC			(10000)
+#define MCE_DEFAULT_BPOOL_TIMER_MSEC			(500)
 
 #define MCE_DEFAULT_NEIGH_UC_ARP_QUATA			3
 #define MCE_DEFAULT_NEIGH_UC_ARP_DELAY_MSEC		10000

--- a/src/vma/util/utils.cpp
+++ b/src/vma/util/utils.cpp
@@ -904,3 +904,18 @@ const char* vma_error::what() const throw()
 }
 
 ///////////////////////////////////////////
+std::vector<std::string> &split(const std::string &s, char delim, std::vector<std::string> &elems) {
+    std::stringstream ss(s);
+    std::string item;
+    while (std::getline(ss, item, delim)) {
+        elems.push_back(item);
+    }
+    return elems;
+}
+
+
+std::vector<std::string> split(const std::string &s, char delim) {
+    std::vector<std::string> elems;
+    split(s, delim, elems);
+    return elems;
+}

--- a/src/vma/util/utils.h
+++ b/src/vma/util/utils.h
@@ -37,6 +37,8 @@
 #include <time.h>
 #include <string>
 #include <string.h>
+#include <sstream>
+#include <vector>
 #include <ifaddrs.h>
 #include <linux/if_ether.h>
 #include <exception>
@@ -50,6 +52,12 @@
 struct iphdr; //forward declaration
 
 #define VMA_ALIGN(x, y) ((((x) + (y) - 1) / (y)) * (y) )
+
+/*
+ * split string by delimiters
+ */
+std::vector<std::string> &split(const std::string &s, char delim, std::vector<std::string> &elems);
+std::vector<std::string> split(const std::string &s, char delim);
 
 /**
 * Check if file type is regular

--- a/src/vma/util/vma_stats.h
+++ b/src/vma/util/vma_stats.h
@@ -302,9 +302,8 @@ typedef struct {
 //
 typedef struct {
 	bool		is_rx;
-	bool		is_tx;
-	uint32_t	n_buffer_pool_size;
-	uint32_t	n_buffer_pool_no_bufs;
+	uint32_t	n_buffer_pool_size_free;
+	uint32_t	n_buffer_pool_size_total;
 } bpool_stats_t;
 
 typedef struct {

--- a/tests/dynamic_memory_pools/test_rx.py
+++ b/tests/dynamic_memory_pools/test_rx.py
@@ -1,0 +1,362 @@
+import socket
+import threading
+import argparse
+from time import sleep
+from time import time
+
+TCP_SOCKET_ARGS = socket.AF_INET, socket.SOCK_STREAM
+UDP_SOCKET_ARGS = socket.AF_INET, socket.SOCK_DGRAM
+NUMBER_OF_CONNECTIONS = 5
+DATA_SIZE = 64  # (2**4) * (2**2) chars
+DATA = '0123456789ABCDEF'* (2**2)
+DATA_LAST = "FIN"
+START_COMM = "START_COMM"
+STOP_COMM = "STOP_COMM"
+
+
+class DynamicMemHost(object):
+    def __init__(self, parsed_args):
+        self.server_ip = parsed_args.server_ip
+
+        self.control_port = parsed_args.ports[0]
+        self.free_port = parsed_args.ports[1]
+        self.congested_port = parsed_args.ports[2]
+
+        self.transport = parsed_args.transport
+
+        self.iterations = parsed_args.test_iterations
+        self.interval = parsed_args.interval
+        self.interval_increase = parsed_args.interval_increase
+
+        self.control_socket_elem = socket.socket(*(TCP_SOCKET_ARGS))
+        self.free_socket_elem = socket.socket(*(TCP_SOCKET_ARGS))
+        self.congested_socket_elem =\
+            socket.socket(*(TCP_SOCKET_ARGS if
+                            self.transport == 'tcp' else UDP_SOCKET_ARGS))
+
+        self.flag_do_bg_communication = True
+
+    def set_stop_bg_communication(self):
+        self.flag_do_bg_communication = False
+
+
+class ServerRX(DynamicMemHost):
+    def __init__(self, parsed_args):
+        DynamicMemHost.__init__(self, parsed_args)
+
+        self.control_socket_elem.bind((self.server_ip, self.control_port))
+        self.free_socket_elem.bind((self.server_ip, self.free_port))
+        self.congested_socket_elem.bind((self.server_ip, self.congested_port))
+
+        self.flag_send_to_client = False
+
+    def set_send_to_client(self, val):
+        self.flag_send_to_client = val
+
+    def run_background_communication(self):
+        def run_comm_server_tcp(so):
+            so.listen(1)
+            ss, _ = so.accept()
+
+            print "server accepted connection"
+            try:
+                while self.flag_do_bg_communication:
+                    sleep(0.1)
+                    print "waiting for start"
+                    while self.flag_send_to_client:
+                        sleep(0.05)
+                        ss.sendall(DATA)
+                    ss.sendall(DATA_LAST)
+                    sleep(1)
+
+            except socket.error as e:
+                print e
+            finally:
+                ss.close()
+
+        def run_comm_server_udp(so):
+            iteration = 0
+            data, address = so.recvfrom(DATA_SIZE)
+            if data != START_COMM:
+                print "wrong start message"
+
+            try:
+                while self.flag_do_bg_communication:
+                    sleep(0.1)
+                    print "waiting for start"
+                    while self.flag_send_to_client:
+                        sleep(0.2)
+                        so.sendto(DATA, address)
+                        iteration += 1
+                    so.sendto(DATA_LAST, address)
+                    sleep(1)
+
+            except socket.error as e:
+                print e
+
+        td_servers = []
+
+        # free server - data constantly recv'd on client side
+        td_servers.append(threading.Thread(target=run_comm_server_tcp,
+                                           args=[self.free_socket_elem]))
+
+        # congestion server = data recv'd on client side on intervals
+        if self.transport == 'tcp':
+            td_servers.append(threading.Thread(target=run_comm_server_tcp,
+                                               args=
+                                               [self.congested_socket_elem]))
+        else: #  udp
+            td_servers.append(threading.Thread(target=run_comm_server_udp,
+                                               args=
+                                               [self.congested_socket_elem]))
+
+        for td in td_servers:
+            td.start()
+
+        return td_servers
+
+    def close_background_communication(self, td_servers):
+        self.set_stop_bg_communication()
+        for td in td_servers:
+            td.join()
+
+    def run(self):
+        tds = self.run_background_communication()
+
+        print "waiting for client"
+        self.control_socket_elem.listen(1)
+        ss, _ = self.control_socket_elem.accept()
+        print "control accepted connection"
+        try:
+            while True:
+                print "wait for control command"
+                data = ss.recv(DATA_SIZE)
+                if data:
+                    print "received data: ", data
+                    if data == START_COMM:
+                        self.set_send_to_client(True)
+                    elif data == STOP_COMM:
+                        self.set_send_to_client(False)
+                else:
+                    # Client disconnected
+                    break
+        except socket.error as e:
+            print e
+        finally:
+            ss.close()
+
+        self.close_background_communication(tds)
+
+
+class ClientRX(DynamicMemHost):
+    def __init__(self, parsed_args):
+        DynamicMemHost.__init__(self, parsed_args)
+
+    def run(self):
+        if self.transport == 'tcp': #(socket.AF_INET, socket.SOCK_STREAM)
+            self.run_congested_client_tcp()
+        else:
+            self.run_congested_client_udp()
+
+    def run_congested_client_tcp(self):
+        ret = self.control_socket_elem.connect_ex((self.server_ip,
+                                                   self.control_port))
+        count_connect_errors = 0
+        while ret:
+            if count_connect_errors > 10:
+                print "error in connecting to server"
+                exit(1)
+            print "return value for connect is %d" % ret
+            sleep(1)
+            count_connect_errors += 1
+            ret = self.control_socket_elem.connect_ex((self.server_ip,
+                                                       self.control_port))
+
+        ret = self.free_socket_elem.connect_ex((self.server_ip,
+                                                self.free_port))
+        count_connect_errors = 0
+        while ret:
+            if count_connect_errors > 10:
+                print "error in connecting to server"
+                exit(1)
+            print "return value for connect is %d" % ret
+            sleep(1)
+            count_connect_errors += 1
+            ret = self.free_socket_elem.connect_ex((self.server_ip,
+                                                    self.free_port))
+
+        ret = self.congested_socket_elem.connect_ex((self.server_ip,
+                                                     self.congested_port))
+        count_connect_errors = 0
+        while ret:
+            if count_connect_errors > 10:
+                print "error in connecting to server"
+                exit(1)
+            print "return value for connect is %d" % ret
+            sleep(1)
+            count_connect_errors += 1
+            ret = self.congested_socket_elem.connect_ex((self.server_ip,
+                                                         self.congested_port))
+
+
+        try:
+            for _ in range(self.iterations):
+                self.control_socket_elem.send(START_COMM)
+                start_time = time()
+                # consume data for {interval} seconds
+                while time() < start_time + self.interval:
+                    data = self.free_socket_elem.recv(DATA_SIZE)
+
+                print "send stop"
+                self.control_socket_elem.send(STOP_COMM)
+
+                message_iterations = 0
+                print "recv'd data"
+                flag_do_recv = True
+                accumulated_data = ""
+                while flag_do_recv:
+                    data = self.congested_socket_elem.recv(DATA_SIZE)
+                    if data == DATA_LAST:
+                        flag_do_recv = False
+                        continue
+
+                    accumulated_data.join(data)
+                    if len(accumulated_data) >= DATA_SIZE:
+                        if accumulated_data[:DATA_SIZE] != DATA:
+                            print "warning: data mismatch."
+                        accumulated_data = accumulated_data[DATA_SIZE:]
+
+                    message_iterations += 1
+                print "messages received: %d" % message_iterations
+
+                self.interval += self.interval_increase
+
+        except socket.error as e:
+            print e
+        finally:
+            self.congested_socket_elem.close()
+            self.free_socket_elem.close()
+            self.control_socket_elem.close()
+
+    def run_congested_client_udp(self):
+        ret = self.control_socket_elem.connect_ex((self.server_ip,
+                                                   self.control_port))
+        count_connect_errors = 0
+        while ret:
+            if count_connect_errors > 10:
+                print "error in connecting to server"
+                exit(1)
+            print "return value for connect is %d" % ret
+            sleep(1)
+            count_connect_errors += 1
+            ret = self.control_socket_elem.connect_ex((self.server_ip,
+                                                       self.control_port))
+
+        ret = self.free_socket_elem.connect_ex((self.server_ip,
+                                                self.free_port))
+        count_connect_errors = 0
+        while ret:
+            if count_connect_errors > 10:
+                print "error in connecting to server"
+                exit(1)
+            print "return value for connect is %d" % ret
+            sleep(1)
+            count_connect_errors += 1
+            ret = self.free_socket_elem.connect_ex((self.server_ip,
+                                                    self.free_port))
+
+        self.congested_socket_elem.sendto(START_COMM,
+                                          (self.server_ip,
+                                           self.congested_port))
+        try:
+            for _ in range(self.iterations):
+                self.control_socket_elem.send(START_COMM)
+                start_time = time()
+                # consume data for {interval} seconds
+                while time() < start_time + self.interval:
+                    data = self.free_socket_elem.recv(DATA_SIZE)
+
+                print "send stop"
+                self.control_socket_elem.send(STOP_COMM)
+
+                message_iterations = 0
+                print "recv'd data"
+                flag_do_recv = True
+                accumulated_data = ""
+                while flag_do_recv:
+                    data, _ = self.congested_socket_elem.recvfrom(DATA_SIZE)
+                    if data == DATA_LAST:
+                        flag_do_recv = False
+                    else:
+                        accumulated_data += data
+                        if len(accumulated_data) >= DATA_SIZE:
+                            if accumulated_data[:DATA_SIZE] != DATA:
+                                print "warning: data mismatch."
+                            accumulated_data = accumulated_data[DATA_SIZE:]
+
+                    message_iterations += 1
+                print "messages received: %d" % message_iterations
+
+                self.interval += self.interval_increase
+
+        except socket.error as e:
+            print e
+        finally:
+            self.free_socket_elem.close()
+            self.control_socket_elem.close()
+
+
+if __name__ == "__main__":
+    EPILOG = """
+server is a simple echo server. client should be run with VMA.
+check client's vma_stats to check for bpool status.
+
+example tcp:
+server:
+$ python tests/dynamic_memory_pools/test_rx.py -host server -trans tcp -ip 1.2.105.2 -ports 12345 12346 12347
+client:
+$ VMA_QP_COMPENSATION_LEVEL=10 VMA_RX_WRE_BATCHING=10 VMA_RX_WRE=10 VMA_BPOOL_TIMER=2 VMA_RX_BUFS=200:5:200000:300 LD_PRELOAD=src/vma/.libs/libvma.so python tests/dynamic_memory_pools/test_rx.py -host client -trans tcp -ip 1.2.105.2 -ports 12345 12346 12347
+
+- replace 'tcp' with 'udp' for testing udp.
+- run vma_stats on client and make sure buffer pools are allocated.
+"""
+
+    parser = argparse.ArgumentParser(epilog=EPILOG,
+                                     formatter_class=argparse.
+                                     RawDescriptionHelpFormatter)
+    parser.add_argument('-host', dest="host", type=str,
+                        choices=["server", "client"], default=None,
+                        help="server or client", required=True)
+    parser.add_argument('-trans', dest="transport", type=str,
+                        choices=["tcp", "udp"], default="tcp",
+                        help="tcp (default) or udp", required=True)
+    parser.add_argument('-ip', dest="server_ip", type=str,
+                        default='', #default: localhost
+                        help="server ip. default: localhost",
+                        required=True)
+    parser.add_argument('-ports', nargs=3, type=int,
+                        default=None, required=True,
+                        help=\
+"3 ports: control_port, free_port, and congested_port. "
+"usage: -ports 7888 7889 7890")
+
+    parser.add_argument('-iterations', dest="test_iterations",
+                        type=int, default=10,
+                        help="number of total iterations of the test.")
+    parser.add_argument('-interval', dest="interval", type=int, default=3,
+                        help=\
+"initial interval of server sending data in seconds.")
+    parser.add_argument('-interval_increase', dest="interval_increase",
+                        type=int, default=2,
+                        help=\
+"increase quanta of interval of server sending data (if init is 3,"
+" will be 3 seconds, then 5 for the next iteration and so forth).")
+
+    parsed_args = parser.parse_args()
+
+    if parsed_args.host == 'server':
+        host = ServerRX(parsed_args)
+    else:
+        host = ClientRX(parsed_args)
+
+    exit(host.run())

--- a/tests/dynamic_memory_pools/test_tx.py
+++ b/tests/dynamic_memory_pools/test_tx.py
@@ -1,0 +1,170 @@
+import socket
+import threading
+import argparse
+from time import sleep
+
+
+TCP_SOCKET_ARGS = socket.AF_INET, socket.SOCK_STREAM
+UDP_SOCKET_ARGS = socket.AF_INET, socket.SOCK_DGRAM
+NUMBER_OF_CONNECTIONS = 100
+DATA_SIZE = 128  # (2**4) * (2**3) chars
+DATA = '0123456789ABCDEF'* (2**3)
+
+class DynamicMemHost(object):
+    def __init__(self, parsed_args):
+        self.server_ip = parsed_args.server_ip
+        self.port = parsed_args.port
+        self.transport = parsed_args.transport
+        self.socket_elem = None
+
+class ServerTX(DynamicMemHost):
+    def __init__(self, parsed_args):
+        DynamicMemHost.__init__(self, parsed_args)
+
+        self.socket_elem = socket.socket(*(TCP_SOCKET_ARGS if
+                                           self.transport == 'tcp' else
+                                           UDP_SOCKET_ARGS))
+        self.socket_elem.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+        self.socket_elem.bind((self.server_ip, self.port))
+
+    def run(self):
+        if self.transport == 'tcp': #(socket.AF_INET, socket.SOCK_STREAM)
+            return self.run_tcp()
+        else:
+            return self.run_udp()
+
+    def run_tcp(self):
+        def listen_to_client(client):
+            while True:
+                try:
+                    data = client.recv(DATA_SIZE)
+                    if data:
+                        client.send(DATA)
+                    else:
+                        raise socket.error('Client disconnected')
+                except socket.error as e:
+                    print e
+                finally:
+                    client.close()
+
+
+        self.socket_elem.listen(NUMBER_OF_CONNECTIONS)
+        while True:
+            ss, address = self.socket_elem.accept()
+            ss.settimeout(60)
+            td = threading.Thread(target=listen_to_client,
+                                  args=(ss))
+            td.start()
+
+    def run_udp(self):
+        while True:
+            data, _ = self.socket_elem.recvfrom(DATA_SIZE)
+            if len(data) != DATA_SIZE or data != DATA:
+                print "ERROR: data received corrupted."
+
+
+class ClientTX(DynamicMemHost):
+    def __init__(self, parsed_args):
+        DynamicMemHost.__init__(self, parsed_args)
+
+    def run(self):
+        def create_tcp_sockets(step_connections):
+            connect_error = 0
+            for _ in range(step_connections): #open [step_connections] socket
+                cs = socket.socket(socket.AF_INET)
+                while True:
+                    try:
+                        cs.connect((self.server_ip, self.port))
+                        break
+                    except socket.error as e:
+                        sleep(1)
+                        connect_error += 1
+                        print "Connect ERROR: %d" % connect_error
+                        continue
+
+                client_sockets.append(cs)
+                sleep(0.1)
+
+        def send_tcp():
+            for cs in client_sockets:
+                cs.send(DATA)
+
+        def recv_tcp():
+            for cs in client_sockets:
+                recieved_data = cs.recv(DATA_SIZE)
+                #print recieved_data
+                if len(recieved_data) != DATA_SIZE or recieved_data != DATA:
+                    print "ERROR: data returned corrupted."
+                    return False
+            return True
+
+        def create_udp_sockets(step_connections):
+            for _ in range(step_connections): #open [step_connections] socket
+                cs = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+                client_sockets.append(cs)
+                sleep(0.1)
+
+        def send_udp():
+            for cs in client_sockets:
+                cs.sendto(DATA, (self.server_ip, self.port))
+
+        step_iterations = 10
+        step_connections = NUMBER_OF_CONNECTIONS/10
+        client_sockets = []
+
+        for i in range(step_iterations):
+            print "Step %d:\trunning with %d sockets."\
+                "" %(i + 1, (i + 1)*step_connections)
+            if self.transport == 'tcp':
+                create_tcp_sockets(step_connections)
+                send_tcp()
+                if not recv_tcp():
+                    return -1
+
+            else:  # 'udp'
+                create_udp_sockets(step_connections)
+                send_udp()
+            sleep(1)
+
+        for cs in client_sockets:
+            cs.close()
+
+
+if __name__ == "__main__":
+    EPILOG = """
+server is a simple echo server. client should be run with VMA.
+check client's vma_stats to check for bpool status.
+
+example udp:
+server:
+    $ python tests/dynamic_memory_pools/test_tx.py -host server -trans udp -ip 1.2.105.2 -port 12345
+client:
+    $ VMA_RING_ALLOCATION_LOGIC_TX=20 VMA_TX_BUFS=5000:100:10000:5000 LD_PRELOAD=src/vma/.libs/libvma.so python tests/dynamic_memory_pools/test_tx.py -host client -trans udp -ip 1.2.105.2 -port 12345 
+
+replace 'udp' with 'tcp' for testing tcp.
+"""
+
+    parser = argparse.ArgumentParser(epilog=EPILOG,
+                                     formatter_class=argparse.
+                                     RawDescriptionHelpFormatter)
+    parser.add_argument('-host', dest="host", type=str,
+                        choices=["server", "client"], default=None,
+                        help="server or client")
+    parser.add_argument('-trans', dest="transport", type=str,
+                        choices=["tcp", "udp"], default="tcp",
+                        help="tcp (default) or udp")
+    parser.add_argument('-ip', dest="server_ip", type=str,
+                        default='', #default: localhost
+                        help="server ip, default: localhost")
+    parser.add_argument('-port', dest="port", type=int, default=None,
+                        help="port")
+
+
+    parsed_args = parser.parse_args()
+
+    if parsed_args.host == 'server':
+        host = ServerTX(parsed_args)
+    else:
+        host = ClientTX(parsed_args)
+
+    exit(host.run())


### PR DESCRIPTION
Reworked VMA parameters: VMA_RX_BUFS, VMA_RX_BUFS
New parameter: VMA_BPOOL_TIMER
format:    init:quanta:max:threshold

Allows VMA memory signature to increase in size as the buffer pools are
filled.
Timer runs in background and every VMA_BPOOL_TIMER seconds checks if
threshold was reached, if so [quanta] memory is allocated.

Signed-off-by: Or Shalev <orsh@mellanox.com>