### PR TITLE
issue: 964360 Improve Page Fault event on mlx5_send call

### DIFF
--- a/src/stats/stats_reader.cpp
+++ b/src/stats/stats_reader.cpp
@@ -1519,7 +1519,7 @@ int  init_print_process_stats(sh_mem_info_t & sh_mem_info)
 	sh_mem_info.p_sh_stats = mmap(0, sizeof(sh_mem_t), PROT_READ, MAP_SHARED, sh_mem_info.fd_sh_stats, 0);
 	MAP_SH_MEM(sh_mem,sh_mem_info.p_sh_stats);
 	if (sh_mem_info.p_sh_stats == MAP_FAILED) {
-		log_system_err("MAP_FAILED - %m\n");
+		log_system_err("MAP_FAILED - %s\n", strerror (errno));
 		close(sh_mem_info.fd_sh_stats);
 		return 1;
 	}
@@ -1559,7 +1559,7 @@ int  init_print_process_stats(sh_mem_info_t & sh_mem_info)
 		sh_mem_info.p_sh_stats = mmap(0, sh_mem_info.shmem_size, PROT_READ, MAP_SHARED, sh_mem_info.fd_sh_stats, 0);
 	
 	if (sh_mem_info.p_sh_stats == MAP_FAILED) {
-		log_system_err("MAP_FAILED - %m\n");
+		log_system_err("MAP_FAILED - %s\n", strerror (errno));
 		close(sh_mem_info.fd_sh_stats);
 		return 1;
 	}

--- a/src/vma/dev/cq_mgr.cpp
+++ b/src/vma/dev/cq_mgr.cpp
@@ -202,7 +202,7 @@ cq_mgr::cq_mgr(ring_simple* p_ring, ib_ctx_handler* p_ib_ctx_handler, int cq_siz
 	m_p_cq_stat->n_rx_drained_at_once_max = 0;
 	m_p_cq_stat->n_buffer_pool_len = 0;
 	m_p_cq_stat->buffer_miss_rate = 0.0;
-//*/
+*/
 	m_buffer_miss_count = 0;
 	m_buffer_total_count = 0;
 	m_buffer_prev_id = 0;

--- a/src/vma/event/delta_timer.cpp
+++ b/src/vma/event/delta_timer.cpp
@@ -55,12 +55,6 @@ timer::~timer()
 	NOT_IN_USE(iter);
 	NOT_IN_USE(to_free);
 	return;
-	// free all the list
-	while (iter) {
-		to_free = iter;
-		iter = iter->next;
-		free(to_free);
-	}
 }
 
 void timer::add_new_timer(unsigned int timeout_msec, timer_node_t* node, timer_handler* handler, void* user_data, timer_req_type_t req_type)

--- a/src/vma/iomux/select_call.cpp
+++ b/src/vma/iomux/select_call.cpp
@@ -215,7 +215,7 @@ bool select_call::wait_os(bool zero_timeout)
 	// extend check to write/except fds
 	if (m_rfd_count == m_n_exclude_fds)
 		return;
-//*/
+*/
 	
 	if (zero_timeout) {
 		to.tv_sec = to.tv_usec = 0;
@@ -297,7 +297,7 @@ bool select_call::wait(const timeval &elapsed)
                         return false;
                 }
         }
-//*/
+*/
 
 	// Call OS select() on original sets + CQ epfd in read set
 	if (m_readfds)

--- a/src/vma/proto/flow_tuple.cpp
+++ b/src/vma/proto/flow_tuple.cpp
@@ -98,7 +98,7 @@ void flow_tuple::set_protocol(in_protocol_t protocol)
 	m_protocol = protocol;
 	set_str();
 }
-//*/
+*/
 
 bool flow_tuple::is_tcp()
 {

--- a/src/vma/proto/flow_tuple.h
+++ b/src/vma/proto/flow_tuple.h
@@ -44,7 +44,7 @@ public:
 	void		set_dst_port(in_port_t dst_port);
 	void		set_src_port(in_port_t src_port);
 	void		set_protocol(in_protocol_t protocol);
-//*/
+*/
 	bool		is_tcp();
 	bool		is_udp_uc();
 	bool		is_udp_mc();

--- a/src/vma/proto/neighbour.cpp
+++ b/src/vma/proto/neighbour.cpp
@@ -1995,17 +1995,6 @@ int neigh_ib::destroy_ah()
 	//We cannot destroy ah till each post_send with this ah has ended
 	//TODO: Need to think how to  handle this - for now there will be ah leak
 	return 0;
-//unreachable code
-#ifndef __COVERITY__
-	if (m_val && ((neigh_ib_val *) m_val)->m_ah) {
-		IF_VERBS_FAILURE(ibv_destroy_ah(((neigh_ib_val *) m_val)->m_ah))
-		{
-			neigh_logdbg("failed destroying address handle (errno=%d %m)", errno);
-			return -1;
-		}ENDIF_VERBS_FAILURE;
-	}
-	return 0;
-#endif
 }
 
 //==================================================================================================================

--- a/src/vma/proto/vma_lwip.h
+++ b/src/vma/proto/vma_lwip.h
@@ -49,10 +49,6 @@ static inline const char* lwip_cc_algo_str(uint32_t algo)
 	case CC_MOD_LWIP:
 	default:		return "(LWIP)";
 	}
-//unreachable code
-#ifndef __COVERITY__
-	return "unsupported";
-#endif
 }
 
 #if _BullseyeCoverage

--- a/src/vma/sock/sock-redirect.cpp
+++ b/src/vma/sock/sock-redirect.cpp
@@ -65,6 +65,12 @@ void assign_dlsym(T &ptr, const char *name) {
 	ptr = reinterpret_cast<T>(dlsym(RTLD_NEXT, name));
 }
 
+#if defined(__INTEL_COMPILER) || defined(__clang__)
+#define VMA_THROW
+#else
+#define VMA_THROW	throw(vma_error)
+#endif
+
 #define FD_MAP_SIZE 		(g_p_fd_collection ? g_p_fd_collection->get_fd_map_size() : 1024)
 
 #define GET_ORIG_FUNC(__name) \
@@ -740,7 +746,7 @@ int connect(int __fd, const struct sockaddr *__to, socklen_t __tolen)
    Returns 0 on success, -1 for errors.  */
 extern "C"
 int setsockopt(int __fd, int __level, int __optname,
-	       __const void *__optval, socklen_t __optlen) throw (vma_error)
+	       __const void *__optval, socklen_t __optlen) VMA_THROW
 {
 	BULLSEYE_EXCLUDE_BLOCK_START
 	if (!orig_os_api.setsockopt) get_orig_funcs();
@@ -776,7 +782,7 @@ int setsockopt(int __fd, int __level, int __optname,
    Returns 0 on success, -1 for errors.  */
 extern "C"
 int getsockopt(int __fd, int __level, int __optname,
-	       void *__optval, socklen_t *__optlen) throw (vma_error)
+	       void *__optval, socklen_t *__optlen) VMA_THROW
 {
 	BULLSEYE_EXCLUDE_BLOCK_START
 	if (!orig_os_api.getsockopt) get_orig_funcs();
@@ -829,7 +835,7 @@ int getsockopt(int __fd, int __level, int __optname,
    accordingly (see README.txt)
    */
 extern "C"
-int fcntl(int __fd, int __cmd, ...) throw (vma_error)
+int fcntl(int __fd, int __cmd, ...) VMA_THROW
 {
 	BULLSEYE_EXCLUDE_BLOCK_START
 	if (!orig_os_api.fcntl) get_orig_funcs();
@@ -866,7 +872,7 @@ int fcntl(int __fd, int __cmd, ...) throw (vma_error)
    One argument may follow; its presence and type depend on REQUEST.
    Return value depends on REQUEST.  Usually -1 indicates error. */
 extern "C"
-int ioctl (int __fd, unsigned long int __request, ...) throw (vma_error)
+int ioctl (int __fd, unsigned long int __request, ...) VMA_THROW
 {
 	BULLSEYE_EXCLUDE_BLOCK_START
 	if (!orig_os_api.fcntl) get_orig_funcs();
@@ -1130,10 +1136,12 @@ ssize_t recvmsg(int __fd, struct msghdr *__msg, int __flags)
 
 /* The following definitions are for kernels previous to 2.6.32 which dont support recvmmsg */
 #ifndef HAVE_STRUCT_MMSGHDR
+#ifndef __INTEL_COMPILER
 struct mmsghdr {
     struct msghdr msg_hdr;  // Message header
     unsigned int  msg_len;  // Number of received bytes for header
 };
+#endif
 #endif
 
 #ifndef MSG_WAITFORONE

--- a/src/vma/sock/sockinfo_tcp.cpp
+++ b/src/vma/sock/sockinfo_tcp.cpp
@@ -3503,7 +3503,7 @@ int sockinfo_tcp::getsockname(sockaddr *__name, socklen_t *__namelen)
 		errno = EINVAL;
 		return -1;
 	}
-#//*/
+*/
 	// according to man address should be truncated if given struct is too small
 	if (__name && __namelen && (*__namelen >= m_bound.get_socklen())) {
 		m_bound.get_sa(__name);
@@ -3529,7 +3529,7 @@ int sockinfo_tcp::getpeername(sockaddr *__name, socklen_t *__namelen)
 		errno = EINVAL;
 		return -1;
 	}
-//*/
+*/
 	if (m_conn_state != TCP_CONN_CONNECTED) {
 		errno = ENOTCONN;
 		return -1;

--- a/src/vma/sock/sockinfo_udp.cpp
+++ b/src/vma/sock/sockinfo_udp.cpp
@@ -520,7 +520,7 @@ int sockinfo_udp::connect(const struct sockaddr *__to, socklen_t __tolen)
 		si_udp_logdbg("'connect()' to local loopback address [%s] will be handled by the OS", connect_to.to_str());
 		return 0; // zero returned from orig_connect()
 	}
-//*/
+*/
 
 		in_addr_t dst_ip = connect_to.get_in_addr();
 		in_port_t dst_port = connect_to.get_in_port();
@@ -1624,7 +1624,7 @@ ssize_t sockinfo_udp::tx(const tx_call_t call_type, const struct iovec* p_iov, c
 				m_dst_entry_map[dst] = p_dst_entry;
 				/* ADD logging
 				si_udp_logfunc("Address %d.%d.%d.%d failed resolving as Tx on supported devices for interfaces %d.%d.%d.%d (tx-ing to os)", NIPQUAD(to_ip), NIPQUAD(local_if));
-			//*/
+			*/
 			}
 		}
 	}

--- a/src/vma/sock/sockinfo_udp.h
+++ b/src/vma/sock/sockinfo_udp.h
@@ -159,7 +159,7 @@ private:
 	in_port_t 	m_bound_port;
 	in_addr_t 	m_connected_ip;
 	in_port_t 	m_connected_port;
-//*/
+*/
 	in_addr_t 	m_mc_tx_if;
 	bool 		m_b_mc_tx_loop;
 	uint8_t 	m_n_mc_ttl;


### PR DESCRIPTION
These changes designed to eliminate page fault event during
qp_mgr::mlx5_send() call.

See related at master https://github.com/Mellanox/libvma/pull/292