### PR TITLE
issue 966492: vma returns different errno when sending tcp packet to …

### DIFF
--- a/src/vma/proto/dst_entry.cpp
+++ b/src/vma/proto/dst_entry.cpp
@@ -572,6 +572,7 @@ bool dst_entry::prepare_to_send(bool skip_rules, bool is_connect)
 		}
 		if (!resolved) {
 			set_state(false);
+			dst_logdbg("dst_entry not resolved!");
 		}
 	}
 	m_slow_path_lock.unlock();

--- a/src/vma/sock/sockinfo_tcp.cpp
+++ b/src/vma/sock/sockinfo_tcp.cpp
@@ -1977,6 +1977,13 @@ int sockinfo_tcp::connect(const sockaddr *__to, socklen_t __tolen)
 		return -1;
 	}
 	m_p_connected_dst_entry->prepare_to_send(false, true);
+	if (!m_p_connected_dst_entry->is_valid()) {
+		destructor_helper();
+		unlock_tcp_con();
+		si_tcp_logdbg("not a valid dst");
+		errno = EHOSTUNREACH;
+		return -1;
+	}
 
 	// update it after route was resolved and device was updated
 	m_p_socket_stats->bound_if = m_p_connected_dst_entry->get_src_addr();


### PR DESCRIPTION
…not valid ip

set errno EHOSTUNREACH when ip is invalid.
Perior to this change, a connection to an invalid ip
e.g. ip that doesn't exists will endup with a
ETIMEDOUT error and not EHOSTUNREACH like the os.
This patch adds a check the destination exists before
trying to connect to it.

Signed-off-by: Rafi Wiener <rafiw@mellanox.com>