### PR TITLE
issue: 964360 Improve Page Fault event on mlx5_send call

### DIFF
--- a/src/vma/dev/qp_mgr.cpp
+++ b/src/vma/dev/qp_mgr.cpp
@@ -76,8 +76,17 @@ qp_mgr::qp_mgr(const ring_simple* p_ring, const ib_ctx_handler* p_context, const
 #ifdef DEFINED_VMAPOLL
 	m_rq_wqe_counter = 0;
 	m_sq_wqe_counter = 0;
-	m_rq_wqe_idx_to_wrid = (uint64_t*)malloc(m_rx_num_wr * sizeof *m_rq_wqe_idx_to_wrid);
-	m_sq_wqe_idx_to_wrid = (uint64_t*)malloc(m_tx_num_wr * sizeof *m_sq_wqe_idx_to_wrid);
+
+	m_rq_wqe_idx_to_wrid = (uint64_t*)mmap(NULL, m_rx_num_wr * sizeof(*m_rq_wqe_idx_to_wrid),
+		PROT_READ | PROT_WRITE, MAP_ANONYMOUS | MAP_PRIVATE, -1, 0);
+	if (m_rq_wqe_idx_to_wrid == MAP_FAILED) {
+		qp_logerr("Failed allocating m_rq_wqe_idx_to_wrid (errno=%d %m)", errno);
+	}
+	m_sq_wqe_idx_to_wrid = (uint64_t*)mmap(NULL, m_tx_num_wr * sizeof(*m_sq_wqe_idx_to_wrid),
+		PROT_READ | PROT_WRITE, MAP_ANONYMOUS | MAP_PRIVATE, -1, 0);
+	if (m_sq_wqe_idx_to_wrid == MAP_FAILED) {
+		qp_logerr("Failed allocating m_sq_wqe_idx_to_wrid (errno=%d %m)", errno);
+	}
 #endif // DEFINED_VMAPOLL
 }
 
@@ -110,6 +119,10 @@ qp_mgr::~qp_mgr()
 	delete[] m_ibv_rx_sg_array;
 	delete[] m_ibv_rx_wr_array;
 
+#ifdef DEFINED_VMAPOLL
+	munmap(m_rq_wqe_idx_to_wrid, m_rx_num_wr * sizeof(*m_rq_wqe_idx_to_wrid));
+	munmap(m_sq_wqe_idx_to_wrid, m_tx_num_wr * sizeof(*m_sq_wqe_idx_to_wrid));
+#endif // DEFINED_VMAPOLL
 	qp_logdbg("Rx buffer poll: %d free global buffers available", g_buffer_pool_rx->get_free_count());
 	qp_logdbg("delete done");
 }
@@ -530,34 +543,42 @@ int qp_mgr::post_recv(mem_buf_desc_t* p_mem_buf_desc)
 }
 
 #ifdef DEFINED_VMAPOLL
+static inline void mlx5_bf_copy(volatile uintptr_t *dst, volatile uintptr_t *src)
+{
+	COPY_64B_NT(dst, src);
+}
+
 void qp_mgr::mlx5_send(vma_ibv_send_wr *p_send_wqe)
 {
 	uintptr_t addr = 0;
 	uint32_t length = 0;
+	uint32_t lkey = 0;
 
 	addr = p_send_wqe->sg_list[0].addr;
+	length = p_send_wqe->sg_list[0].length;
+	lkey = p_send_wqe->sg_list[0].lkey;
 
-	/* Copy the first 16 bytes into the inline header */
-	memcpy((void *)(uintptr_t)m_sq_hot_wqe->eseg.inline_hdr_start,
-	       (void *)(uintptr_t)addr,
+	/* Copy the first bytes into the inline header */
+	memcpy((void *)m_sq_hot_wqe->eseg.inline_hdr_start,
+	       (void *)addr,
 	       MLX5_ETH_INLINE_HEADER_SIZE);
 
 	addr += MLX5_ETH_INLINE_HEADER_SIZE;
-	length = p_send_wqe->sg_list[0].length;
 	length -= MLX5_ETH_INLINE_HEADER_SIZE;
 
 	m_sq_hot_wqe->dseg.byte_count = htonl(length);
-	m_sq_hot_wqe->dseg.lkey = htonl(p_send_wqe->sg_list[0].lkey);
+	m_sq_hot_wqe->dseg.lkey = htonl(lkey);
 	m_sq_hot_wqe->dseg.addr = htonll(addr);
 
-	m_sq_wqe_idx_to_wrid[m_sq_hot_wqe_index] = (uintptr_t)p_send_wqe->wr_id;
-
 	++m_sq_wqe_counter;
-	volatile uintptr_t *dst = (volatile uintptr_t *)
-			((uintptr_t)m_sq_bf_reg + m_sq_bf_offset);
 
+	/*
+	 * Make sure that descriptors are written before
+	 * updating doorbell record and ringing the doorbell
+	 */
 	wmb();
 	*m_sq_db = htonl(m_sq_wqe_counter);
+
 	/* This wc_wmb ensures ordering between DB record and BF copy */
 	wc_wmb();
 
@@ -566,15 +587,19 @@ void qp_mgr::mlx5_send(vma_ibv_send_wr *p_send_wqe)
 	 * implementations may use move-string-buffer assembler instructions,
 	 * which do not guarantee order of copying.
 	 */
-	COPY_64B_NT(dst, m_sq_hot_wqe);
+	mlx5_bf_copy((volatile uintptr_t *)((uintptr_t)m_sq_bf_reg + m_sq_bf_offset),
+		(volatile uintptr_t *)m_sq_hot_wqe);
+
 	m_sq_bf_offset ^= m_sq_bf_buf_size;
+
+	m_sq_wqe_idx_to_wrid[m_sq_hot_wqe_index] = (uintptr_t)p_send_wqe->wr_id;
 
 	/*Set the next WQE and index*/
 	m_sq_hot_wqe = &(*m_mlx5_sq_wqes)[m_sq_wqe_counter & (m_tx_num_wr - 1)];
 	/* Write only data[0] which is the single element which changes.
 	 * Other fields are already initialised in mlx5_init_sq. */
 	m_sq_hot_wqe->ctrl.data[0] = htonl((m_sq_wqe_counter << 8) | MLX5_OPCODE_SEND);
-	m_sq_hot_wqe_index = m_sq_wqe_counter & (m_tx_num_wr - 1);;
+	m_sq_hot_wqe_index = m_sq_wqe_counter & (m_tx_num_wr - 1);
 }
 #endif // DEFINED_VMAPOLL
 
@@ -588,7 +613,7 @@ void qp_mgr::mlx5_init_sq()
 		volatile struct mlx5_wqe64 *wqe = &(*m_mlx5_sq_wqes)[i];
 
 		memset((void *)(uintptr_t)wqe, 0, sizeof(struct mlx5_wqe64));
-		wqe->eseg.inline_hdr_sz = htons(16);
+		wqe->eseg.inline_hdr_sz = htons(MLX5_ETH_INLINE_HEADER_SIZE);
 		wqe->eseg.cs_flags = MLX5_ETH_WQE_L3_CSUM | MLX5_ETH_WQE_L4_CSUM;
 		wqe->ctrl.data[1] = htonl((m_qp_num << 8) | 4);
 		//wqe->dseg.lkey = (m_p_ring->get_lkey());

--- a/src/vma/event/delta_timer.cpp
+++ b/src/vma/event/delta_timer.cpp
@@ -73,13 +73,14 @@ timer::~timer()
 	NOT_IN_USE(iter);
 	NOT_IN_USE(to_free);
 	return;
-#endif // DEFINED_VMAPOLL		
+#else
 	// free all the list
 	while (iter) {
 		to_free = iter;
 		iter = iter->next;
 		free(to_free);
 	}
+#endif // DEFINED_VMAPOLL
 }
 
 void timer::add_new_timer(unsigned int timeout_msec, timer_node_t* node, timer_handler* handler, void* user_data, timer_req_type_t req_type)

--- a/src/vma/sock/sock-redirect.cpp
+++ b/src/vma/sock/sock-redirect.cpp
@@ -541,8 +541,10 @@ extern "C"
 int vma_dump_fd_stats(int fd, int log_level)
 {
 #ifdef DEFINED_VMAPOLL
+NOT_IN_USE(fd);
+NOT_IN_USE(log_level);
 	return 0;
-#endif // DEFINED_VMAPOLL
+#else
 	do_global_ctors();
 
 	if (g_p_fd_collection) {
@@ -550,6 +552,7 @@ int vma_dump_fd_stats(int fd, int log_level)
 		return 0;
 	}
 	return -1;
+#endif // DEFINED_VMAPOLL
 }
 
 //-----------------------------------------------------------------------------


### PR DESCRIPTION
These changes designed to eliminate page fault event during
qp_mgr::mlx5_send() call.

@OphirMunk please review. I hope that these changes can improve page fault issue in this specific function.