### PR TITLE
issue: 968200 FlowTag support for vmapoll merged to master.

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -169,6 +169,22 @@ AS_IF([test "x$enable_exp_cq" == xyes],
 	[
 	  AC_MSG_RESULT([no])
 	])
+
+	AC_MSG_CHECKING([if IBV_EXP_FLOW_SPEC_ACTION_TAG is defined])
+	AC_TRY_LINK(
+	#include <infiniband/verbs_exp.h>
+	,
+	[
+	  int access = (int)IBV_EXP_FLOW_SPEC_ACTION_TAG;
+	  return access;
+	],
+	[
+	  AC_MSG_RESULT([yes])
+	  AC_DEFINE(DEFINED_IBV_EXP_FLOW_TAG, 1, [Define to 1 if IBV_EXP_FLOW_SPEC_ACTION_TAG is defined])
+	],
+	[
+	  AC_MSG_RESULT([no])
+	])
 )
 
 #

--- a/src/vma/dev/cq_mgr.cpp
+++ b/src/vma/dev/cq_mgr.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001-2016 Mellanox Technologies, Ltd. All rights reserved.
+ * Copyright (c) 2001-2017 Mellanox Technologies, Ltd. All rights reserved.
  *
  * This software is available to you under a choice of one of two
  * licenses.  You may choose to be licensed under the terms of the GNU
@@ -739,6 +739,7 @@ void cq_mgr::reclaim_recv_buffer_helper(mem_buf_desc_t* buff)
 #ifdef DEFINED_VMAPOLL				
 				temp->path.rx.vma_polled = false;
 #endif // DEFINED_VMAPOLL				
+				temp->path.rx.flow_tag_id = 0;
 				temp->path.rx.p_ip_h = NULL;
 				temp->path.rx.p_tcp_h = NULL;
 				temp->path.rx.sw_timestamp.tv_nsec = 0;
@@ -778,6 +779,7 @@ void cq_mgr::vma_poll_reclaim_recv_buffer_helper(mem_buf_desc_t* buff)
 				temp->path.rx.gro = 0;
 				temp->path.rx.is_vma_thr = false;
 				temp->path.rx.vma_polled = false;
+				temp->path.rx.flow_tag_id = 0;
 				temp->path.rx.p_ip_h = NULL;
 				temp->path.rx.p_tcp_h = NULL;
 				temp->path.rx.sw_timestamp.tv_nsec = 0;
@@ -815,6 +817,7 @@ int cq_mgr::vma_poll_reclaim_single_recv_buffer_helper(mem_buf_desc_t* buff)
 		buff->path.rx.gro = 0;
 		buff->path.rx.is_vma_thr = false;
 		buff->path.rx.vma_polled = false;
+		buff->path.rx.flow_tag_id = 0;
 		buff->path.rx.p_ip_h = NULL;
 		buff->path.rx.p_tcp_h = NULL;
 		buff->path.rx.sw_timestamp.tv_nsec = 0;
@@ -892,6 +895,7 @@ int cq_mgr::vma_poll_and_process_element_rx(mem_buf_desc_t **p_desc_lst)
 		++m_n_wce_counter;
 		++m_qp->m_mlx5_hw_qp->rq.tail;
 		m_rx_hot_buff->sz_data = ntohl(cqe->byte_cnt);
+		m_rx_hot_buff->path.rx.flow_tag_id = vma_get_flow_tag(cqe);
 
 		if (unlikely(++m_qp_rec.debth >= (int)m_n_sysvar_rx_num_wr_to_post_recv)) {
 			compensate_qp_poll_success(m_rx_hot_buff);

--- a/src/vma/dev/cq_mgr.cpp
+++ b/src/vma/dev/cq_mgr.cpp
@@ -965,6 +965,7 @@ int cq_mgr::poll_and_process_helper_rx(uint64_t* p_cq_poll_sn, void* pv_fd_ready
 			++m_n_wce_counter;
 			++m_qp->m_mlx5_hw_qp->rq.tail;
 			m_rx_hot_buff->sz_data = ntohl(cqe->byte_cnt);
+			m_rx_hot_buff->path.rx.flow_tag_id = vma_get_flow_tag(cqe);
 
 			if (unlikely(++m_qp_rec.debth >= (int)m_n_sysvar_rx_num_wr_to_post_recv)) {
 				compensate_qp_poll_success(m_rx_hot_buff);

--- a/src/vma/dev/ib_ctx_handler.cpp
+++ b/src/vma/dev/ib_ctx_handler.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001-2016 Mellanox Technologies, Ltd. All rights reserved.
+ * Copyright (c) 2001-2017 Mellanox Technologies, Ltd. All rights reserved.
  *
  * This software is available to you under a choice of one of two
  * licenses.  You may choose to be licensed under the terms of the GNU
@@ -55,8 +55,13 @@
 
 
 ib_ctx_handler::ib_ctx_handler(struct ibv_context* ctx, ts_conversion_mode_t ctx_time_converter_mode) :
-	m_removed(false), m_conf_attr_rx_num_wre(0), m_conf_attr_tx_num_to_signal(0),
-	m_conf_attr_tx_max_inline(0), m_conf_attr_tx_num_wre(0), ctx_time_converter(ctx, ctx_time_converter_mode)
+	m_flow_tag_enabled(false)
+	, m_removed(false)
+	, m_conf_attr_rx_num_wre(0)
+	, m_conf_attr_tx_num_to_signal(0)
+	, m_conf_attr_tx_max_inline(0)
+	, m_conf_attr_tx_num_wre(0)
+	, ctx_time_converter(ctx, ctx_time_converter_mode)
 {
 	memset(&m_ibv_port_attr, 0, sizeof(m_ibv_port_attr));
 	m_p_ibv_context = ctx;
@@ -120,6 +125,11 @@ ibv_mr* ib_ctx_handler::mem_reg(void *addr, size_t length, uint64_t access)
 #else
 	return ibv_reg_mr(m_p_ibv_pd, addr, length, access);
 #endif
+}
+
+void ib_ctx_handler::set_flow_tag_capability(bool flow_tag_capability)
+{
+	m_flow_tag_enabled = flow_tag_capability;  // m_flow_tag_capability = flow_tag_capability;
 }
 
 bool ib_ctx_handler::update_port_attr(int port_num)

--- a/src/vma/dev/ib_ctx_handler.h
+++ b/src/vma/dev/ib_ctx_handler.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001-2016 Mellanox Technologies, Ltd. All rights reserved.
+ * Copyright (c) 2001-2017 Mellanox Technologies, Ltd. All rights reserved.
  *
  * This software is available to you under a choice of one of two
  * licenses.  You may choose to be licensed under the terms of the GNU
@@ -62,6 +62,8 @@ public:
 	virtual void            handle_event_ibverbs_cb(void *ev_data, void *ctx);
 	void                    handle_event_DEVICE_FATAL();
 	ts_conversion_mode_t    get_ctx_time_converter_status();
+	void                    set_flow_tag_capability(bool flow_tag_capability); 
+	bool                    get_flow_tag_capability() { return m_flow_tag_enabled;} // m_flow_tag_capability
 
 	inline void convert_hw_time_to_system_time(uint64_t hwtime, struct timespec* systime) { ctx_time_converter.convert_hw_time_to_system_time(hwtime, systime); }
 
@@ -71,6 +73,7 @@ private:
 	ibv_device*             m_p_ibv_device; // HCA handle
 	vma_ibv_device_attr     m_ibv_device_attr;
 	ibv_pd*                 m_p_ibv_pd;
+	bool                    m_flow_tag_enabled;
 	bool                    m_removed;
 
 	bool                    update_port_attr(int port_num);

--- a/src/vma/dev/net_device_table_mgr.h
+++ b/src/vma/dev/net_device_table_mgr.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001-2016 Mellanox Technologies, Ltd. All rights reserved.
+ * Copyright (c) 2001-2017 Mellanox Technologies, Ltd. All rights reserved.
  *
  * This software is available to you under a choice of one of two
  * licenses.  You may choose to be licensed under the terms of the GNU
@@ -134,9 +134,9 @@ private:
 
 	bool 			verify_ipoib_mode(struct ifaddrs* ifa);
 	bool			verify_mlx4_ib_device(const char* ifname);
-	bool 			verify_eth_qp_creation(const char* ifname);
-	bool 			verify_bond_ipoib_or_eth_qp_creation(struct ifaddrs * ifa);
-	bool 			verify_ipoib_or_eth_qp_creation(const char* interface_name, struct ifaddrs * ifa);
+	bool 			verify_eth_qp_creation(const char* ifname, uint8_t port_num);
+	bool 			verify_bond_ipoib_or_eth_qp_creation(struct ifaddrs * ifa, uint8_t port_num);
+	bool 			verify_ipoib_or_eth_qp_creation(const char* interface_name, struct ifaddrs * ifa, uint8_t port_num);
 	bool 			verify_enable_ipoib(const char* ifname);
 };
 

--- a/src/vma/dev/rfs.cpp
+++ b/src/vma/dev/rfs.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001-2016 Mellanox Technologies, Ltd. All rights reserved.
+ * Copyright (c) 2001-2017 Mellanox Technologies, Ltd. All rights reserved.
  *
  * This software is available to you under a choice of one of two
  * licenses.  You may choose to be licensed under the terms of the GNU
@@ -101,10 +101,10 @@ inline void rfs::prepare_filter_detach(int& filter_counter)
 	}
 }
 
-rfs::rfs(flow_tuple *flow_spec_5t, ring_simple *p_ring, rfs_rule_filter* rule_filter /*= NULL*/):
+rfs::rfs(flow_tuple *flow_spec_5t, ring_simple *p_ring, rfs_rule_filter* rule_filter /*= NULL*/, uint32_t flow_tag_id):
 	m_flow_tuple(rule_filter ? rule_filter->m_flow_tuple : *flow_spec_5t), m_p_ring(p_ring),
 	m_p_rule_filter(rule_filter), m_n_sinks_list_entries(0), m_n_sinks_list_max_length(RFS_SINKS_LIST_DEFAULT_LEN),
-	m_b_tmp_is_attached(false)
+	m_flow_tag_id(flow_tag_id), m_b_tmp_is_attached(false)
 {
 	m_sinks_list = new pkt_rcvr_sink*[m_n_sinks_list_max_length];
 
@@ -269,13 +269,14 @@ bool rfs::create_ibv_flow()
 		attach_flow_data_t* iter = m_attach_flow_data_vector[i];
 		iter->ibv_flow = vma_ibv_create_flow(iter->p_qp_mgr->get_ibv_qp(), &(iter->ibv_flow_attr));
 		if (!iter->ibv_flow) {
-			rfs_logerr("Create of QP flow ID failed with flow %s (errno=%d - %m)", m_flow_tuple.to_str(), errno); //TODO ALEXR - Add info about QP, spec, priority into log msg
+			rfs_logerr("Create of QP flow ID (tag: %d) failed with flow %s (errno=%d - %m)",
+				   m_flow_tag_id, m_flow_tuple.to_str(), errno); //TODO ALEXR - Add info about QP, spec, priority into log msg
 			return false;
 		}
 	}
 
 	m_b_tmp_is_attached = true;
-	rfs_logdbg("ibv_create_flow succeeded with flow %s", m_flow_tuple.to_str());
+	rfs_logdbg("ibv_create_flow succeeded with flow %s, tag_id: %d", m_flow_tuple.to_str(), m_flow_tag_id);
 	return true;
 }
 

--- a/src/vma/dev/rfs.h
+++ b/src/vma/dev/rfs.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001-2016 Mellanox Technologies, Ltd. All rights reserved.
+ * Copyright (c) 2001-2017 Mellanox Technologies, Ltd. All rights reserved.
  *
  * This software is available to you under a choice of one of two
  * licenses.  You may choose to be licensed under the terms of the GNU
@@ -92,6 +92,8 @@ typedef struct __attribute__ ((packed)) ibv_flow_attr_ib_ipv4_tcp_udp {
 		attr.flags = VMA_IBV_FLOW_ATTR_FLAGS_ALLOW_LOOP_BACK;
 	}
 } ibv_flow_attr_ib_ipv4_tcp_udp;
+
+
 #else
 //for uc
 typedef struct __attribute__ ((packed)) ibv_flow_attr_ib_ipv4_tcp_udp {
@@ -117,15 +119,21 @@ typedef struct __attribute__ ((packed)) ibv_flow_attr_eth_ipv4_tcp_udp {
 	vma_ibv_flow_spec_eth         eth;
 	vma_ibv_flow_spec_ipv4        ipv4;
 	vma_ibv_flow_spec_tcp_udp     tcp_udp;
+	vma_ibv_flow_spec_action_tag  flow_tag; // should be the latest as struct can be used without it
 
 	ibv_flow_attr_eth_ipv4_tcp_udp(uint8_t port) {
 		memset(this, 0, sizeof(*this));
-		attr.size = sizeof(struct ibv_flow_attr_eth_ipv4_tcp_udp);
+		attr.size = sizeof(struct ibv_flow_attr_eth_ipv4_tcp_udp) - sizeof(flow_tag);
 		attr.num_of_specs = 3;
 		attr.type = VMA_IBV_FLOW_ATTR_NORMAL;
 		attr.priority = 1; // almost highest priority, 0 is used for 5-tuple later
 		attr.port = port;
 	}
+	inline void add_flow_tag_spec(void) {
+		attr.num_of_specs++;
+		attr.size += sizeof(flow_tag);
+	}
+
 } ibv_flow_attr_eth_ipv4_tcp_udp;
 
 #ifdef DEFINED_IBV_FLOW_SPEC_IB
@@ -191,7 +199,8 @@ public:
 class rfs
 {
 public:
-	rfs(flow_tuple *flow_spec_5t, ring_simple *p_ring, rfs_rule_filter* rule_filter = NULL);
+	rfs(flow_tuple *flow_spec_5t, ring_simple *p_ring,
+	    rfs_rule_filter* rule_filter = NULL, uint32_t flow_tag_id=0);
 	virtual ~rfs();
 
 	/**
@@ -210,12 +219,13 @@ public:
 
 protected:
 	flow_tuple		m_flow_tuple;
-	ring_simple*			m_p_ring;
+	ring_simple*		m_p_ring;
 	rfs_rule_filter*	m_p_rule_filter;
 	attach_flow_data_vector_t m_attach_flow_data_vector;
 	pkt_rcvr_sink**		m_sinks_list;
 	uint32_t 		m_n_sinks_list_entries; // Number of actual sinks in the array (we shrink the array if a sink is removed)
 	uint32_t		m_n_sinks_list_max_length;
+	uint32_t		m_flow_tag_id; // Associated with this rule, set by attach_flow()
 	bool 			m_b_tmp_is_attached; // Only temporary, while ibcm calls attach_flow with no sinks...
 
 	bool 			create_ibv_flow(); // Attach flow to all qps

--- a/src/vma/dev/rfs_uc.cpp
+++ b/src/vma/dev/rfs_uc.cpp
@@ -115,9 +115,12 @@ bool rfs_uc::prepare_flow_spec()
 		p_attach_flow_data->ibv_flow_attr.priority = 0;
 	}
 
-	if (m_flow_tag_id && attach_flow_data_eth) {
+	if (m_flow_tag_id && attach_flow_data_eth) { // Will not attach flow_tag spec to rule for tag_id==0
 		ibv_flow_spec_flow_tag_set(p_flow_tag, m_flow_tag_id);
 		attach_flow_data_eth->ibv_flow_attr.add_flow_tag_spec();
+                rfs_logdbg("Adding flow_tag spec to rule, num_of_specs: %d flow_tag_id: %d",
+			   attach_flow_data_eth->ibv_flow_attr.attr.num_of_specs,
+			   m_flow_tag_id);
 	}
 
 	m_attach_flow_data_vector.push_back(p_attach_flow_data);
@@ -152,7 +155,6 @@ bool rfs_uc::rx_dispatch_packet(mem_buf_desc_t* p_rx_wc_buf_desc, void* pv_fd_re
 				return true;
 			}
 		}
-	//}
 	}
 	// Reuse this data buffer & mem_buf_desc
 	return false;

--- a/src/vma/dev/rfs_uc.cpp
+++ b/src/vma/dev/rfs_uc.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001-2016 Mellanox Technologies, Ltd. All rights reserved.
+ * Copyright (c) 2001-2017 Mellanox Technologies, Ltd. All rights reserved.
  *
  * This software is available to you under a choice of one of two
  * licenses.  You may choose to be licensed under the terms of the GNU
@@ -40,7 +40,8 @@
 #define MODULE_NAME 		"rfs_uc"
 
 
-rfs_uc::rfs_uc(flow_tuple *flow_spec_5t, ring_simple *p_ring, rfs_rule_filter* rule_filter /*= NULL*/) : rfs(flow_spec_5t, p_ring, rule_filter)
+rfs_uc::rfs_uc(flow_tuple *flow_spec_5t, ring_simple *p_ring, rfs_rule_filter* rule_filter, uint32_t flow_tag_id) :
+	rfs(flow_spec_5t, p_ring, rule_filter, flow_tag_id)
 {
 	BULLSEYE_EXCLUDE_BLOCK_START
 	if (m_flow_tuple.is_udp_mc()) {
@@ -67,6 +68,7 @@ bool rfs_uc::prepare_flow_spec()
 	attach_flow_data_eth_ipv4_tcp_udp_t*   attach_flow_data_eth = NULL;
 	vma_ibv_flow_spec_ipv4*             p_ipv4 = NULL;
 	vma_ibv_flow_spec_tcp_udp*          p_tcp_udp = NULL;
+	vma_ibv_flow_spec_action_tag*       p_flow_tag = NULL;
 
 	switch (type) {
 		case VMA_TRANSPORT_IB:
@@ -84,12 +86,11 @@ bool rfs_uc::prepare_flow_spec()
 			attach_flow_data_eth = new attach_flow_data_eth_ipv4_tcp_udp_t(m_p_ring->m_p_qp_mgr);
 
 			ibv_flow_spec_eth_set(&(attach_flow_data_eth->ibv_flow_attr.eth),
-					m_p_ring->m_p_l2_addr->get_address(),
+						m_p_ring->m_p_l2_addr->get_address(),
 						htons(m_p_ring->m_p_qp_mgr->get_partiton()));
-
-
 			p_ipv4 = &(attach_flow_data_eth->ibv_flow_attr.ipv4);
 			p_tcp_udp = &(attach_flow_data_eth->ibv_flow_attr.tcp_udp);
+			p_flow_tag = &(attach_flow_data_eth->ibv_flow_attr.flow_tag);
 			p_attach_flow_data = (attach_flow_data_t*)attach_flow_data_eth;
 			break;
 		BULLSEYE_EXCLUDE_BLOCK_START
@@ -112,6 +113,11 @@ bool rfs_uc::prepare_flow_spec()
 		// set priority of 5-tuple to be higher than 3-tuple
 		// to make sure 5-tuple have higher priority on ConnectX-4
 		p_attach_flow_data->ibv_flow_attr.priority = 0;
+	}
+
+	if (m_flow_tag_id && attach_flow_data_eth) {
+		ibv_flow_spec_flow_tag_set(p_flow_tag, m_flow_tag_id);
+		attach_flow_data_eth->ibv_flow_attr.add_flow_tag_spec();
 	}
 
 	m_attach_flow_data_vector.push_back(p_attach_flow_data);
@@ -146,8 +152,8 @@ bool rfs_uc::rx_dispatch_packet(mem_buf_desc_t* p_rx_wc_buf_desc, void* pv_fd_re
 				return true;
 			}
 		}
+	//}
 	}
-
 	// Reuse this data buffer & mem_buf_desc
 	return false;
 }

--- a/src/vma/dev/rfs_uc.h
+++ b/src/vma/dev/rfs_uc.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001-2016 Mellanox Technologies, Ltd. All rights reserved.
+ * Copyright (c) 2001-2017 Mellanox Technologies, Ltd. All rights reserved.
  *
  * This software is available to you under a choice of one of two
  * licenses.  You may choose to be licensed under the terms of the GNU
@@ -49,7 +49,8 @@
 class rfs_uc : public rfs
 {
 public:
-	rfs_uc(flow_tuple *flow_spec_5t, ring_simple *p_ring, rfs_rule_filter* rule_filter = NULL);
+	rfs_uc(flow_tuple *flow_spec_5t, ring_simple *p_ring,
+	       rfs_rule_filter* rule_filter = NULL, uint32_t flow_tag_id = 0);
 
 	virtual bool rx_dispatch_packet(mem_buf_desc_t* p_rx_wc_buf_desc, void* pv_fd_ready_array);
 

--- a/src/vma/dev/rfs_uc_tcp_gro.cpp
+++ b/src/vma/dev/rfs_uc_tcp_gro.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001-2016 Mellanox Technologies, Ltd. All rights reserved.
+ * Copyright (c) 2001-2017 Mellanox Technologies, Ltd. All rights reserved.
  *
  * This software is available to you under a choice of one of two
  * licenses.  You may choose to be licensed under the terms of the GNU
@@ -42,7 +42,9 @@
 #define TCP_H_LEN_TIMESTAMP 8
 
 
-rfs_uc_tcp_gro::rfs_uc_tcp_gro(flow_tuple *flow_spec_5t, ring_simple *p_ring, rfs_rule_filter* rule_filter /*= NULL*/) : rfs_uc(flow_spec_5t, p_ring, rule_filter), m_p_gro_mgr(&(p_ring->m_gro_mgr)), m_b_active(false), m_b_reserved(false)
+rfs_uc_tcp_gro::rfs_uc_tcp_gro(flow_tuple *flow_spec_5t, ring_simple *p_ring, rfs_rule_filter* rule_filter, uint32_t flow_tag_id) :
+	rfs_uc(flow_spec_5t, p_ring, rule_filter, flow_tag_id),
+	m_p_gro_mgr(&(p_ring->m_gro_mgr)), m_b_active(false), m_b_reserved(false)
 {
 	m_n_buf_max = m_p_gro_mgr->get_buf_max();
 	m_n_byte_max = m_p_gro_mgr->get_byte_max() - p_ring->get_mtu(); 

--- a/src/vma/dev/rfs_uc_tcp_gro.h
+++ b/src/vma/dev/rfs_uc_tcp_gro.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001-2016 Mellanox Technologies, Ltd. All rights reserved.
+ * Copyright (c) 2001-2017 Mellanox Technologies, Ltd. All rights reserved.
  *
  * This software is available to you under a choice of one of two
  * licenses.  You may choose to be licensed under the terms of the GNU
@@ -64,7 +64,8 @@ class gro_mgr;
 class rfs_uc_tcp_gro : public rfs_uc
 {
 public:
-	rfs_uc_tcp_gro(flow_tuple *flow_spec_5t, ring_simple *p_ring,  rfs_rule_filter* rule_filter = NULL);
+	rfs_uc_tcp_gro(flow_tuple *flow_spec_5t, ring_simple *p_ring,
+		       rfs_rule_filter* rule_filter = NULL, uint32_t flow_tag_id = 0);
 
 	virtual bool rx_dispatch_packet(mem_buf_desc_t* p_rx_wc_buf_desc, void* pv_fd_ready_array);
 

--- a/src/vma/dev/ring_simple.cpp
+++ b/src/vma/dev/ring_simple.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001-2016 Mellanox Technologies, Ltd. All rights reserved.
+ * Copyright (c) 2001-2017 Mellanox Technologies, Ltd. All rights reserved.
  *
  * This software is available to you under a choice of one of two
  * licenses.  You may choose to be licensed under the terms of the GNU
@@ -42,6 +42,7 @@
 #include "vma/proto/ip_frag.h"
 #include "vma/proto/L2_address.h"
 #include "vma/proto/igmp_mgr.h"
+#include "vma/sock/pkt_rcvr_sink.h"
 #include "vma/sock/sockinfo_tcp.h"
 #include "vma/sock/fd_collection.h"
 #include "vma/dev/rfs_mc.h"
@@ -57,12 +58,6 @@
 
 #define ALIGN_WR_DOWN(_num_wr_) 		(max(32, ((_num_wr_      ) & ~(0xf))))
 
-#ifdef DEFINED_VMAPOLL	
-// Used to single that we have a single 5tuple TCP connected socket, we can improve fast path
-// TODO: We should be able to show similar behaviour for UDP
-// REVIEW: it seems p_rfs_single_tcp is not uded in code. AlexV: can it be removed?
-rfs *p_rfs_single_tcp = NULL;
-#endif // DEFINED_VMAPOLL	
 
 /**/
 /** inlining functions can only help if they are implemented before their usage **/
@@ -106,9 +101,11 @@ ring_simple::ring_simple(in_addr_t local_if, uint16_t partition_sn, int count, t
 	m_p_rx_comp_event_channel(NULL), m_p_tx_comp_event_channel(NULL), m_p_l2_addr(NULL), m_p_ring_stat(NULL),
 	m_local_if(local_if), m_transport_type(transport_type), m_b_sysvar_eth_mc_l2_only_rules(safe_mce_sys().eth_mc_l2_only_rules)
 #ifdef DEFINED_VMAPOLL		
-	, m_rx_buffs_rdy_for_free_head(NULL), m_rx_buffs_rdy_for_free_tail(NULL) 
+	, m_rx_buffs_rdy_for_free_head(NULL)
+	, m_rx_buffs_rdy_for_free_tail(NULL) 
 #endif // DEFINED_VMAPOLL		
-	{
+	, m_flow_tag_enabled(false)
+{
 
 	if (count != 1)
 		ring_logpanic("Error creating simple ring with more than 1 resource");
@@ -240,6 +237,8 @@ void ring_simple::create_resources(ring_resource_creation_info_t* p_ring_info, b
 
 	memset(&m_cq_moderation_info, 0, sizeof(m_cq_moderation_info));
 
+	m_flow_tag_enabled = p_ring_info->p_ib_ctx->get_flow_tag_capability();
+
 	m_p_rx_comp_event_channel = ibv_create_comp_channel(p_ring_info->p_ib_ctx->get_ibv_context()); // ODED TODO: Adjust the ibv_context to be the exact one in case of different devices
 	BULLSEYE_EXCLUDE_BLOCK_START
 	if (m_p_rx_comp_event_channel == NULL) {
@@ -314,10 +313,32 @@ void ring_simple::restart(ring_resource_creation_info_t* p_ring_info)
 
 bool ring_simple::attach_flow(flow_tuple& flow_spec_5t, pkt_rcvr_sink *sink)
 {
-	rfs *p_rfs;
-	rfs *p_tmp_rfs = NULL;
+	rfs* p_rfs;
+	rfs* p_tmp_rfs = NULL;
+	sockinfo* si = static_cast<sockinfo*> (sink);
+	uint32_t flow_tag_id = 0;
 
 	ring_logdbg("flow: %s, with sink (%p)", flow_spec_5t.to_str(), sink);
+
+	if (m_flow_tag_enabled && (si != NULL)) {
+		int	sock_fd = si->get_fd();
+
+		if (sock_fd > 0) {
+			flow_tag_id = sock_fd & FLOW_TAG_MASK;
+			if ((uint32_t)sock_fd != flow_tag_id) {
+			//  tag_id is out of the range by mask, will not use it
+				flow_tag_id = 0;
+				ring_logdbg("flow_tag disabled as tag_id: %d is out of mask (%x) range!",
+					    flow_tag_id, FLOW_TAG_MASK);
+			}
+			ring_logdbg("flow: %s, sink:%p sock_fd:%d enabled:%d with id:%d",
+				    flow_spec_5t.to_str(), sink, sock_fd,
+				    m_flow_tag_enabled, flow_tag_id);
+		} else {
+			// 0 - means FT should not be used
+			ring_logdbg("flow_tag disabled as sock_fd <=0!");
+		}
+	}
 
 	/*
 	 * //auto_unlocker lock(m_lock_ring_rx);
@@ -333,10 +354,13 @@ bool ring_simple::attach_flow(flow_tuple& flow_spec_5t, pkt_rcvr_sink *sink)
 	if (flow_spec_5t.is_udp_uc()) {
 		flow_spec_udp_uc_key_t key_udp_uc(flow_spec_5t.get_dst_port());
 		p_rfs = m_flow_udp_uc_map.get(key_udp_uc, NULL);
-		if (p_rfs == NULL) {		// It means that no rfs object exists so I need to create a new one and insert it to the flow map
+		if (p_rfs == NULL) {
+			/* It means that no rfs object exists so I need to create a new one
+			 * and insert it to the flow map
+			 */
 			m_lock_ring_rx.unlock();
 			try {
-				p_tmp_rfs = new rfs_uc(&flow_spec_5t, this);
+				p_tmp_rfs = new rfs_uc(&flow_spec_5t, this, NULL, flow_tag_id);
 			} catch(vma_exception& e) {
 				ring_logerr("%s", e.message);
 				return false;
@@ -358,6 +382,8 @@ bool ring_simple::attach_flow(flow_tuple& flow_spec_5t, pkt_rcvr_sink *sink)
 		}
 	} else if (flow_spec_5t.is_udp_mc()) {
 		flow_spec_udp_mc_key_t key_udp_mc(flow_spec_5t.get_dst_ip(), flow_spec_5t.get_dst_port());
+		flow_tag_id = 0; // MC so far can't be handled by flow_tag due issues in FW
+
 		// For IB MC flow, the port is zeroed in the ibv_flow_spec when calling to ibv_flow_spec().
 		// It means that for every MC group, even if we have sockets with different ports - only one rule in the HW.
 		// So the hash map below keeps track of the number of sockets per rule so we know when to call ibv_attach and ibv_detach
@@ -417,10 +443,10 @@ bool ring_simple::attach_flow(flow_tuple& flow_spec_5t, pkt_rcvr_sink *sink)
 				tcp_dst_port_filter = new rfs_rule_filter(m_tcp_dst_port_attach_map, key_tcp.dst_port, tcp_3t_only);
 			}
 			if(safe_mce_sys().gro_streams_max && flow_spec_5t.is_5_tuple()) {
-				p_tmp_rfs = new rfs_uc_tcp_gro(&flow_spec_5t, this, tcp_dst_port_filter);
+				p_tmp_rfs = new rfs_uc_tcp_gro(&flow_spec_5t, this, tcp_dst_port_filter, flow_tag_id);
 			} else {
 				try {
-					p_tmp_rfs = new rfs_uc(&flow_spec_5t, this, tcp_dst_port_filter);
+					p_tmp_rfs = new rfs_uc(&flow_spec_5t, this, tcp_dst_port_filter, flow_tag_id);
 				} catch(vma_exception& e) {
 					ring_logerr("%s", e.message);
 					return false;
@@ -450,21 +476,34 @@ bool ring_simple::attach_flow(flow_tuple& flow_spec_5t, pkt_rcvr_sink *sink)
 	BULLSEYE_EXCLUDE_BLOCK_END
 
 	bool ret = p_rfs->attach_flow(sink);
-#ifdef DEFINED_VMAPOLL	
-// REVIEW: can p_rfs_single_tcp be removed?
-	if (flow_spec_5t.is_tcp() && !flow_spec_5t.is_3_tuple()) {
-		// save the single 5tuple TCP connected socket for improved fast path
-		//p_rfs_single_tcp = p_rfs;
-		ring_logdbg("update p_rfs_single_tcp=%p", p_rfs_single_tcp);
+	if (ret) {
+		if (m_flow_tag_enabled) {
+			/* Flow with FlowTag was attached succesfully, check
+			 *  stored rfs for fast path be tag_id
+			 */
+			if ((si != NULL) && flow_tag_id) {
+				si->set_flow_tag(flow_tag_id);
+				ring_logdbg("flow_tag: %d registration is done!", flow_tag_id);
+			}
+		} 
+		if (flow_spec_5t.is_tcp() && !flow_spec_5t.is_3_tuple()) {
+			/* save the single 5tuple TCP connected socket for improved fast path
+			 */
+			if (si != NULL) {
+				si->set_tcp_flow_is_5t();
+				ring_logdbg("single 5T TCP update m_tcp_flow_is_5t m_flow_tag_enabled: %d", m_flow_tag_enabled);
+			}
+		}
+	} else {
+		ring_logerr("attach_flow=%d failed, flow_tag %d should be disabled!", ret, flow_tag_id);
 	}
-#endif // DEFINED_VMAPOLL	
 	m_lock_ring_rx.unlock();
 	return ret;
 }
 
 bool ring_simple::detach_flow(flow_tuple& flow_spec_5t, pkt_rcvr_sink* sink)
 {
-	rfs *p_rfs = NULL;
+	rfs* p_rfs = NULL;
 
 	ring_logdbg("flow: %s, with sink (%p)", flow_spec_5t.to_str(), sink);
 
@@ -542,14 +581,6 @@ bool ring_simple::detach_flow(flow_tuple& flow_spec_5t, pkt_rcvr_sink* sink)
 		}
 		BULLSEYE_EXCLUDE_BLOCK_END
 
-#ifdef DEFINED_VMAPOLL
-// REVIEW: can p_rfs_single_tcp be removed?
-		if (p_rfs_single_tcp == p_rfs) {
-			// clear the single 5tuple TCP connected socket for improved fast path
-			p_rfs_single_tcp = NULL;
-			ring_logdbg("update p_rfs_single_tcp=%p", p_rfs_single_tcp);
-		}
-#endif // DEFINED_VMAPOLL
 		p_rfs->detach_flow(sink);
 		if(!keep_in_map){
 			m_tcp_dst_port_attach_map.erase(m_tcp_dst_port_attach_map.find(key_tcp.dst_port));
@@ -627,7 +658,7 @@ void ring::print_flow_to_rfs_udp_uc_map(flow_spec_udp_uc_map_t *p_flow_map)
 	}
 }
 
-void ring::print_flow_to_rfs_tcp_map(flow_spec_tcp_map_t *p_flow_map)
+void ring_simple::print_flow_to_rfs_tcp_map(flow_spec_tcp_map_t *p_flow_map)
 {
 	rfs *curr_rfs;
 	flow_spec_tcp_key_t map_key;
@@ -639,7 +670,7 @@ void ring::print_flow_to_rfs_tcp_map(flow_spec_tcp_map_t *p_flow_map)
 
 	itr = p_flow_map->begin();
 	if (!(itr != p_flow_map->end())) {
-		ring_logdbg("flow_spec_udp_uc_map is EMPTY!\n");
+		ring_logdbg("flow_spec_tcp_map is EMPTY!\n");
 	} else {
 		for (itr = p_flow_map->begin(); itr != p_flow_map->end(); ++itr) {
 			curr_rfs = itr->second;
@@ -648,7 +679,9 @@ void ring::print_flow_to_rfs_tcp_map(flow_spec_tcp_map_t *p_flow_map)
 				ring_logdbg("######### key: port = %d, rfs: NULL", ntohs(map_key.dst_port));
 			}
 			else {
-				ring_logdbg("######### key: src_ip:%d.%d.%d.%d, dst_port=%d, src_port=%d, rfs: num of sinks = %d", NIPQUAD(map_key.src_ip), ntohs(map_key.dst_port), ntohs(map_key.src_port), curr_rfs->get_num_of_sinks());
+				ring_logdbg("######### key: src=%d.%d.%d.%d:%d, dst_port=%d rfs: num of sinks = %d",
+					NIPQUAD(map_key.src_ip), ntohs(map_key.src_port),
+					ntohs(map_key.dst_port), curr_rfs->get_num_of_sinks());
 			}
 		}
 	}
@@ -673,10 +706,35 @@ const char* priv_igmp_type_tostr(uint8_t igmptype)
 }
 
 #ifdef DEFINED_VMAPOLL
+// calling sockinfo callback with RFS bypass
+static inline bool check_rx_packet(sockinfo *si, mem_buf_desc_t* p_rx_wc_buf_desc)
+{
+	// Dispatching: Notify new packet to the FIRST registered receiver ONLY
+	p_rx_wc_buf_desc->reset_ref_count();
+#ifdef RDTSC_MEASURE_RX_DISPATCH_PACKET
+	RDTSC_TAKE_START(g_rdtsc_instr_info_arr[RDTSC_FLOW_RX_DISPATCH_PACKET]);
+#endif //RDTSC_MEASURE_RX_DISPATCH_PACKET
+	if (likely(si)) {
+		p_rx_wc_buf_desc->inc_ref_count();
+		si->rx_input_cb(p_rx_wc_buf_desc, NULL);
+#ifdef RDTSC_MEASURE_RX_DISPATCH_PACKET
+	RDTSC_TAKE_END(g_rdtsc_instr_info_arr[RDTSC_FLOW_RX_DISPATCH_PACKET]);
+#endif //RDTSC_MEASURE_RX_DISPATCH_PACKET
+		// Check packet ref_count to see the last receiver is interested in this packet
+		if (p_rx_wc_buf_desc->dec_ref_count() > 1) {
+			// The sink will be responsible to return the buffer to CQ for reuse
+			return true;
+		}
+	}
+	// Reuse this data buffer & mem_buf_desc
+	return false;
+}
+
 inline void ring_simple::vma_poll_process_recv_buffer(mem_buf_desc_t* p_rx_wc_buf_desc)
 {
 	//size_t sz_data = 0;
-	size_t transport_header_len = 0;
+	size_t transport_header_len = ETH_HDR_LEN;
+
 	uint16_t ip_hdr_len = 0;
 	uint16_t ip_tot_len = 0;
 	uint16_t ip_frag_off = 0;
@@ -691,22 +749,71 @@ inline void ring_simple::vma_poll_process_recv_buffer(mem_buf_desc_t* p_rx_wc_bu
 	NOT_IN_USE(p_udp_h);
 	NOT_IN_USE(local_addr);
 
-	if (likely(p_rfs_single_tcp)) {
-		// we have a single 5tuple TCP connected socket, use simpler fast path
-		transport_header_len = ETH_HDR_LEN;
-		p_ip_h = (struct iphdr*)(p_rx_wc_buf_desc->p_buffer + transport_header_len);
-		ip_hdr_len = 20; //(int)(p_ip_h->ihl)*4;
-		struct tcphdr* p_tcp_h = (struct tcphdr*)((uint8_t*)p_ip_h + ip_hdr_len);
-		p_rx_wc_buf_desc->path.rx.p_ip_h        = p_ip_h;
-		p_rx_wc_buf_desc->path.rx.p_tcp_h       = p_tcp_h;
-		p_rx_wc_buf_desc->transport_header_len  = transport_header_len;
-		p_rx_wc_buf_desc->path.rx.vma_polled = true;
-		p_rfs_single_tcp->rx_dispatch_packet(p_rx_wc_buf_desc, NULL);
-		p_rx_wc_buf_desc->path.rx.vma_polled = false;
-		return;
-	}
-
 	// This is an internal function (within ring and 'friends'). No need for lock mechanism.
+
+	if (likely(m_flow_tag_enabled && p_rx_wc_buf_desc->path.rx.flow_tag_id)) {
+		sockinfo* si = NULL;
+		si = static_cast <sockinfo* >(g_p_fd_collection->get_sockfd(p_rx_wc_buf_desc->path.rx.flow_tag_id));
+
+		if (likely(si != NULL)) {
+			p_ip_h = (struct iphdr*)(p_rx_wc_buf_desc->p_buffer + transport_header_len);
+			ip_hdr_len = 20; //(int)(p_ip_h->ihl)*4;
+			ip_tot_len = ntohs(p_ip_h->tot_len);
+
+			if (likely(si->tcp_flow_is_5t())) {
+				// we have a single 5tuple TCP connected socket, use simpler fast path
+				struct tcphdr* p_tcp_h = (struct tcphdr*)((uint8_t*)p_ip_h + ip_hdr_len);
+				size_t sz_payload = ip_tot_len - ip_hdr_len - p_tcp_h->doff*4;
+
+				// Update packet descriptor with datagram base address and length
+				p_rx_wc_buf_desc->path.rx.frag.iov_base = (uint8_t*)p_tcp_h + sizeof(struct tcphdr);
+				p_rx_wc_buf_desc->path.rx.frag.iov_len  = ip_tot_len - ip_hdr_len - sizeof(struct tcphdr);
+
+				p_rx_wc_buf_desc->path.rx.sz_payload          = sz_payload;
+
+				p_rx_wc_buf_desc->path.rx.p_ip_h              = p_ip_h;
+				p_rx_wc_buf_desc->path.rx.p_tcp_h             = p_tcp_h;
+				p_rx_wc_buf_desc->transport_header_len        = transport_header_len;
+
+/*				ring_logfunc("FAST PATH Rx TCP segment info: src_port=%d, dst_port=%d, flags='%s%s%s%s%s%s' seq=%u, ack=%u, win=%u, payload_sz=%u",
+					ntohs(p_tcp_h->source), ntohs(p_tcp_h->dest),
+					p_tcp_h->urg?"U":"", p_tcp_h->ack?"A":"", p_tcp_h->psh?"P":"",
+					p_tcp_h->rst?"R":"", p_tcp_h->syn?"S":"", p_tcp_h->fin?"F":"",
+					ntohl(p_tcp_h->seq), ntohl(p_tcp_h->ack_seq), ntohs(p_tcp_h->window),
+					sz_payload);
+*/
+				p_rx_wc_buf_desc->path.rx.vma_polled = true;
+				check_rx_packet(si,p_rx_wc_buf_desc);
+				p_rx_wc_buf_desc->path.rx.vma_polled = false;
+				return;
+			} else if (p_ip_h->protocol==IPPROTO_UDP) {
+				// Get the udp header pointer + udp payload size
+				p_udp_h = (struct udphdr*)((uint8_t*)p_ip_h + ip_hdr_len);
+				size_t sz_payload = ntohs(p_udp_h->len) - sizeof(struct udphdr);
+				// Update packet descriptor with datagram base address and length
+				p_rx_wc_buf_desc->path.rx.frag.iov_base = (uint8_t*)p_udp_h + sizeof(struct udphdr);
+				p_rx_wc_buf_desc->path.rx.frag.iov_len  = ip_tot_len - ip_hdr_len - sizeof(struct udphdr);
+
+				// Update the L4 info
+				p_rx_wc_buf_desc->path.rx.src.sin_port        = p_udp_h->source;
+				p_rx_wc_buf_desc->path.rx.dst.sin_port        = p_udp_h->dest;
+				p_rx_wc_buf_desc->path.rx.sz_payload          = sz_payload;
+				p_rx_wc_buf_desc->transport_header_len        = transport_header_len;
+
+				// Update the L3 info
+				p_rx_wc_buf_desc->path.rx.src.sin_family      = AF_INET;
+				p_rx_wc_buf_desc->path.rx.src.sin_addr.s_addr = p_ip_h->saddr;
+
+/*				ring_logfunc("FAST PATH Rx UDP datagram info: src_port=%d, dst_port=%d, payload_sz=%d, csum=%#x",
+					     ntohs(p_udp_h->source), ntohs(p_udp_h->dest), sz_payload, p_udp_h->check);
+*/
+				p_rx_wc_buf_desc->path.rx.vma_polled = true;
+				check_rx_packet(si,p_rx_wc_buf_desc);
+				p_rx_wc_buf_desc->path.rx.vma_polled = false;
+				return;
+			}
+		}
+	}
 
 	// Validate buffer size
 	size_t sz_data = p_rx_wc_buf_desc->sz_data;
@@ -734,7 +841,6 @@ inline void ring_simple::vma_poll_process_recv_buffer(mem_buf_desc_t* p_rx_wc_bu
 			ETH_HW_ADDR_PRINT_ADDR(p_eth_h->h_source),
 			htons(p_eth_h->h_proto));
 
-	transport_header_len = ETH_HDR_LEN;
 	uint16_t* p_h_proto = &p_eth_h->h_proto;
 
 	// Handle VLAN header as next protocol
@@ -856,7 +962,7 @@ inline void ring_simple::vma_poll_process_recv_buffer(mem_buf_desc_t* p_rx_wc_bu
 		return false;
 	}
 #endif
-	rfs *p_rfs = NULL;
+	rfs* p_rfs = NULL;
 
 	// Update the L3 info
 	p_rx_wc_buf_desc->path.rx.src.sin_family      = AF_INET;
@@ -888,7 +994,7 @@ inline void ring_simple::vma_poll_process_recv_buffer(mem_buf_desc_t* p_rx_wc_bu
 			p_rfs = m_flow_udp_uc_map.get((flow_spec_udp_uc_key_t){p_rx_wc_buf_desc->path.rx.dst.sin_port}, NULL);
 		} else {	// This is UDP MC packet
 			p_rfs = m_flow_udp_mc_map.get((flow_spec_udp_mc_key_t){p_rx_wc_buf_desc->path.rx.dst.sin_addr.s_addr,
-				p_rx_wc_buf_desc->path.rx.dst.sin_port}, NULL);
+							p_rx_wc_buf_desc->path.rx.dst.sin_port}, NULL);
 		}
 	}
 	break;
@@ -939,7 +1045,6 @@ inline void ring_simple::vma_poll_process_recv_buffer(mem_buf_desc_t* p_rx_wc_bu
 				NIPQUAD(p_rx_wc_buf_desc->path.rx.dst.sin_addr.s_addr), ntohs(p_rx_wc_buf_desc->path.rx.dst.sin_port),
 				NIPQUAD(p_rx_wc_buf_desc->path.rx.src.sin_addr.s_addr), ntohs(p_rx_wc_buf_desc->path.rx.src.sin_port),
 				iphdr_protocol_type_to_str(p_ip_h->protocol), p_ip_h->protocol);
-
 		return;
 	}
 	p_rx_wc_buf_desc->path.rx.vma_polled = true;
@@ -947,7 +1052,6 @@ inline void ring_simple::vma_poll_process_recv_buffer(mem_buf_desc_t* p_rx_wc_bu
 	p_rx_wc_buf_desc->path.rx.vma_polled = false;
 }
 #endif // DEFINED_VMAPOLL
-
 
 
 // All CQ wce come here for some basic sanity checks and then are distributed to the correct ring handler
@@ -971,20 +1075,6 @@ bool ring_simple::rx_process_buffer(mem_buf_desc_t* p_rx_wc_buf_desc, transport_
 	NOT_IN_USE(transport_type);
 #endif // DEFINED_VMAPOLL
 
-#ifdef DEFINED_VMAPOLL
-// REVIEW - can p_rfs_single_tcp be removed?
-	if (likely(p_rfs_single_tcp)) {
-		// we have a single 5tuple TCP connected socket, use simpler fast path
-		transport_header_len = ETH_HDR_LEN;
-		p_ip_h = (struct iphdr*)(p_rx_wc_buf_desc->p_buffer + transport_header_len);
-		ip_hdr_len = 20; //(int)(p_ip_h->ihl)*4;
-		struct tcphdr* p_tcp_h = (struct tcphdr*)((uint8_t*)p_ip_h + ip_hdr_len);
-		p_rx_wc_buf_desc->path.rx.p_ip_h        = p_ip_h;
-		p_rx_wc_buf_desc->path.rx.p_tcp_h       = p_tcp_h;
-		p_rx_wc_buf_desc->transport_header_len  = transport_header_len;
-		return p_rfs_single_tcp->rx_dispatch_packet(p_rx_wc_buf_desc, pv_fd_ready_array);
-	}
-#endif // DEFINED_VMAPOLL
 	// This is an internal function (within ring and 'friends'). No need for lock mechanism.
 
 	// Validate buffer size

--- a/src/vma/dev/ring_simple.h
+++ b/src/vma/dev/ring_simple.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001-2016 Mellanox Technologies, Ltd. All rights reserved.
+ * Copyright (c) 2001-2017 Mellanox Technologies, Ltd. All rights reserved.
  *
  * This software is available to you under a choice of one of two
  * licenses.  You may choose to be licensed under the terms of the GNU
@@ -49,7 +49,7 @@ public:
 	virtual void		adapt_cq_moderation();
 	bool			reclaim_recv_buffers_no_lock(descq_t *rx_reuse); // No locks
 // REVIEW - in experimental next method was defined as virtual	
-	bool		reclaim_recv_buffers_no_lock(mem_buf_desc_t* rx_reuse_lst); // No locks
+	bool			reclaim_recv_buffers_no_lock(mem_buf_desc_t* rx_reuse_lst); // No locks
 #ifdef DEFINED_VMAPOLL	
 	virtual int 		vma_poll(struct vma_completion_t *vma_completions, unsigned int ncompletions, int flags);	
 	virtual int		vma_poll_reclaim_single_recv_buffer(mem_buf_desc_t* rx_reuse_lst); // No locks
@@ -163,6 +163,7 @@ private:
 	mem_buf_desc_t*		m_rx_buffs_rdy_for_free_head;
 	mem_buf_desc_t*		m_rx_buffs_rdy_for_free_tail;
 #endif // DEFINED_VMAPOLL		
+	bool			m_flow_tag_enabled;
 };
 
 class ring_eth : public ring_simple

--- a/src/vma/proto/mem_buf_desc.h
+++ b/src/vma/proto/mem_buf_desc.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001-2016 Mellanox Technologies, Ltd. All rights reserved.
+ * Copyright (c) 2001-2017 Mellanox Technologies, Ltd. All rights reserved.
  *
  * This software is available to you under a choice of one of two
  * licenses.  You may choose to be licensed under the terms of the GNU
@@ -108,6 +108,7 @@ public:
 
 	union {
 		struct {
+			uint32_t	flow_tag_id;	// Flow Tag ID of this received packet
 			struct iphdr* 	p_ip_h;
 			struct tcphdr* 	p_tcp_h;
 			uint32_t	gro;		// is gro buff

--- a/src/vma/sock/fd_collection.h
+++ b/src/vma/sock/fd_collection.h
@@ -208,7 +208,7 @@ inline cls* fd_collection::get(int fd, cls **map_type)
 		return NULL;
 
 	cls* obj = map_type[fd];
-	fdcoll_logfuncall("fd=%d %sFound", fd, (obj ? "" : "Not "));
+//	fdcoll_logfuncall("fd=%d %sFound", fd, (obj ? "" : "Not "));
 	return obj;
 }
 

--- a/src/vma/sock/sockinfo.cpp
+++ b/src/vma/sock/sockinfo.cpp
@@ -83,8 +83,11 @@ sockinfo::sockinfo(int fd) throw (vma_exception):
 		m_rx_callback(NULL),
 		m_rx_callback_context(NULL)
 #ifdef DEFINED_VMAPOLL 		
-		,m_fd_context((void *)((uintptr_t)m_fd))
+		, m_fd_context((void *)((uintptr_t)m_fd))
 #endif // DEFINED_VMAPOLL 		
+		, m_flow_tag_id(0)
+		, m_flow_tag_enabled(false)
+		, m_tcp_flow_is_5t(false)
 {
 	m_rx_epfd = orig_os_api.epoll_create(128);
 	if (unlikely(m_rx_epfd == -1)) {

--- a/src/vma/sock/sockinfo.h
+++ b/src/vma/sock/sockinfo.h
@@ -127,6 +127,7 @@ public:
 		m_flow_tag_id = flow_tag_id;
 		m_flow_tag_enabled = flow_tag_id > 0 ? true : false;
 	}
+	inline bool flow_tag_enabled(void) { return m_flow_tag_enabled; }
 
 #ifdef DEFINED_VMAPOLL
 	virtual int fast_nonblocking_rx(vma_packets_t *vma_pkts);

--- a/src/vma/sock/sockinfo.h
+++ b/src/vma/sock/sockinfo.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001-2016 Mellanox Technologies, Ltd. All rights reserved.
+ * Copyright (c) 2001-2017 Mellanox Technologies, Ltd. All rights reserved.
  *
  * This software is available to you under a choice of one of two
  * licenses.  You may choose to be licensed under the terms of the GNU
@@ -121,6 +121,13 @@ public:
 	virtual int add_epoll_context(epfd_info *epfd);
 	virtual void remove_epoll_context(epfd_info *epfd);
 
+	inline bool tcp_flow_is_5t(void) { return m_tcp_flow_is_5t; }
+	inline void set_tcp_flow_is_5t(void) { m_tcp_flow_is_5t = true; }
+	inline void set_flow_tag(int flow_tag_id) {
+		m_flow_tag_id = flow_tag_id;
+		m_flow_tag_enabled = flow_tag_id > 0 ? true : false;
+	}
+
 #ifdef DEFINED_VMAPOLL
 	virtual int fast_nonblocking_rx(vma_packets_t *vma_pkts);
 	virtual int get_rings_num() {return 1;}
@@ -190,6 +197,9 @@ protected:
 #ifdef DEFINED_VMAPOLL	
 	void*			m_fd_context;
 #endif // DEFINED_VMAPOLL	
+	uint32_t		m_flow_tag_id;	// Flow Tag for this socket
+	bool			m_flow_tag_enabled; // for this socket
+	bool			m_tcp_flow_is_5t; // to bypass packet analysis
 
 	virtual void 		set_blocking(bool is_blocked);
 	virtual int 		fcntl(int __cmd, unsigned long int __arg) throw (vma_error);
@@ -395,7 +405,7 @@ protected:
 
     inline void reuse_buffer(mem_buf_desc_t *buff)
     {
-    	set_rx_reuse_pending(false);
+	set_rx_reuse_pending(false);
     	ring* p_ring = ((ring*)(buff->p_desc_owner))->get_parent();
     	rx_ring_map_t::iterator iter = m_rx_ring_map.find(p_ring);
     	if(likely(iter != m_rx_ring_map.end())){

--- a/src/vma/sock/sockinfo_udp.cpp
+++ b/src/vma/sock/sockinfo_udp.cpp
@@ -1775,36 +1775,35 @@ bool sockinfo_udp::tx_check_if_would_not_block()
 
 bool sockinfo_udp::rx_input_cb(mem_buf_desc_t* p_desc, void* pv_fd_ready_array)
 {
+
 	// Check that sockinfo is bound to the packets dest port
 	if (unlikely(p_desc->path.rx.dst.sin_port != m_bound.get_in_port())) {
 		si_udp_logfunc("rx packet discarded - not socket's bound port (pkt: %d, sock:%s)",
-		           ntohs(p_desc->path.rx.dst.sin_port), m_bound.to_str_in_port());
+			       ntohs(p_desc->path.rx.dst.sin_port), m_bound.to_str_in_port());
 		return false;
 	}
 
 	if (m_connected.get_in_port() != INPORT_ANY && m_connected.get_in_addr() != INADDR_ANY) {
 		if (unlikely(m_connected.get_in_port() != p_desc->path.rx.src.sin_port)) {
 			si_udp_logfunc("rx packet discarded - not socket's connected port (pkt: %d, sock:%s)",
-				   ntohs(p_desc->path.rx.src.sin_port), m_connected.to_str_in_port());
+					ntohs(p_desc->path.rx.src.sin_port), m_connected.to_str_in_port());
 			return false;
 		}
 
 		if (unlikely(m_connected.get_in_addr() != p_desc->path.rx.src.sin_addr.s_addr)) {
 			si_udp_logfunc("rx packet discarded - not socket's connected port (pkt: [%d:%d:%d:%d], sock:[%s])",
-				   NIPQUAD(p_desc->path.rx.src.sin_addr.s_addr), m_connected.to_str_in_addr());
+					NIPQUAD(p_desc->path.rx.src.sin_addr.s_addr), m_connected.to_str_in_addr());
 			return false;
 		}
 	}
-
 	// if loopback is disabled, discard loopback packets.
 	// in linux, loopback control (set by setsockopt) is done in TX flow.
 	// since we currently can't control it in TX, we behave like windows, which filter on RX
 	if (unlikely(!m_b_mc_tx_loop && p_desc->path.rx.local_if == p_desc->path.rx.src.sin_addr.s_addr)) {
 		si_udp_logfunc("rx packet discarded - loopback is disabled (pkt: [%d:%d:%d:%d], sock:%s)",
-			NIPQUAD(p_desc->path.rx.src.sin_addr.s_addr), m_bound.to_str_in_addr());
+				NIPQUAD(p_desc->path.rx.src.sin_addr.s_addr), m_bound.to_str_in_addr());
 		return false;
 	}
-
 	// Check port mapping - redirecting packets to another socket
 	while (!m_port_map.empty()) {
 		m_port_map_lock.lock();
@@ -2263,6 +2262,7 @@ int sockinfo_udp::mc_change_membership(const mc_pending_pram *p_mc_pram)
 
 	return 0;
 }
+
 
 void sockinfo_udp::original_os_setsockopt_helper( void* pram, int pram_size, int optname)
 {

--- a/src/vma/util/verbs_extra.cpp
+++ b/src/vma/util/verbs_extra.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001-2016 Mellanox Technologies, Ltd. All rights reserved.
+ * Copyright (c) 2001-2017 Mellanox Technologies, Ltd. All rights reserved.
  *
  * This software is available to you under a choice of one of two
  * licenses.  You may choose to be licensed under the terms of the GNU
@@ -259,3 +259,52 @@ int priv_ibv_query_qp_state(struct ibv_qp *qp)
 	BULLSEYE_EXCLUDE_BLOCK_END
 	return (ibv_qp_state)qp_attr.qp_state;
 }
+
+int priv_ibv_query_flow_tag_state(struct ibv_qp *qp, uint8_t port_num)
+{
+	NOT_IN_USE(qp);
+	NOT_IN_USE(port_num);
+	int res = -1;
+
+#ifdef DEFINED_IBV_EXP_FLOW_TAG
+
+	// Create
+	struct __attribute__ ((packed)) {
+		vma_ibv_flow_attr             attr;
+		vma_ibv_flow_spec_eth         eth;
+		vma_ibv_flow_spec_ipv4        ipv4;
+		vma_ibv_flow_spec_tcp_udp     tcp_udp;
+		vma_ibv_flow_spec_action_tag  flow_tag;
+	} ft_attr;
+
+	// Initialize
+	memset(&ft_attr, 0, sizeof(ft_attr));
+	ft_attr.attr.size = sizeof(ft_attr);
+	ft_attr.attr.num_of_specs = 4;
+	ft_attr.attr.type = VMA_IBV_FLOW_ATTR_NORMAL;
+	ft_attr.attr.priority = 1; // almost highest priority, 0 is used for 5-tuple later
+	ft_attr.attr.port = port_num;
+
+	// Set filters
+	uint8_t mac_0[ETH_ALEN] = { 0x00, 0x00, 0x00, 0x00, 0x00, 0x00 };
+	uint8_t mac_f[ETH_ALEN] = { 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF };
+
+	ibv_flow_spec_eth_set(&ft_attr.eth, mac_0 , 0); // L2 filter
+	memcpy(ft_attr.eth.val.src_mac, mac_f, ETH_ALEN);
+	memset(ft_attr.eth.mask.src_mac, FS_MASK_ON_8, ETH_ALEN);
+
+	ibv_flow_spec_ipv4_set(&ft_attr.ipv4, INADDR_LOOPBACK, INADDR_LOOPBACK); // L3 filter
+	ibv_flow_spec_tcp_udp_set(&ft_attr.tcp_udp, true, 0, 0); // L4 filter
+	ibv_flow_spec_flow_tag_set(&ft_attr.flow_tag, FLOW_TAG_MASK-1); // enable flow tag
+
+	// Create flow
+	vma_ibv_flow *ibv_flow = vma_ibv_create_flow(qp, &ft_attr.attr);
+	if (ibv_flow) {
+		res = 0;
+		vma_ibv_destroy_flow(ibv_flow);
+	}
+#endif // DEFINED_IBV_EXP_FLOW_TAG
+
+	return res;
+}
+

--- a/src/vma/util/verbs_extra.h
+++ b/src/vma/util/verbs_extra.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001-2016 Mellanox Technologies, Ltd. All rights reserved.
+ * Copyright (c) 2001-2017 Mellanox Technologies, Ltd. All rights reserved.
  *
  * This software is available to you under a choice of one of two
  * licenses.  You may choose to be licensed under the terms of the GNU
@@ -100,6 +100,9 @@ int priv_ibv_query_qp_state(struct ibv_qp *qp);
 #define FS_MASK_ON_16     (0xffff)
 #define FS_MASK_ON_32     (0xffffffff)
 
+#define FLOW_TAG_MASK     ((1 << 20) -1)
+int priv_ibv_query_flow_tag_state(struct ibv_qp *qp, uint8_t port_num);
+
 //old MLNX_OFED verbs (2.1 and older)
 #ifdef DEFINED_IBV_OLD_VERBS_MLX_OFED
 //ibv_query_device
@@ -171,6 +174,9 @@ typedef struct ibv_flow_spec_ib			vma_ibv_flow_spec_ib;
 typedef struct ibv_flow_spec_eth		vma_ibv_flow_spec_eth;
 typedef struct ibv_flow_spec_ipv4		vma_ibv_flow_spec_ipv4;
 typedef struct ibv_flow_spec_tcp_udp		vma_ibv_flow_spec_tcp_udp;
+#define vma_get_flow_tag			0
+typedef struct ibv_exp_flow_spec_action_tag_dummy {}	vma_ibv_flow_spec_action_tag;
+
 #else //new MLNX_OFED verbs (2.2 and newer)
 //ibv_query_device
 #define vma_ibv_query_device(context, attr)	ibv_exp_query_device(context, attr)
@@ -230,10 +236,9 @@ typedef int            vma_ibv_cq_init_attr;
 #define VMA_IBV_WC_WITH_TIMESTAMP              IBV_EXP_WC_WITH_TIMESTAMP
 #define vma_wc_timestamp(wc)			(wc).timestamp
 #else
-#define VMA_IBV_WC_WITH_TIMESTAMP              0
+#define VMA_IBV_WC_WITH_TIMESTAMP		0
 #define vma_wc_timestamp(wc)			0
 #endif
-
 
 //ibv_post_send
 #define VMA_IBV_SEND_SIGNALED			IBV_EXP_SEND_SIGNALED
@@ -277,6 +282,14 @@ typedef struct ibv_exp_flow_spec_ib		vma_ibv_flow_spec_ib;
 typedef struct ibv_exp_flow_spec_eth		vma_ibv_flow_spec_eth;
 typedef struct ibv_exp_flow_spec_ipv4		vma_ibv_flow_spec_ipv4;
 typedef struct ibv_exp_flow_spec_tcp_udp	vma_ibv_flow_spec_tcp_udp;
+//Flow tag
+#ifdef DEFINED_IBV_EXP_FLOW_TAG
+#define vma_get_flow_tag(wc)			ntohl((uint32_t)(wc->sop_drop_qpn))
+typedef struct ibv_exp_flow_spec_action_tag	vma_ibv_flow_spec_action_tag;
+#else
+#define vma_get_flow_tag(cqe)			0
+typedef struct ibv_exp_flow_spec_action_tag_dummy {}	vma_ibv_flow_spec_action_tag;
+#endif //DEFINED_IBV_EXP_FLOW_TAG
 #endif
 
 static inline void init_vma_ibv_cq_init_attr(vma_ibv_cq_init_attr* attr)
@@ -340,6 +353,18 @@ static inline void ibv_flow_spec_tcp_udp_set(vma_ibv_flow_spec_tcp_udp* tcp_udp,
 	if(tcp_udp->val.src_port) tcp_udp->mask.src_port = FS_MASK_ON_16;
 	tcp_udp->val.dst_port = dst_port;
 	if(tcp_udp->val.dst_port) tcp_udp->mask.dst_port = FS_MASK_ON_16;
+}
+
+static inline void ibv_flow_spec_flow_tag_set(vma_ibv_flow_spec_action_tag* flow_tag, uint32_t tag_id)
+{
+	NOT_IN_USE(tag_id);
+	if (flow_tag == NULL)
+		return;
+#ifdef DEFINED_IBV_EXP_FLOW_TAG
+	flow_tag->type = IBV_EXP_FLOW_SPEC_ACTION_TAG;
+	flow_tag->size = sizeof(vma_ibv_flow_spec_action_tag);
+	flow_tag->tag_id = tag_id;
+#endif //DEFINED_IBV_EXP_FLOW_TAG
 }
 
 #endif


### PR DESCRIPTION
Includes using socket FD as tag_id, dynamic probing for flow_tag support on port initialization, fast path for UC TCP/UPD to bypass most of packet checks and RFS dispatch which lead gain for ~15... >100 ns for ping-pong latency test by sockperf for multisocket/flow cases.

Signed-off-by: Oleg Kuporosov <olegk@mellanox.com>