### PR TITLE
issue: 968200 FlowTag support for vmapoll merged to master.

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -141,6 +141,7 @@ Example:
  VMA DETAILS: GRO max streams                32                         [VMA_GRO_STREAMS_MAX]
  VMA DETAILS: TCP 3T rules                   Disabled                   [VMA_TCP_3T_RULES]
  VMA DETAILS: ETH MC L2 only rules           Disabled                   [VMA_ETH_MC_L2_ONLY_RULES]
+ VMA DETAILS: MC Force FlowTag               Disabled                   [VMA_MC_FORCE_FLOWTAG]
  VMA DETAILS: Select Poll (usec)             100000                     [VMA_SELECT_POLL]
  VMA DETAILS: Select Poll OS Force           Disabled                   [VMA_SELECT_POLL_OS_FORCE]
  VMA DETAILS: Select Poll OS Ratio           10                         [VMA_SELECT_POLL_OS_RATIO]
@@ -546,6 +547,10 @@ connections.
 VMA_ETH_MC_L2_ONLY_RULES
 Use only L2 rules for Ethernet Multicast.
 All loopback traffic will be handled by VMA instead of OS.
+
+VMA_MC_FORCE_FLOWTAG
+Allows to use FlowTag acceleration for multicast flows by skip to check SO_REUSEADDR.
+Applicable if there are no other sockets opened for the same flow in system.
 
 VMA_SELECT_POLL
 The duration in micro-seconds (usec) in which to poll the hardware on Rx path before

--- a/configure.ac
+++ b/configure.ac
@@ -169,6 +169,22 @@ AS_IF([test "x$enable_exp_cq" == xyes],
 	[
 	  AC_MSG_RESULT([no])
 	])
+
+	AC_MSG_CHECKING([if IBV_EXP_FLOW_SPEC_ACTION_TAG is defined])
+	AC_TRY_LINK(
+	#include <infiniband/verbs_exp.h>
+	,
+	[
+	  int access = (int)IBV_EXP_FLOW_SPEC_ACTION_TAG;
+	  return access;
+	],
+	[
+	  AC_MSG_RESULT([yes])
+	  AC_DEFINE(DEFINED_IBV_EXP_FLOW_TAG, 1, [Define to 1 if IBV_EXP_FLOW_SPEC_ACTION_TAG is defined])
+	],
+	[
+	  AC_MSG_RESULT([no])
+	])
 )
 
 #

--- a/src/vma/dev/cq_mgr.cpp
+++ b/src/vma/dev/cq_mgr.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001-2016 Mellanox Technologies, Ltd. All rights reserved.
+ * Copyright (c) 2001-2017 Mellanox Technologies, Ltd. All rights reserved.
  *
  * This software is available to you under a choice of one of two
  * licenses.  You may choose to be licensed under the terms of the GNU
@@ -703,6 +703,7 @@ void cq_mgr::reclaim_recv_buffer_helper(mem_buf_desc_t* buff)
 #ifdef DEFINED_VMAPOLL				
 				temp->rx.vma_polled = false;
 #endif // DEFINED_VMAPOLL				
+				temp->rx.flow_tag_id = 0;
 				temp->rx.tcp.p_ip_h = NULL;
 				temp->rx.tcp.p_tcp_h = NULL;
 				temp->rx.udp.sw_timestamp.tv_nsec = 0;
@@ -742,6 +743,7 @@ void cq_mgr::vma_poll_reclaim_recv_buffer_helper(mem_buf_desc_t* buff)
 				temp->rx.tcp.gro = 0;
 				temp->rx.is_vma_thr = false;
 				temp->rx.vma_polled = false;
+				temp->rx.flow_tag_id = 0;
 				temp->rx.tcp.p_ip_h = NULL;
 				temp->rx.tcp.p_tcp_h = NULL;
 				temp->rx.udp.sw_timestamp.tv_nsec = 0;
@@ -780,6 +782,7 @@ int cq_mgr::vma_poll_reclaim_single_recv_buffer_helper(mem_buf_desc_t* buff)
 		buff->rx.tcp.gro = 0;
 		buff->rx.is_vma_thr = false;
 		buff->rx.vma_polled = false;
+		buff->rx.flow_tag_id = 0;
 		buff->rx.tcp.p_ip_h = NULL;
 		buff->rx.tcp.p_tcp_h = NULL;
 		buff->rx.udp.sw_timestamp.tv_nsec = 0;
@@ -858,6 +861,7 @@ int cq_mgr::vma_poll_and_process_element_rx(mem_buf_desc_t **p_desc_lst)
 		++m_n_wce_counter;
 		++m_qp->m_mlx5_hw_qp->rq.tail;
 		m_rx_hot_buff->sz_data = ntohl(cqe->byte_cnt);
+		m_rx_hot_buff->rx.flow_tag_id = vma_get_flow_tag(cqe);
 
 		if (unlikely(++m_qp_rec.debth >= (int)m_n_sysvar_rx_num_wr_to_post_recv)) {
 			compensate_qp_poll_success(m_rx_hot_buff);
@@ -927,6 +931,7 @@ int cq_mgr::poll_and_process_helper_rx(uint64_t* p_cq_poll_sn, void* pv_fd_ready
 			++m_n_wce_counter;
 			++m_qp->m_mlx5_hw_qp->rq.tail;
 			m_rx_hot_buff->sz_data = ntohl(cqe->byte_cnt);
+			m_rx_hot_buff->rx.flow_tag_id = vma_get_flow_tag(cqe);
 
 			if (unlikely(++m_qp_rec.debth >= (int)m_n_sysvar_rx_num_wr_to_post_recv)) {
 				compensate_qp_poll_success(m_rx_hot_buff);

--- a/src/vma/dev/ib_ctx_handler.cpp
+++ b/src/vma/dev/ib_ctx_handler.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001-2016 Mellanox Technologies, Ltd. All rights reserved.
+ * Copyright (c) 2001-2017 Mellanox Technologies, Ltd. All rights reserved.
  *
  * This software is available to you under a choice of one of two
  * licenses.  You may choose to be licensed under the terms of the GNU
@@ -55,8 +55,13 @@
 
 
 ib_ctx_handler::ib_ctx_handler(struct ibv_context* ctx, ts_conversion_mode_t ctx_time_converter_mode) :
-	m_removed(false), m_conf_attr_rx_num_wre(0), m_conf_attr_tx_num_to_signal(0),
-	m_conf_attr_tx_max_inline(0), m_conf_attr_tx_num_wre(0), ctx_time_converter(ctx, ctx_time_converter_mode)
+	m_flow_tag_enabled(false)
+	, m_removed(false)
+	, m_conf_attr_rx_num_wre(0)
+	, m_conf_attr_tx_num_to_signal(0)
+	, m_conf_attr_tx_max_inline(0)
+	, m_conf_attr_tx_num_wre(0)
+	, ctx_time_converter(ctx, ctx_time_converter_mode)
 {
 	memset(&m_ibv_port_attr, 0, sizeof(m_ibv_port_attr));
 	m_p_ibv_context = ctx;
@@ -120,6 +125,11 @@ ibv_mr* ib_ctx_handler::mem_reg(void *addr, size_t length, uint64_t access)
 #else
 	return ibv_reg_mr(m_p_ibv_pd, addr, length, access);
 #endif
+}
+
+void ib_ctx_handler::set_flow_tag_capability(bool flow_tag_capability)
+{
+	m_flow_tag_enabled = flow_tag_capability;
 }
 
 bool ib_ctx_handler::update_port_attr(int port_num)

--- a/src/vma/dev/ib_ctx_handler.h
+++ b/src/vma/dev/ib_ctx_handler.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001-2016 Mellanox Technologies, Ltd. All rights reserved.
+ * Copyright (c) 2001-2017 Mellanox Technologies, Ltd. All rights reserved.
  *
  * This software is available to you under a choice of one of two
  * licenses.  You may choose to be licensed under the terms of the GNU
@@ -62,6 +62,8 @@ public:
 	virtual void            handle_event_ibverbs_cb(void *ev_data, void *ctx);
 	void                    handle_event_DEVICE_FATAL();
 	ts_conversion_mode_t    get_ctx_time_converter_status();
+	void                    set_flow_tag_capability(bool flow_tag_capability); 
+	bool                    get_flow_tag_capability() { return m_flow_tag_enabled;} // m_flow_tag_capability
 
 	inline void convert_hw_time_to_system_time(uint64_t hwtime, struct timespec* systime) { ctx_time_converter.convert_hw_time_to_system_time(hwtime, systime); }
 
@@ -71,6 +73,7 @@ private:
 	ibv_device*             m_p_ibv_device; // HCA handle
 	vma_ibv_device_attr     m_ibv_device_attr;
 	ibv_pd*                 m_p_ibv_pd;
+	bool                    m_flow_tag_enabled;
 	bool                    m_removed;
 
 	bool                    update_port_attr(int port_num);

--- a/src/vma/dev/net_device_table_mgr.cpp
+++ b/src/vma/dev/net_device_table_mgr.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001-2016 Mellanox Technologies, Ltd. All rights reserved.
+ * Copyright (c) 2001-2017 Mellanox Technologies, Ltd. All rights reserved.
  *
  * This software is available to you under a choice of one of two
  * licenses.  You may choose to be licensed under the terms of the GNU
@@ -235,9 +235,9 @@ int net_device_table_mgr::map_net_devices()
 		get_base_interface_name((const char*)(ifa->ifa_name), base_ifname, sizeof(base_ifname));
 		if (check_device_exist(base_ifname, BOND_DEVICE_FILE)) {
 			// this is a bond interface (or a vlan/alias over bond), find the slaves
-			valid = verify_bond_ipoib_or_eth_qp_creation(ifa);
+			valid = verify_bond_ipoib_or_eth_qp_creation(ifa, cma_id->port_num);
 		} else {
-			valid = verify_ipoib_or_eth_qp_creation(ifa->ifa_name, ifa);
+			valid = verify_ipoib_or_eth_qp_creation(ifa->ifa_name, ifa, cma_id->port_num);
 		}
 		if (!valid) {
 			// Close the cma_id which will not be offload
@@ -288,7 +288,7 @@ int net_device_table_mgr::map_net_devices()
 	return 0;
 }
 
-bool net_device_table_mgr::verify_bond_ipoib_or_eth_qp_creation(struct ifaddrs * ifa)
+bool net_device_table_mgr::verify_bond_ipoib_or_eth_qp_creation(struct ifaddrs * ifa, uint8_t port_num)
 {
 	char base_ifname[IFNAMSIZ];
 	get_base_interface_name((const char*)(ifa->ifa_name), base_ifname, sizeof(base_ifname));
@@ -307,7 +307,7 @@ bool net_device_table_mgr::verify_bond_ipoib_or_eth_qp_creation(struct ifaddrs *
 	{
 		char* p = strchr(slave_name, '\n');
 		if (p) *p = '\0'; // Remove the tailing 'new line" char
-		if (!verify_ipoib_or_eth_qp_creation(slave_name, ifa)) {
+		if (!verify_ipoib_or_eth_qp_creation(slave_name, ifa, port_num)) {
 			//check all slaves but print only once for bond
 			bond_ok =  false;
 		}
@@ -323,7 +323,7 @@ bool net_device_table_mgr::verify_bond_ipoib_or_eth_qp_creation(struct ifaddrs *
 }
 
 //interface name can be slave while ifa struct can describe bond
-bool net_device_table_mgr::verify_ipoib_or_eth_qp_creation(const char* interface_name, struct ifaddrs * ifa)
+bool net_device_table_mgr::verify_ipoib_or_eth_qp_creation(const char* interface_name, struct ifaddrs * ifa, uint8_t port_num)
 {
 	int iftype = get_iftype_from_ifname(interface_name);
 	if (iftype == ARPHRD_INFINIBAND) {
@@ -331,7 +331,7 @@ bool net_device_table_mgr::verify_ipoib_or_eth_qp_creation(const char* interface
 			return true;
 		}
 	} else {
-		if (verify_eth_qp_creation(interface_name)) {
+		if (verify_eth_qp_creation(interface_name, port_num)) {
 			return true;
 		}
 	}
@@ -383,7 +383,7 @@ bool net_device_table_mgr::verify_ipoib_mode(struct ifaddrs* ifa)
 }
 
 //ifname should point to a physical device
-bool net_device_table_mgr::verify_eth_qp_creation(const char* ifname)
+bool net_device_table_mgr::verify_eth_qp_creation(const char* ifname, uint8_t port_num)
 {
 	int num_devices = 0;
 	bool success = false;
@@ -438,6 +438,12 @@ bool net_device_table_mgr::verify_eth_qp_creation(const char* ifname)
 			qp = ibv_create_qp(p_ib_ctx->get_ibv_pd(), &qp_init_attr);
 			if (qp) {
 				success = true;
+
+				if (!priv_ibv_query_flow_tag_supported(qp, port_num)) {
+					p_ib_ctx->set_flow_tag_capability(true);
+				}
+				ndtm_logdbg("verified interface %s for flow tag capabilities : %s", ifname, p_ib_ctx->get_flow_tag_capability() ? "enabled" : "disabled");
+
 			} else {
 				ndtm_logdbg("QP creation failed on interface %s (errno=%d %m), Traffic will not be offloaded \n", ifname, errno);
 				success = false;

--- a/src/vma/dev/net_device_table_mgr.h
+++ b/src/vma/dev/net_device_table_mgr.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001-2016 Mellanox Technologies, Ltd. All rights reserved.
+ * Copyright (c) 2001-2017 Mellanox Technologies, Ltd. All rights reserved.
  *
  * This software is available to you under a choice of one of two
  * licenses.  You may choose to be licensed under the terms of the GNU
@@ -134,9 +134,9 @@ private:
 
 	bool 			verify_ipoib_mode(struct ifaddrs* ifa);
 	bool			verify_mlx4_ib_device(const char* ifname);
-	bool 			verify_eth_qp_creation(const char* ifname);
-	bool 			verify_bond_ipoib_or_eth_qp_creation(struct ifaddrs * ifa);
-	bool 			verify_ipoib_or_eth_qp_creation(const char* interface_name, struct ifaddrs * ifa);
+	bool 			verify_eth_qp_creation(const char* ifname, uint8_t port_num);
+	bool 			verify_bond_ipoib_or_eth_qp_creation(struct ifaddrs * ifa, uint8_t port_num);
+	bool 			verify_ipoib_or_eth_qp_creation(const char* interface_name, struct ifaddrs * ifa, uint8_t port_num);
 	bool 			verify_enable_ipoib(const char* ifname);
 };
 

--- a/src/vma/dev/rfs.cpp
+++ b/src/vma/dev/rfs.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001-2016 Mellanox Technologies, Ltd. All rights reserved.
+ * Copyright (c) 2001-2017 Mellanox Technologies, Ltd. All rights reserved.
  *
  * This software is available to you under a choice of one of two
  * licenses.  You may choose to be licensed under the terms of the GNU
@@ -101,10 +101,10 @@ inline void rfs::prepare_filter_detach(int& filter_counter)
 	}
 }
 
-rfs::rfs(flow_tuple *flow_spec_5t, ring_simple *p_ring, rfs_rule_filter* rule_filter /*= NULL*/):
+rfs::rfs(flow_tuple *flow_spec_5t, ring_simple *p_ring, rfs_rule_filter* rule_filter /*= NULL*/, uint32_t flow_tag_id /*=0*/):
 	m_flow_tuple(rule_filter ? rule_filter->m_flow_tuple : *flow_spec_5t), m_p_ring(p_ring),
 	m_p_rule_filter(rule_filter), m_n_sinks_list_entries(0), m_n_sinks_list_max_length(RFS_SINKS_LIST_DEFAULT_LEN),
-	m_b_tmp_is_attached(false)
+	m_flow_tag_id(flow_tag_id), m_b_tmp_is_attached(false)
 {
 	m_sinks_list = new pkt_rcvr_sink*[m_n_sinks_list_max_length];
 
@@ -269,13 +269,14 @@ bool rfs::create_ibv_flow()
 		attach_flow_data_t* iter = m_attach_flow_data_vector[i];
 		iter->ibv_flow = vma_ibv_create_flow(iter->p_qp_mgr->get_ibv_qp(), &(iter->ibv_flow_attr));
 		if (!iter->ibv_flow) {
-			rfs_logerr("Create of QP flow ID failed with flow %s (errno=%d - %m)", m_flow_tuple.to_str(), errno); //TODO ALEXR - Add info about QP, spec, priority into log msg
+			rfs_logerr("Create of QP flow ID (tag: %d) failed with flow %s (errno=%d - %m)",
+				   m_flow_tag_id, m_flow_tuple.to_str(), errno); //TODO ALEXR - Add info about QP, spec, priority into log msg
 			return false;
 		}
 	}
 
 	m_b_tmp_is_attached = true;
-	rfs_logdbg("ibv_create_flow succeeded with flow %s", m_flow_tuple.to_str());
+	rfs_logdbg("ibv_create_flow succeeded with flow %s, tag_id: %d", m_flow_tuple.to_str(), m_flow_tag_id);
 	return true;
 }
 

--- a/src/vma/dev/rfs.h
+++ b/src/vma/dev/rfs.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001-2016 Mellanox Technologies, Ltd. All rights reserved.
+ * Copyright (c) 2001-2017 Mellanox Technologies, Ltd. All rights reserved.
  *
  * This software is available to you under a choice of one of two
  * licenses.  You may choose to be licensed under the terms of the GNU
@@ -117,14 +117,19 @@ typedef struct __attribute__ ((packed)) ibv_flow_attr_eth_ipv4_tcp_udp {
 	vma_ibv_flow_spec_eth         eth;
 	vma_ibv_flow_spec_ipv4        ipv4;
 	vma_ibv_flow_spec_tcp_udp     tcp_udp;
+	vma_ibv_flow_spec_action_tag  flow_tag; // must be the last as struct can be used without it
 
 	ibv_flow_attr_eth_ipv4_tcp_udp(uint8_t port) {
 		memset(this, 0, sizeof(*this));
-		attr.size = sizeof(struct ibv_flow_attr_eth_ipv4_tcp_udp);
+		attr.size = sizeof(struct ibv_flow_attr_eth_ipv4_tcp_udp) - sizeof(flow_tag);
 		attr.num_of_specs = 3;
 		attr.type = VMA_IBV_FLOW_ATTR_NORMAL;
 		attr.priority = 1; // almost highest priority, 0 is used for 5-tuple later
 		attr.port = port;
+	}
+	inline void add_flow_tag_spec(void) {
+		attr.num_of_specs++;
+		attr.size += sizeof(flow_tag);
 	}
 } ibv_flow_attr_eth_ipv4_tcp_udp;
 
@@ -191,7 +196,8 @@ public:
 class rfs
 {
 public:
-	rfs(flow_tuple *flow_spec_5t, ring_simple *p_ring, rfs_rule_filter* rule_filter = NULL);
+	rfs(flow_tuple *flow_spec_5t, ring_simple *p_ring,
+	    rfs_rule_filter* rule_filter = NULL, uint32_t flow_tag_id = 0);
 	virtual ~rfs();
 
 	/**
@@ -210,12 +216,13 @@ public:
 
 protected:
 	flow_tuple		m_flow_tuple;
-	ring_simple*			m_p_ring;
+	ring_simple*		m_p_ring;
 	rfs_rule_filter*	m_p_rule_filter;
 	attach_flow_data_vector_t m_attach_flow_data_vector;
 	pkt_rcvr_sink**		m_sinks_list;
 	uint32_t 		m_n_sinks_list_entries; // Number of actual sinks in the array (we shrink the array if a sink is removed)
 	uint32_t		m_n_sinks_list_max_length;
+	uint32_t		m_flow_tag_id; // Associated with this rule, set by attach_flow()
 	bool 			m_b_tmp_is_attached; // Only temporary, while ibcm calls attach_flow with no sinks...
 
 	bool 			create_ibv_flow(); // Attach flow to all qps

--- a/src/vma/dev/rfs_mc.cpp
+++ b/src/vma/dev/rfs_mc.cpp
@@ -39,7 +39,8 @@
 #define MODULE_NAME 		"rfs_mc"
 
 
-rfs_mc::rfs_mc(flow_tuple *flow_spec_5t, ring_simple *p_ring, rfs_rule_filter* rule_filter /*= NULL*/) throw (vma_exception): rfs (flow_spec_5t, p_ring, rule_filter)
+rfs_mc::rfs_mc(flow_tuple *flow_spec_5t, ring_simple *p_ring, rfs_rule_filter* rule_filter /*= NULL*/, int flow_tag_id /*=0*/) throw (vma_exception):
+	rfs (flow_spec_5t, p_ring, rule_filter, flow_tag_id)
 {
 	BULLSEYE_EXCLUDE_BLOCK_START
 	if (!m_flow_tuple.is_udp_mc()) {
@@ -109,6 +110,13 @@ bool rfs_mc::prepare_flow_spec()
 						(m_flow_tuple.get_protocol() == PROTO_TCP),
 						m_flow_tuple.get_dst_port(),
 						m_flow_tuple.get_src_port());
+
+			if (m_flow_tag_id) { // Will not attach flow_tag spec to rule for tag_id==0
+				ibv_flow_spec_flow_tag_set(&attach_flow_data_eth->ibv_flow_attr.flow_tag, m_flow_tag_id);
+				attach_flow_data_eth->ibv_flow_attr.add_flow_tag_spec();
+				rfs_logdbg("Adding flow_tag spec to MC rule, num_of_specs: %d flow_tag_id: %d",
+					   attach_flow_data_eth->ibv_flow_attr.attr.num_of_specs, m_flow_tag_id);
+			}
 
 			p_attach_flow_data = (attach_flow_data_t*)attach_flow_data_eth;
 			break;

--- a/src/vma/dev/rfs_mc.h
+++ b/src/vma/dev/rfs_mc.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001-2016 Mellanox Technologies, Ltd. All rights reserved.
+ * Copyright (c) 2001-2017 Mellanox Technologies, Ltd. All rights reserved.
  *
  * This software is available to you under a choice of one of two
  * licenses.  You may choose to be licensed under the terms of the GNU
@@ -49,7 +49,7 @@
 class rfs_mc : public rfs
 {
 public:
-	rfs_mc(flow_tuple *flow_spec_5t, ring_simple *p_ring, rfs_rule_filter* rule_filter = NULL) throw (vma_exception);
+	rfs_mc(flow_tuple *flow_spec_5t, ring_simple *p_ring, rfs_rule_filter* rule_filter = NULL, int32_t flow_tag_id = 0) throw (vma_exception);
 
 	virtual bool rx_dispatch_packet(mem_buf_desc_t* p_rx_wc_buf_desc, void* pv_fd_ready_array);
 

--- a/src/vma/dev/rfs_uc.cpp
+++ b/src/vma/dev/rfs_uc.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001-2016 Mellanox Technologies, Ltd. All rights reserved.
+ * Copyright (c) 2001-2017 Mellanox Technologies, Ltd. All rights reserved.
  *
  * This software is available to you under a choice of one of two
  * licenses.  You may choose to be licensed under the terms of the GNU
@@ -40,7 +40,8 @@
 #define MODULE_NAME 		"rfs_uc"
 
 
-rfs_uc::rfs_uc(flow_tuple *flow_spec_5t, ring_simple *p_ring, rfs_rule_filter* rule_filter /*= NULL*/) : rfs(flow_spec_5t, p_ring, rule_filter)
+rfs_uc::rfs_uc(flow_tuple *flow_spec_5t, ring_simple *p_ring, rfs_rule_filter* rule_filter, uint32_t flow_tag_id) :
+	rfs(flow_spec_5t, p_ring, rule_filter, flow_tag_id)
 {
 	BULLSEYE_EXCLUDE_BLOCK_START
 	if (m_flow_tuple.is_udp_mc()) {
@@ -67,6 +68,7 @@ bool rfs_uc::prepare_flow_spec()
 	attach_flow_data_eth_ipv4_tcp_udp_t*   attach_flow_data_eth = NULL;
 	vma_ibv_flow_spec_ipv4*             p_ipv4 = NULL;
 	vma_ibv_flow_spec_tcp_udp*          p_tcp_udp = NULL;
+	vma_ibv_flow_spec_action_tag*       p_flow_tag = NULL;
 
 	switch (type) {
 		case VMA_TRANSPORT_IB:
@@ -84,12 +86,11 @@ bool rfs_uc::prepare_flow_spec()
 			attach_flow_data_eth = new attach_flow_data_eth_ipv4_tcp_udp_t(m_p_ring->m_p_qp_mgr);
 
 			ibv_flow_spec_eth_set(&(attach_flow_data_eth->ibv_flow_attr.eth),
-					m_p_ring->m_p_l2_addr->get_address(),
+						m_p_ring->m_p_l2_addr->get_address(),
 						htons(m_p_ring->m_p_qp_mgr->get_partiton()));
-
-
 			p_ipv4 = &(attach_flow_data_eth->ibv_flow_attr.ipv4);
 			p_tcp_udp = &(attach_flow_data_eth->ibv_flow_attr.tcp_udp);
+			p_flow_tag = &(attach_flow_data_eth->ibv_flow_attr.flow_tag);
 			p_attach_flow_data = (attach_flow_data_t*)attach_flow_data_eth;
 			break;
 		BULLSEYE_EXCLUDE_BLOCK_START
@@ -112,6 +113,14 @@ bool rfs_uc::prepare_flow_spec()
 		// set priority of 5-tuple to be higher than 3-tuple
 		// to make sure 5-tuple have higher priority on ConnectX-4
 		p_attach_flow_data->ibv_flow_attr.priority = 0;
+	}
+
+	if (m_flow_tag_id && attach_flow_data_eth) { // Will not attach flow_tag spec to rule for tag_id==0
+		ibv_flow_spec_flow_tag_set(p_flow_tag, m_flow_tag_id);
+		attach_flow_data_eth->ibv_flow_attr.add_flow_tag_spec();
+                rfs_logdbg("Adding flow_tag spec to rule, num_of_specs: %d flow_tag_id: %d",
+			   attach_flow_data_eth->ibv_flow_attr.attr.num_of_specs,
+			   m_flow_tag_id);
 	}
 
 	m_attach_flow_data_vector.push_back(p_attach_flow_data);
@@ -147,7 +156,6 @@ bool rfs_uc::rx_dispatch_packet(mem_buf_desc_t* p_rx_wc_buf_desc, void* pv_fd_re
 			}
 		}
 	}
-
 	// Reuse this data buffer & mem_buf_desc
 	return false;
 }

--- a/src/vma/dev/rfs_uc.h
+++ b/src/vma/dev/rfs_uc.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001-2016 Mellanox Technologies, Ltd. All rights reserved.
+ * Copyright (c) 2001-2017 Mellanox Technologies, Ltd. All rights reserved.
  *
  * This software is available to you under a choice of one of two
  * licenses.  You may choose to be licensed under the terms of the GNU
@@ -49,7 +49,8 @@
 class rfs_uc : public rfs
 {
 public:
-	rfs_uc(flow_tuple *flow_spec_5t, ring_simple *p_ring, rfs_rule_filter* rule_filter = NULL);
+	rfs_uc(flow_tuple *flow_spec_5t, ring_simple *p_ring,
+	       rfs_rule_filter* rule_filter = NULL, uint32_t flow_tag_id = 0);
 
 	virtual bool rx_dispatch_packet(mem_buf_desc_t* p_rx_wc_buf_desc, void* pv_fd_ready_array);
 

--- a/src/vma/dev/rfs_uc_tcp_gro.cpp
+++ b/src/vma/dev/rfs_uc_tcp_gro.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001-2016 Mellanox Technologies, Ltd. All rights reserved.
+ * Copyright (c) 2001-2017 Mellanox Technologies, Ltd. All rights reserved.
  *
  * This software is available to you under a choice of one of two
  * licenses.  You may choose to be licensed under the terms of the GNU
@@ -42,7 +42,9 @@
 #define TCP_H_LEN_TIMESTAMP 8
 
 
-rfs_uc_tcp_gro::rfs_uc_tcp_gro(flow_tuple *flow_spec_5t, ring_simple *p_ring, rfs_rule_filter* rule_filter /*= NULL*/) : rfs_uc(flow_spec_5t, p_ring, rule_filter), m_p_gro_mgr(&(p_ring->m_gro_mgr)), m_b_active(false), m_b_reserved(false)
+rfs_uc_tcp_gro::rfs_uc_tcp_gro(flow_tuple *flow_spec_5t, ring_simple *p_ring, rfs_rule_filter* rule_filter, uint32_t flow_tag_id) :
+	rfs_uc(flow_spec_5t, p_ring, rule_filter, flow_tag_id),
+	m_p_gro_mgr(&(p_ring->m_gro_mgr)), m_b_active(false), m_b_reserved(false)
 {
 	m_n_buf_max = m_p_gro_mgr->get_buf_max();
 	m_n_byte_max = m_p_gro_mgr->get_byte_max() - p_ring->get_mtu(); 

--- a/src/vma/dev/rfs_uc_tcp_gro.h
+++ b/src/vma/dev/rfs_uc_tcp_gro.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001-2016 Mellanox Technologies, Ltd. All rights reserved.
+ * Copyright (c) 2001-2017 Mellanox Technologies, Ltd. All rights reserved.
  *
  * This software is available to you under a choice of one of two
  * licenses.  You may choose to be licensed under the terms of the GNU
@@ -64,7 +64,8 @@ class gro_mgr;
 class rfs_uc_tcp_gro : public rfs_uc
 {
 public:
-	rfs_uc_tcp_gro(flow_tuple *flow_spec_5t, ring_simple *p_ring,  rfs_rule_filter* rule_filter = NULL);
+	rfs_uc_tcp_gro(flow_tuple *flow_spec_5t, ring_simple *p_ring,
+		       rfs_rule_filter* rule_filter = NULL, uint32_t flow_tag_id = 0);
 
 	virtual bool rx_dispatch_packet(mem_buf_desc_t* p_rx_wc_buf_desc, void* pv_fd_ready_array);
 

--- a/src/vma/dev/ring_simple.cpp
+++ b/src/vma/dev/ring_simple.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001-2016 Mellanox Technologies, Ltd. All rights reserved.
+ * Copyright (c) 2001-2017 Mellanox Technologies, Ltd. All rights reserved.
  *
  * This software is available to you under a choice of one of two
  * licenses.  You may choose to be licensed under the terms of the GNU
@@ -42,6 +42,7 @@
 #include "vma/proto/ip_frag.h"
 #include "vma/proto/L2_address.h"
 #include "vma/proto/igmp_mgr.h"
+#include "vma/sock/pkt_rcvr_sink.h"
 #include "vma/sock/sockinfo_tcp.h"
 #include "vma/sock/fd_collection.h"
 #include "vma/dev/rfs_mc.h"
@@ -57,12 +58,6 @@
 
 #define ALIGN_WR_DOWN(_num_wr_) 		(max(32, ((_num_wr_      ) & ~(0xf))))
 
-#ifdef DEFINED_VMAPOLL	
-// Used to single that we have a single 5tuple TCP connected socket, we can improve fast path
-// TODO: We should be able to show similar behaviour for UDP
-// REVIEW: it seems p_rfs_single_tcp is not uded in code. AlexV: can it be removed?
-rfs *p_rfs_single_tcp = NULL;
-#endif // DEFINED_VMAPOLL	
 
 /**/
 /** inlining functions can only help if they are implemented before their usage **/
@@ -106,9 +101,11 @@ ring_simple::ring_simple(in_addr_t local_if, uint16_t partition_sn, int count, t
 	m_p_rx_comp_event_channel(NULL), m_p_tx_comp_event_channel(NULL), m_p_l2_addr(NULL), m_p_ring_stat(NULL),
 	m_local_if(local_if), m_transport_type(transport_type), m_b_sysvar_eth_mc_l2_only_rules(safe_mce_sys().eth_mc_l2_only_rules)
 #ifdef DEFINED_VMAPOLL		
-	, m_rx_buffs_rdy_for_free_head(NULL), m_rx_buffs_rdy_for_free_tail(NULL) 
+	, m_rx_buffs_rdy_for_free_head(NULL)
+	, m_rx_buffs_rdy_for_free_tail(NULL) 
 #endif // DEFINED_VMAPOLL		
-	{
+	, m_flow_tag_enabled(false)
+{
 
 	if (count != 1)
 		ring_logpanic("Error creating simple ring with more than 1 resource");
@@ -240,6 +237,8 @@ void ring_simple::create_resources(ring_resource_creation_info_t* p_ring_info, b
 
 	memset(&m_cq_moderation_info, 0, sizeof(m_cq_moderation_info));
 
+	m_flow_tag_enabled = p_ring_info->p_ib_ctx->get_flow_tag_capability();
+
 	m_p_rx_comp_event_channel = ibv_create_comp_channel(p_ring_info->p_ib_ctx->get_ibv_context()); // ODED TODO: Adjust the ibv_context to be the exact one in case of different devices
 	BULLSEYE_EXCLUDE_BLOCK_START
 	if (m_p_rx_comp_event_channel == NULL) {
@@ -314,10 +313,39 @@ void ring_simple::restart(ring_resource_creation_info_t* p_ring_info)
 
 bool ring_simple::attach_flow(flow_tuple& flow_spec_5t, pkt_rcvr_sink *sink)
 {
-	rfs *p_rfs;
-	rfs *p_tmp_rfs = NULL;
+	rfs* p_rfs;
+	rfs* p_tmp_rfs = NULL;
+	sockinfo* si = static_cast<sockinfo*> (sink);
+	uint32_t flow_tag_id = 0;
 
 	ring_logdbg("flow: %s, with sink (%p)", flow_spec_5t.to_str(), sink);
+
+	if( si == NULL )
+		return false;
+
+	if (m_flow_tag_enabled) {
+#ifdef DEFINED_VMAPOLL
+		// sockfd=0 is valid too but flow_tag_id=0 is invalid, increment it
+		// effectively limiting our sockfd range to FLOW_TAG_MASK-1
+		int flow_tag_id_candidate = si->get_fd() + 1;
+#else
+		int flow_tag_id_candidate = 0;
+#endif
+		if (flow_tag_id_candidate > 0) {
+			flow_tag_id = flow_tag_id_candidate & FLOW_TAG_MASK;
+			if ((uint32_t)flow_tag_id_candidate != flow_tag_id) {
+				// tag_id is out of the range by mask, will not use it
+				flow_tag_id = 0;
+				ring_logdbg("flow_tag disabled as tag_id: %d is out of mask (%x) range!",
+					    flow_tag_id, FLOW_TAG_MASK);
+			}
+			ring_logdbg("sock_fd:%d enabled:%d with id:%d",
+				    flow_tag_id_candidate-1, m_flow_tag_enabled, flow_tag_id);
+		} else {
+			// 0 - means FT should not be used
+			ring_logdbg("flow_tag disabled as flow_tag_id_candidate:%d", flow_tag_id_candidate);
+		}
+	}
 
 	/*
 	 * //auto_unlocker lock(m_lock_ring_rx);
@@ -333,10 +361,11 @@ bool ring_simple::attach_flow(flow_tuple& flow_spec_5t, pkt_rcvr_sink *sink)
 	if (flow_spec_5t.is_udp_uc()) {
 		flow_spec_udp_uc_key_t key_udp_uc(flow_spec_5t.get_dst_port());
 		p_rfs = m_flow_udp_uc_map.get(key_udp_uc, NULL);
-		if (p_rfs == NULL) {		// It means that no rfs object exists so I need to create a new one and insert it to the flow map
+		if (p_rfs == NULL) {
+			// No rfs object exists so a new one must be created and inserted in the flow map
 			m_lock_ring_rx.unlock();
 			try {
-				p_tmp_rfs = new rfs_uc(&flow_spec_5t, this);
+				p_tmp_rfs = new rfs_uc(&flow_spec_5t, this, NULL, flow_tag_id);
 			} catch(vma_exception& e) {
 				ring_logerr("%s", e.message);
 				return false;
@@ -358,6 +387,8 @@ bool ring_simple::attach_flow(flow_tuple& flow_spec_5t, pkt_rcvr_sink *sink)
 		}
 	} else if (flow_spec_5t.is_udp_mc()) {
 		flow_spec_udp_mc_key_t key_udp_mc(flow_spec_5t.get_dst_ip(), flow_spec_5t.get_dst_port());
+		flow_tag_id = 0; // MC so far can't be handled by flow_tag due issues in FW
+
 		// For IB MC flow, the port is zeroed in the ibv_flow_spec when calling to ibv_flow_spec().
 		// It means that for every MC group, even if we have sockets with different ports - only one rule in the HW.
 		// So the hash map below keeps track of the number of sockets per rule so we know when to call ibv_attach and ibv_detach
@@ -417,10 +448,10 @@ bool ring_simple::attach_flow(flow_tuple& flow_spec_5t, pkt_rcvr_sink *sink)
 				tcp_dst_port_filter = new rfs_rule_filter(m_tcp_dst_port_attach_map, key_tcp.dst_port, tcp_3t_only);
 			}
 			if(safe_mce_sys().gro_streams_max && flow_spec_5t.is_5_tuple()) {
-				p_tmp_rfs = new rfs_uc_tcp_gro(&flow_spec_5t, this, tcp_dst_port_filter);
+				p_tmp_rfs = new rfs_uc_tcp_gro(&flow_spec_5t, this, tcp_dst_port_filter, flow_tag_id);
 			} else {
 				try {
-					p_tmp_rfs = new rfs_uc(&flow_spec_5t, this, tcp_dst_port_filter);
+					p_tmp_rfs = new rfs_uc(&flow_spec_5t, this, tcp_dst_port_filter, flow_tag_id);
 				} catch(vma_exception& e) {
 					ring_logerr("%s", e.message);
 					return false;
@@ -450,21 +481,27 @@ bool ring_simple::attach_flow(flow_tuple& flow_spec_5t, pkt_rcvr_sink *sink)
 	BULLSEYE_EXCLUDE_BLOCK_END
 
 	bool ret = p_rfs->attach_flow(sink);
-#ifdef DEFINED_VMAPOLL	
-// REVIEW: can p_rfs_single_tcp be removed?
-	if (flow_spec_5t.is_tcp() && !flow_spec_5t.is_3_tuple()) {
-		// save the single 5tuple TCP connected socket for improved fast path
-		//p_rfs_single_tcp = p_rfs;
-		ring_logdbg("update p_rfs_single_tcp=%p", p_rfs_single_tcp);
+	if (ret) {
+		if (m_flow_tag_enabled && flow_tag_id ) {
+			// A flow with FlowTag was attached succesfully, check stored rfs for fast path be tag_id
+			si->set_flow_tag(flow_tag_id);
+			ring_logdbg("flow_tag: %d registration is done!", flow_tag_id);
+		}
+		if (flow_spec_5t.is_tcp() && !flow_spec_5t.is_3_tuple()) {
+			// save the single 5tuple TCP connected socket for improved fast path
+			si->set_tcp_flow_is_5t();
+			ring_logdbg("single 5T TCP update m_tcp_flow_is_5t m_flow_tag_enabled: %d", m_flow_tag_enabled);
+		}
+	} else {
+		ring_logerr("attach_flow=%d failed, flow_tag %d should be disabled!", ret, flow_tag_id);
 	}
-#endif // DEFINED_VMAPOLL	
 	m_lock_ring_rx.unlock();
 	return ret;
 }
 
 bool ring_simple::detach_flow(flow_tuple& flow_spec_5t, pkt_rcvr_sink* sink)
 {
-	rfs *p_rfs = NULL;
+	rfs* p_rfs = NULL;
 
 	ring_logdbg("flow: %s, with sink (%p)", flow_spec_5t.to_str(), sink);
 
@@ -542,14 +579,6 @@ bool ring_simple::detach_flow(flow_tuple& flow_spec_5t, pkt_rcvr_sink* sink)
 		}
 		BULLSEYE_EXCLUDE_BLOCK_END
 
-#ifdef DEFINED_VMAPOLL
-// REVIEW: can p_rfs_single_tcp be removed?
-		if (p_rfs_single_tcp == p_rfs) {
-			// clear the single 5tuple TCP connected socket for improved fast path
-			p_rfs_single_tcp = NULL;
-			ring_logdbg("update p_rfs_single_tcp=%p", p_rfs_single_tcp);
-		}
-#endif // DEFINED_VMAPOLL
 		p_rfs->detach_flow(sink);
 		if(!keep_in_map){
 			m_tcp_dst_port_attach_map.erase(m_tcp_dst_port_attach_map.find(key_tcp.dst_port));
@@ -627,7 +656,7 @@ void ring::print_flow_to_rfs_udp_uc_map(flow_spec_udp_uc_map_t *p_flow_map)
 	}
 }
 
-void ring::print_flow_to_rfs_tcp_map(flow_spec_tcp_map_t *p_flow_map)
+void ring_simple::print_flow_to_rfs_tcp_map(flow_spec_tcp_map_t *p_flow_map)
 {
 	rfs *curr_rfs;
 	flow_spec_tcp_key_t map_key;
@@ -639,7 +668,7 @@ void ring::print_flow_to_rfs_tcp_map(flow_spec_tcp_map_t *p_flow_map)
 
 	itr = p_flow_map->begin();
 	if (!(itr != p_flow_map->end())) {
-		ring_logdbg("flow_spec_udp_uc_map is EMPTY!\n");
+		ring_logdbg("flow_spec_tcp_map is EMPTY!\n");
 	} else {
 		for (itr = p_flow_map->begin(); itr != p_flow_map->end(); ++itr) {
 			curr_rfs = itr->second;
@@ -648,7 +677,9 @@ void ring::print_flow_to_rfs_tcp_map(flow_spec_tcp_map_t *p_flow_map)
 				ring_logdbg("######### key: port = %d, rfs: NULL", ntohs(map_key.dst_port));
 			}
 			else {
-				ring_logdbg("######### key: src_ip:%d.%d.%d.%d, dst_port=%d, src_port=%d, rfs: num of sinks = %d", NIPQUAD(map_key.src_ip), ntohs(map_key.dst_port), ntohs(map_key.src_port), curr_rfs->get_num_of_sinks());
+				ring_logdbg("######### key: src=%d.%d.%d.%d:%d, dst_port=%d rfs: num of sinks = %d",
+					NIPQUAD(map_key.src_ip), ntohs(map_key.src_port),
+					ntohs(map_key.dst_port), curr_rfs->get_num_of_sinks());
 			}
 		}
 	}
@@ -673,10 +704,34 @@ const char* priv_igmp_type_tostr(uint8_t igmptype)
 }
 
 #ifdef DEFINED_VMAPOLL
+// calling sockinfo callback with RFS bypass
+static inline bool check_rx_packet(sockinfo *si, mem_buf_desc_t* p_rx_wc_buf_desc)
+{
+	// Dispatching: Notify new packet to the FIRST registered receiver ONLY
+	p_rx_wc_buf_desc->reset_ref_count();
+#ifdef RDTSC_MEASURE_RX_DISPATCH_PACKET
+	RDTSC_TAKE_START(g_rdtsc_instr_info_arr[RDTSC_FLOW_RX_DISPATCH_PACKET]);
+#endif //RDTSC_MEASURE_RX_DISPATCH_PACKET
+
+	p_rx_wc_buf_desc->inc_ref_count();
+	si->rx_input_cb(p_rx_wc_buf_desc, NULL);
+
+#ifdef RDTSC_MEASURE_RX_DISPATCH_PACKET
+	RDTSC_TAKE_END(g_rdtsc_instr_info_arr[RDTSC_FLOW_RX_DISPATCH_PACKET]);
+#endif //RDTSC_MEASURE_RX_DISPATCH_PACKET
+	// Check packet ref_count to see the last receiver is interested in this packet
+	if (p_rx_wc_buf_desc->dec_ref_count() > 1) {
+		// The sink will be responsible to return the buffer to CQ for reuse
+		return true;
+	}
+	// Reuse this data buffer & mem_buf_desc
+	return false;
+}
+
 inline void ring_simple::vma_poll_process_recv_buffer(mem_buf_desc_t* p_rx_wc_buf_desc)
 {
 	//size_t sz_data = 0;
-	size_t transport_header_len = 0;
+	size_t transport_header_len = ETH_HDR_LEN;
 	uint16_t ip_hdr_len = 0;
 	uint16_t ip_tot_len = 0;
 	uint16_t ip_frag_off = 0;
@@ -691,22 +746,74 @@ inline void ring_simple::vma_poll_process_recv_buffer(mem_buf_desc_t* p_rx_wc_bu
 	NOT_IN_USE(p_udp_h);
 	NOT_IN_USE(local_addr);
 
-	if (likely(p_rfs_single_tcp)) {
-		// we have a single 5tuple TCP connected socket, use simpler fast path
-		transport_header_len = ETH_HDR_LEN;
-		p_ip_h = (struct iphdr*)(p_rx_wc_buf_desc->p_buffer + transport_header_len);
-		ip_hdr_len = 20; //(int)(p_ip_h->ihl)*4;
-		struct tcphdr* p_tcp_h = (struct tcphdr*)((uint8_t*)p_ip_h + ip_hdr_len);
-		p_rx_wc_buf_desc->rx.tcp.p_ip_h        = p_ip_h;
-		p_rx_wc_buf_desc->rx.tcp.p_tcp_h       = p_tcp_h;
-		p_rx_wc_buf_desc->rx.tcp.n_transport_header_len = transport_header_len;
-		p_rx_wc_buf_desc->rx.vma_polled = true;
-		p_rfs_single_tcp->rx_dispatch_packet(p_rx_wc_buf_desc, NULL);
-		p_rx_wc_buf_desc->rx.vma_polled = false;
-		return;
-	}
-
 	// This is an internal function (within ring and 'friends'). No need for lock mechanism.
+
+	if (likely(m_flow_tag_enabled && p_rx_wc_buf_desc->rx.flow_tag_id)) {
+		sockinfo* si = NULL;
+		// trying to get sockinfo per flow_tag_id-1 as it was incremented at attach
+		// to allow mapping sockfd=0
+		si = static_cast <sockinfo* >(g_p_fd_collection->get_sockfd(p_rx_wc_buf_desc->rx.flow_tag_id-1));
+
+		if (likely((si != NULL) && si->flow_tag_enabled())) { 
+			// will process packets with set flow_tag_id and enabled for the socket
+			p_ip_h = (struct iphdr*)(p_rx_wc_buf_desc->p_buffer + transport_header_len);
+			ip_hdr_len = 20; //(int)(p_ip_h->ihl)*4;
+			ip_tot_len = ntohs(p_ip_h->tot_len);
+
+			if (likely(si->tcp_flow_is_5t())) {
+				// we have a single 5tuple TCP connected socket, use simpler fast path
+				struct tcphdr* p_tcp_h = (struct tcphdr*)((uint8_t*)p_ip_h + ip_hdr_len);
+				size_t sz_payload = ip_tot_len - ip_hdr_len - p_tcp_h->doff*4;
+
+				// Update packet descriptor with datagram base address and length
+				p_rx_wc_buf_desc->rx.frag.iov_base = (uint8_t*)p_tcp_h + sizeof(struct tcphdr);
+				p_rx_wc_buf_desc->rx.frag.iov_len  = ip_tot_len - ip_hdr_len - sizeof(struct tcphdr);
+
+				p_rx_wc_buf_desc->rx.sz_payload                 = sz_payload;
+
+				p_rx_wc_buf_desc->rx.tcp.p_ip_h                 = p_ip_h;
+				p_rx_wc_buf_desc->rx.tcp.p_tcp_h                = p_tcp_h;
+				p_rx_wc_buf_desc->rx.tcp.n_transport_header_len = transport_header_len;
+
+/*				ring_logfunc("FAST PATH Rx TCP segment info: src_port=%d, dst_port=%d, flags='%s%s%s%s%s%s' seq=%u, ack=%u, win=%u, payload_sz=%u",
+					ntohs(p_tcp_h->source), ntohs(p_tcp_h->dest),
+					p_tcp_h->urg?"U":"", p_tcp_h->ack?"A":"", p_tcp_h->psh?"P":"",
+					p_tcp_h->rst?"R":"", p_tcp_h->syn?"S":"", p_tcp_h->fin?"F":"",
+					ntohl(p_tcp_h->seq), ntohl(p_tcp_h->ack_seq), ntohs(p_tcp_h->window),
+					sz_payload);
+*/
+				p_rx_wc_buf_desc->rx.vma_polled = true;
+				check_rx_packet(si, p_rx_wc_buf_desc);
+				p_rx_wc_buf_desc->rx.vma_polled = false;
+				return;
+			} else if (p_ip_h->protocol==IPPROTO_UDP) {
+				// Get the udp header pointer + udp payload size
+				p_udp_h = (struct udphdr*)((uint8_t*)p_ip_h + ip_hdr_len);
+				size_t sz_payload = ntohs(p_udp_h->len) - sizeof(struct udphdr);
+				// Update packet descriptor with datagram base address and length
+				p_rx_wc_buf_desc->rx.frag.iov_base = (uint8_t*)p_udp_h + sizeof(struct udphdr);
+				p_rx_wc_buf_desc->rx.frag.iov_len  = ip_tot_len - ip_hdr_len - sizeof(struct udphdr);
+
+				// Update the L4 info
+				p_rx_wc_buf_desc->rx.src.sin_port        = p_udp_h->source;
+				p_rx_wc_buf_desc->rx.dst.sin_port        = p_udp_h->dest;
+				p_rx_wc_buf_desc->rx.sz_payload          = sz_payload;
+//				p_rx_wc_buf_desc->transport_header_len   = transport_header_len;
+
+				// Update the L3 info
+				p_rx_wc_buf_desc->rx.src.sin_family      = AF_INET;
+				p_rx_wc_buf_desc->rx.src.sin_addr.s_addr = p_ip_h->saddr;
+
+/*				ring_logfunc("FAST PATH Rx UDP datagram info: src_port=%d, dst_port=%d, payload_sz=%d, csum=%#x",
+					     ntohs(p_udp_h->source), ntohs(p_udp_h->dest), sz_payload, p_udp_h->check);
+*/
+				p_rx_wc_buf_desc->rx.vma_polled = true;
+				check_rx_packet(si, p_rx_wc_buf_desc);
+				p_rx_wc_buf_desc->rx.vma_polled = false;
+				return;
+			}
+		}
+	}
 
 	// Validate buffer size
 	size_t sz_data = p_rx_wc_buf_desc->sz_data;
@@ -734,7 +841,6 @@ inline void ring_simple::vma_poll_process_recv_buffer(mem_buf_desc_t* p_rx_wc_bu
 			ETH_HW_ADDR_PRINT_ADDR(p_eth_h->h_source),
 			htons(p_eth_h->h_proto));
 
-	transport_header_len = ETH_HDR_LEN;
 	uint16_t* p_h_proto = &p_eth_h->h_proto;
 
 	// Handle VLAN header as next protocol
@@ -856,7 +962,7 @@ inline void ring_simple::vma_poll_process_recv_buffer(mem_buf_desc_t* p_rx_wc_bu
 		return false;
 	}
 #endif
-	rfs *p_rfs = NULL;
+	rfs* p_rfs = NULL;
 
 	// Update the L3 info
 	p_rx_wc_buf_desc->rx.src.sin_family      = AF_INET;
@@ -941,7 +1047,6 @@ inline void ring_simple::vma_poll_process_recv_buffer(mem_buf_desc_t* p_rx_wc_bu
 				NIPQUAD(p_rx_wc_buf_desc->rx.dst.sin_addr.s_addr), ntohs(p_rx_wc_buf_desc->rx.dst.sin_port),
 				NIPQUAD(p_rx_wc_buf_desc->rx.src.sin_addr.s_addr), ntohs(p_rx_wc_buf_desc->rx.src.sin_port),
 				iphdr_protocol_type_to_str(p_ip_h->protocol), p_ip_h->protocol);
-
 		return;
 	}
 	p_rx_wc_buf_desc->rx.vma_polled = true;
@@ -949,8 +1054,6 @@ inline void ring_simple::vma_poll_process_recv_buffer(mem_buf_desc_t* p_rx_wc_bu
 	p_rx_wc_buf_desc->rx.vma_polled = false;
 }
 #endif // DEFINED_VMAPOLL
-
-
 
 // All CQ wce come here for some basic sanity checks and then are distributed to the correct ring handler
 // Return values: false = Reuse this data buffer & mem_buf_desc
@@ -973,20 +1076,6 @@ bool ring_simple::rx_process_buffer(mem_buf_desc_t* p_rx_wc_buf_desc, transport_
 	NOT_IN_USE(transport_type);
 #endif // DEFINED_VMAPOLL
 
-#ifdef DEFINED_VMAPOLL
-// REVIEW - can p_rfs_single_tcp be removed?
-	if (likely(p_rfs_single_tcp)) {
-		// we have a single 5tuple TCP connected socket, use simpler fast path
-		transport_header_len = ETH_HDR_LEN;
-		p_ip_h = (struct iphdr*)(p_rx_wc_buf_desc->p_buffer + transport_header_len);
-		ip_hdr_len = 20; //(int)(p_ip_h->ihl)*4;
-		struct tcphdr* p_tcp_h = (struct tcphdr*)((uint8_t*)p_ip_h + ip_hdr_len);
-		p_rx_wc_buf_desc->rx.tcp.p_ip_h        = p_ip_h;
-		p_rx_wc_buf_desc->rx.tcp.p_tcp_h       = p_tcp_h;
-		p_rx_wc_buf_desc->rx.tcp.n_transport_header_len = transport_header_len;
-		return p_rfs_single_tcp->rx_dispatch_packet(p_rx_wc_buf_desc, pv_fd_ready_array);
-	}
-#endif // DEFINED_VMAPOLL
 	// This is an internal function (within ring and 'friends'). No need for lock mechanism.
 
 	// Validate buffer size

--- a/src/vma/dev/ring_simple.h
+++ b/src/vma/dev/ring_simple.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001-2016 Mellanox Technologies, Ltd. All rights reserved.
+ * Copyright (c) 2001-2017 Mellanox Technologies, Ltd. All rights reserved.
  *
  * This software is available to you under a choice of one of two
  * licenses.  You may choose to be licensed under the terms of the GNU
@@ -49,7 +49,7 @@ public:
 	virtual void		adapt_cq_moderation();
 	bool			reclaim_recv_buffers_no_lock(descq_t *rx_reuse); // No locks
 // REVIEW - in experimental next method was defined as virtual	
-	bool		reclaim_recv_buffers_no_lock(mem_buf_desc_t* rx_reuse_lst); // No locks
+	bool			reclaim_recv_buffers_no_lock(mem_buf_desc_t* rx_reuse_lst); // No locks
 #ifdef DEFINED_VMAPOLL	
 	virtual int 		vma_poll(struct vma_completion_t *vma_completions, unsigned int ncompletions, int flags);	
 	virtual int		vma_poll_reclaim_single_recv_buffer(mem_buf_desc_t* rx_reuse_lst); // No locks
@@ -163,6 +163,7 @@ private:
 	mem_buf_desc_t*		m_rx_buffs_rdy_for_free_head;
 	mem_buf_desc_t*		m_rx_buffs_rdy_for_free_tail;
 #endif // DEFINED_VMAPOLL		
+	bool			m_flow_tag_enabled;
 };
 
 class ring_eth : public ring_simple

--- a/src/vma/dev/ring_simple.h
+++ b/src/vma/dev/ring_simple.h
@@ -159,7 +159,8 @@ private:
 	flow_spec_udp_mc_map_t	m_flow_udp_mc_map;
 	flow_spec_udp_uc_map_t	m_flow_udp_uc_map;
 	const bool		m_b_sysvar_eth_mc_l2_only_rules;
-#ifdef DEFINED_VMAPOLL	
+	const bool		m_b_sysvar_mc_force_flowtag;
+#ifdef DEFINED_VMAPOLL
 	mem_buf_desc_t*		m_rx_buffs_rdy_for_free_head;
 	mem_buf_desc_t*		m_rx_buffs_rdy_for_free_tail;
 #endif // DEFINED_VMAPOLL		

--- a/src/vma/main.cpp
+++ b/src/vma/main.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001-2016 Mellanox Technologies, Ltd. All rights reserved.
+ * Copyright (c) 2001-2017 Mellanox Technologies, Ltd. All rights reserved.
  *
  * This software is available to you under a choice of one of two
  * licenses.  You may choose to be licensed under the terms of the GNU
@@ -500,6 +500,7 @@ void print_vma_global_settings()
 
 	VLOG_PARAM_STRING("TCP 3T rules", safe_mce_sys().tcp_3t_rules, MCE_DEFAULT_TCP_3T_RULES, SYS_VAR_TCP_3T_RULES, safe_mce_sys().tcp_3t_rules ? "Enabled " : "Disabled");
 	VLOG_PARAM_STRING("ETH MC L2 only rules", safe_mce_sys().eth_mc_l2_only_rules, MCE_DEFAULT_ETH_MC_L2_ONLY_RULES, SYS_VAR_ETH_MC_L2_ONLY_RULES, safe_mce_sys().eth_mc_l2_only_rules ? "Enabled " : "Disabled");
+	VLOG_PARAM_STRING("Force Flowtag for MC", safe_mce_sys().mc_force_flowtag, MCE_DEFAULT_MC_FORCE_FLOWTAG, SYS_VAR_MC_FORCE_FLOWTAG, safe_mce_sys().mc_force_flowtag ? "Enabled " : "Disabled");
 
 	VLOG_PARAM_NUMBER("Select Poll (usec)", safe_mce_sys().select_poll_num, MCE_DEFAULT_SELECT_NUM_POLLS, SYS_VAR_SELECT_NUM_POLLS);
 	VLOG_PARAM_STRING("Select Poll OS Force", safe_mce_sys().select_poll_os_force, MCE_DEFAULT_SELECT_POLL_OS_FORCE, SYS_VAR_SELECT_POLL_OS_FORCE, safe_mce_sys().select_poll_os_force ? "Enabled " : "Disabled");

--- a/src/vma/proto/mem_buf_desc.h
+++ b/src/vma/proto/mem_buf_desc.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001-2016 Mellanox Technologies, Ltd. All rights reserved.
+ * Copyright (c) 2001-2017 Mellanox Technologies, Ltd. All rights reserved.
  *
  * This software is available to you under a choice of one of two
  * licenses.  You may choose to be licensed under the terms of the GNU
@@ -82,6 +82,7 @@ public:
 		size_t		sz_payload; // This is the total amount of data of the packet, if (sz_payload>sz_data) means fragmented packet.
 		uint64_t	hw_raw_timestamp;
 		void* 		context;
+		uint32_t	flow_tag_id; // Flow Tag ID of this received packet
 
 		union {
 			struct {
@@ -105,9 +106,8 @@ public:
 
 #ifdef DEFINED_VMAPOLL
 		bool 		vma_polled;
-		bool		pad[4];
 #else
-		bool		pad[5];
+		bool		pad[1];
 #endif // DEFINED_VMAPOLL
 	} rx;
 
@@ -135,9 +135,9 @@ public:
 	inline unsigned int lwip_pbuf_dec_ref_count() {if (likely(lwip_pbuf.pbuf.ref)) --lwip_pbuf.pbuf.ref; return lwip_pbuf.pbuf.ref;}
 	inline unsigned int lwip_pbuf_get_ref_count() const {return lwip_pbuf.pbuf.ref;}
 #endif // DEFINED_VMAPOLL
-
 };
 
 typedef vma_list_t<mem_buf_desc_t, mem_buf_desc_t::buffer_node_offset> descq_t;
 
 #endif
+

--- a/src/vma/sock/fd_collection.h
+++ b/src/vma/sock/fd_collection.h
@@ -208,7 +208,6 @@ inline cls* fd_collection::get(int fd, cls **map_type)
 		return NULL;
 
 	cls* obj = map_type[fd];
-	fdcoll_logfuncall("fd=%d %sFound", fd, (obj ? "" : "Not "));
 	return obj;
 }
 

--- a/src/vma/sock/sockinfo.cpp
+++ b/src/vma/sock/sockinfo.cpp
@@ -83,8 +83,11 @@ sockinfo::sockinfo(int fd) throw (vma_exception):
 		m_rx_callback(NULL),
 		m_rx_callback_context(NULL)
 #ifdef DEFINED_VMAPOLL 		
-		,m_fd_context((void *)((uintptr_t)m_fd))
+		, m_fd_context((void *)((uintptr_t)m_fd))
 #endif // DEFINED_VMAPOLL 		
+		, m_flow_tag_id(0)
+		, m_flow_tag_enabled(false)
+		, m_tcp_flow_is_5t(false)
 {
 	m_rx_epfd = orig_os_api.epoll_create(128);
 	if (unlikely(m_rx_epfd == -1)) {

--- a/src/vma/sock/sockinfo.cpp
+++ b/src/vma/sock/sockinfo.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001-2016 Mellanox Technologies, Ltd. All rights reserved.
+ * Copyright (c) 2001-2017 Mellanox Technologies, Ltd. All rights reserved.
  *
  * This software is available to you under a choice of one of two
  * licenses.  You may choose to be licensed under the terms of the GNU
@@ -75,6 +75,7 @@ sockinfo::sockinfo(int fd) throw (vma_exception):
 		m_p_rx_ring(0),
 		m_rx_reuse_buf_pending(false),
 		m_rx_reuse_buf_postponed(false),
+		m_reuseaddr(false),
 		m_rx_ring_map_lock(MODULE_NAME "::m_rx_ring_map_lock"),
 		m_ring_alloc_logic(fd, this),
 		m_n_rx_pkt_ready_list_count(0), m_rx_pkt_ready_offset(0), m_rx_ready_byte_count(0),
@@ -221,6 +222,9 @@ int sockinfo::setsockopt(int __level, int __optname, const void *__optval, sockl
 
 	if (__level == SOL_SOCKET) {
 		switch(__optname) {
+		case SO_REUSEADDR:
+			set_reuseaddr((bool*)__optval);
+			break;
 		case SO_VMA_USER_DATA:
 			if (__optlen == sizeof(m_fd_context)) {
 				m_fd_context = *(void **)__optval;

--- a/src/vma/sock/sockinfo.h
+++ b/src/vma/sock/sockinfo.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001-2016 Mellanox Technologies, Ltd. All rights reserved.
+ * Copyright (c) 2001-2017 Mellanox Technologies, Ltd. All rights reserved.
  *
  * This software is available to you under a choice of one of two
  * licenses.  You may choose to be licensed under the terms of the GNU
@@ -121,6 +121,14 @@ public:
 	virtual int add_epoll_context(epfd_info *epfd);
 	virtual void remove_epoll_context(epfd_info *epfd);
 
+	inline bool tcp_flow_is_5t(void) { return m_tcp_flow_is_5t; }
+	inline void set_tcp_flow_is_5t(void) { m_tcp_flow_is_5t = true; }
+	inline void set_flow_tag(int flow_tag_id) {
+		m_flow_tag_id = flow_tag_id;
+		m_flow_tag_enabled = flow_tag_id > 0 ? true : false;
+	}
+	inline bool flow_tag_enabled(void) { return m_flow_tag_enabled; }
+
 #ifdef DEFINED_VMAPOLL
 	virtual int fast_nonblocking_rx(vma_packets_t *vma_pkts);
 	virtual int get_rings_num() {return 1;}
@@ -190,6 +198,9 @@ protected:
 #ifdef DEFINED_VMAPOLL	
 	void*			m_fd_context;
 #endif // DEFINED_VMAPOLL	
+	uint32_t		m_flow_tag_id;	// Flow Tag for this socket
+	bool			m_flow_tag_enabled; // for this socket
+	bool			m_tcp_flow_is_5t; // to bypass packet analysis
 
 	virtual void 		set_blocking(bool is_blocked);
 	virtual int 		fcntl(int __cmd, unsigned long int __arg) throw (vma_error);

--- a/src/vma/sock/sockinfo.h
+++ b/src/vma/sock/sockinfo.h
@@ -128,6 +128,9 @@ public:
 		m_flow_tag_enabled = flow_tag_id > 0 ? true : false;
 	}
 	inline bool flow_tag_enabled(void) { return m_flow_tag_enabled; }
+	
+	inline void set_reuseaddr(bool reuseaddr_) { m_reuseaddr = reuseaddr_; }
+	inline bool addr_in_reuse(void) { return m_reuseaddr; }
 
 #ifdef DEFINED_VMAPOLL
 	virtual int fast_nonblocking_rx(vma_packets_t *vma_pkts);
@@ -164,6 +167,7 @@ protected:
 	buff_info_t		m_rx_reuse_buff; //used in TCP instead of m_rx_ring_map
 	bool			m_rx_reuse_buf_pending; //used to periodically return buffers, even if threshold was not reached
 	bool			m_rx_reuse_buf_postponed; //used to mark threshold was reached, but free was not done yet
+	bool			m_reuseaddr; // to track setsockopt with SO_REUSEADDR
 	inline void		set_rx_reuse_pending(bool is_pending = true) {m_rx_reuse_buf_pending = is_pending;}
 
 	rx_ring_map_t		m_rx_ring_map; // CQ map

--- a/src/vma/sock/sockinfo_udp.cpp
+++ b/src/vma/sock/sockinfo_udp.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001-2016 Mellanox Technologies, Ltd. All rights reserved.
+ * Copyright (c) 2001-2017 Mellanox Technologies, Ltd. All rights reserved.
  *
  * This software is available to you under a choice of one of two
  * licenses.  You may choose to be licensed under the terms of the GNU
@@ -729,6 +729,10 @@ int sockinfo_udp::setsockopt(int __level, int __optname, __const void *__optval,
 			switch (__optname) {
 
 			case SO_REUSEADDR:
+				sockinfo::set_reuseaddr((bool*)__optval);
+				si_udp_logdbg("SOL_SOCKET, %s=%s", setsockopt_so_opt_to_str(__optname), ((bool*)__optval ? "true" : "false"));
+				break;
+
 			case SO_BROADCAST:
 				si_udp_logdbg("SOL_SOCKET, %s=%s", setsockopt_so_opt_to_str(__optname), ((bool*)__optval ? "true" : "false"));
 				break;
@@ -2163,7 +2167,7 @@ int sockinfo_udp::mc_change_membership(const mc_pending_pram *p_mc_pram)
 
 	sock_addr tmp_grp_addr(AF_INET, mc_grp, m_bound.get_in_port());
 	if (__vma_match_udp_receiver(TRANS_VMA, safe_mce_sys().app_id, tmp_grp_addr.get_p_sa(), tmp_grp_addr.get_socklen()) == TRANS_OS) {
-		// Break so we call orig setsockopt() and don't try to offlaod
+		// Break so we call orig setsockopt() and don't try to offload
 		si_udp_logdbg("setsockopt(%s) will be passed to OS for handling due to rule matching", setsockopt_ip_opt_to_str(p_mc_pram->optname));
 		return -1;
 	}

--- a/src/vma/util/sys_vars.cpp
+++ b/src/vma/util/sys_vars.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001-2016 Mellanox Technologies, Ltd. All rights reserved.
+ * Copyright (c) 2001-2017 Mellanox Technologies, Ltd. All rights reserved.
  *
  * This software is available to you under a choice of one of two
  * licenses.  You may choose to be licensed under the terms of the GNU
@@ -435,6 +435,7 @@ void mce_sys_var::get_env_params()
 
 	tcp_3t_rules		= MCE_DEFAULT_TCP_3T_RULES;
 	eth_mc_l2_only_rules	= MCE_DEFAULT_ETH_MC_L2_ONLY_RULES;
+	mc_force_flowtag	= MCE_DEFAULT_MC_FORCE_FLOWTAG;
 
 	select_poll_num		= MCE_DEFAULT_SELECT_NUM_POLLS;
 	select_poll_os_force	= MCE_DEFAULT_SELECT_POLL_OS_FORCE;
@@ -831,8 +832,12 @@ void mce_sys_var::get_env_params()
 	if ((env_ptr = getenv(SYS_VAR_ETH_MC_L2_ONLY_RULES)) != NULL)
 		eth_mc_l2_only_rules = atoi(env_ptr) ? true : false;
 
+	if ((env_ptr = getenv(SYS_VAR_MC_FORCE_FLOWTAG)) != NULL)
+		mc_force_flowtag = atoi(env_ptr) ? true : false;
+
 	if ((env_ptr = getenv(SYS_VAR_SELECT_NUM_POLLS)) != NULL)
 		select_poll_num = atoi(env_ptr);
+
 	if (select_poll_num < MCE_MIN_RX_NUM_POLLS || select_poll_num >  MCE_MAX_RX_NUM_POLLS) {
 		vlog_printf(VLOG_WARNING," Select Poll loops can not be below zero [%d]\n", select_poll_num);
 		select_poll_num = MCE_DEFAULT_SELECT_NUM_POLLS;

--- a/src/vma/util/sys_vars.h
+++ b/src/vma/util/sys_vars.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001-2016 Mellanox Technologies, Ltd. All rights reserved.
+ * Copyright (c) 2001-2017 Mellanox Technologies, Ltd. All rights reserved.
  *
  * This software is available to you under a choice of one of two
  * licenses.  You may choose to be licensed under the terms of the GNU
@@ -347,6 +347,7 @@ struct mce_sys_var {
 
 	bool		tcp_3t_rules;
 	bool		eth_mc_l2_only_rules;
+	bool		mc_force_flowtag;
 
 	int32_t		select_poll_num;
 	bool		select_poll_os_force;
@@ -477,6 +478,7 @@ extern mce_sys_var & safe_mce_sys();
 #define SYS_VAR_GRO_STREAMS_MAX				"VMA_GRO_STREAMS_MAX"
 #define SYS_VAR_TCP_3T_RULES				"VMA_TCP_3T_RULES"
 #define SYS_VAR_ETH_MC_L2_ONLY_RULES			"VMA_ETH_MC_L2_ONLY_RULES"
+#define SYS_VAR_MC_FORCE_FLOWTAG			"VMA_MC_FORCE_FLOWTAG"
 
 #define SYS_VAR_SELECT_CPU_USAGE_STATS			"VMA_CPU_USAGE_STATS"
 #define SYS_VAR_SELECT_NUM_POLLS			"VMA_SELECT_POLL"
@@ -600,6 +602,7 @@ extern mce_sys_var & safe_mce_sys();
 #endif // DEFINED_VMAPOLL
 #define MCE_DEFAULT_TCP_3T_RULES			(false)
 #define MCE_DEFAULT_ETH_MC_L2_ONLY_RULES		(false)
+#define MCE_DEFAULT_MC_FORCE_FLOWTAG			(false)
 #define MCE_DEFAULT_SELECT_NUM_POLLS			(100000)
 #define MCE_DEFAULT_SELECT_POLL_OS_FORCE		(0)
 #define MCE_DEFAULT_SELECT_POLL_OS_RATIO		(10)

--- a/src/vma/util/verbs_extra.cpp
+++ b/src/vma/util/verbs_extra.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001-2016 Mellanox Technologies, Ltd. All rights reserved.
+ * Copyright (c) 2001-2017 Mellanox Technologies, Ltd. All rights reserved.
  *
  * This software is available to you under a choice of one of two
  * licenses.  You may choose to be licensed under the terms of the GNU
@@ -259,3 +259,52 @@ int priv_ibv_query_qp_state(struct ibv_qp *qp)
 	BULLSEYE_EXCLUDE_BLOCK_END
 	return (ibv_qp_state)qp_attr.qp_state;
 }
+
+int priv_ibv_query_flow_tag_supported(struct ibv_qp *qp, uint8_t port_num)
+{
+	NOT_IN_USE(qp);
+	NOT_IN_USE(port_num);
+	int res = -1;
+
+#ifdef DEFINED_IBV_EXP_FLOW_TAG
+
+	// Create
+	struct __attribute__ ((packed)) {
+		vma_ibv_flow_attr             attr;
+		vma_ibv_flow_spec_eth         eth;
+		vma_ibv_flow_spec_ipv4        ipv4;
+		vma_ibv_flow_spec_tcp_udp     tcp_udp;
+		vma_ibv_flow_spec_action_tag  flow_tag;
+	} ft_attr;
+
+	// Initialize
+	memset(&ft_attr, 0, sizeof(ft_attr));
+	ft_attr.attr.size = sizeof(ft_attr);
+	ft_attr.attr.num_of_specs = 4;
+	ft_attr.attr.type = VMA_IBV_FLOW_ATTR_NORMAL;
+	ft_attr.attr.priority = 1; // almost highest priority, 0 is used for 5-tuple later
+	ft_attr.attr.port = port_num;
+
+	// Set filters
+	uint8_t mac_0[ETH_ALEN] = { 0x00, 0x00, 0x00, 0x00, 0x00, 0x00 };
+	uint8_t mac_f[ETH_ALEN] = { 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF };
+
+	ibv_flow_spec_eth_set(&ft_attr.eth, mac_0 , 0); // L2 filter
+	memcpy(ft_attr.eth.val.src_mac, mac_f, ETH_ALEN);
+	memset(ft_attr.eth.mask.src_mac, FS_MASK_ON_8, ETH_ALEN);
+
+	ibv_flow_spec_ipv4_set(&ft_attr.ipv4, INADDR_LOOPBACK, INADDR_LOOPBACK); // L3 filter
+	ibv_flow_spec_tcp_udp_set(&ft_attr.tcp_udp, true, 0, 0); // L4 filter
+	ibv_flow_spec_flow_tag_set(&ft_attr.flow_tag, FLOW_TAG_MASK-1); // enable flow tag
+
+	// Create flow
+	vma_ibv_flow *ibv_flow = vma_ibv_create_flow(qp, &ft_attr.attr);
+	if (ibv_flow) {
+		res = 0;
+		vma_ibv_destroy_flow(ibv_flow);
+	}
+#endif // DEFINED_IBV_EXP_FLOW_TAG
+
+	return res;
+}
+

--- a/src/vma/util/verbs_extra.h
+++ b/src/vma/util/verbs_extra.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001-2016 Mellanox Technologies, Ltd. All rights reserved.
+ * Copyright (c) 2001-2017 Mellanox Technologies, Ltd. All rights reserved.
  *
  * This software is available to you under a choice of one of two
  * licenses.  You may choose to be licensed under the terms of the GNU
@@ -100,6 +100,9 @@ int priv_ibv_query_qp_state(struct ibv_qp *qp);
 #define FS_MASK_ON_16     (0xffff)
 #define FS_MASK_ON_32     (0xffffffff)
 
+#define FLOW_TAG_MASK     ((1 << 20) -1)
+int priv_ibv_query_flow_tag_supported(struct ibv_qp *qp, uint8_t port_num);
+
 //old MLNX_OFED verbs (2.1 and older)
 #ifdef DEFINED_IBV_OLD_VERBS_MLX_OFED
 //ibv_query_device
@@ -171,6 +174,9 @@ typedef struct ibv_flow_spec_ib			vma_ibv_flow_spec_ib;
 typedef struct ibv_flow_spec_eth		vma_ibv_flow_spec_eth;
 typedef struct ibv_flow_spec_ipv4		vma_ibv_flow_spec_ipv4;
 typedef struct ibv_flow_spec_tcp_udp		vma_ibv_flow_spec_tcp_udp;
+#define vma_get_flow_tag			0
+typedef struct ibv_exp_flow_spec_action_tag_dummy {}	vma_ibv_flow_spec_action_tag;
+
 #else //new MLNX_OFED verbs (2.2 and newer)
 //ibv_query_device
 #define vma_ibv_query_device(context, attr)	ibv_exp_query_device(context, attr)
@@ -230,10 +236,9 @@ typedef int            vma_ibv_cq_init_attr;
 #define VMA_IBV_WC_WITH_TIMESTAMP              IBV_EXP_WC_WITH_TIMESTAMP
 #define vma_wc_timestamp(wc)			(wc).timestamp
 #else
-#define VMA_IBV_WC_WITH_TIMESTAMP              0
+#define VMA_IBV_WC_WITH_TIMESTAMP		0
 #define vma_wc_timestamp(wc)			0
 #endif
-
 
 //ibv_post_send
 #define VMA_IBV_SEND_SIGNALED			IBV_EXP_SEND_SIGNALED
@@ -277,6 +282,14 @@ typedef struct ibv_exp_flow_spec_ib		vma_ibv_flow_spec_ib;
 typedef struct ibv_exp_flow_spec_eth		vma_ibv_flow_spec_eth;
 typedef struct ibv_exp_flow_spec_ipv4		vma_ibv_flow_spec_ipv4;
 typedef struct ibv_exp_flow_spec_tcp_udp	vma_ibv_flow_spec_tcp_udp;
+//Flow tag
+#ifdef DEFINED_IBV_EXP_FLOW_TAG
+#define vma_get_flow_tag(wc)			ntohl((uint32_t)(wc->sop_drop_qpn))
+typedef struct ibv_exp_flow_spec_action_tag	vma_ibv_flow_spec_action_tag;
+#else
+#define vma_get_flow_tag(cqe)			0
+typedef struct ibv_exp_flow_spec_action_tag_dummy {}	vma_ibv_flow_spec_action_tag;
+#endif //DEFINED_IBV_EXP_FLOW_TAG
 #endif
 
 static inline void init_vma_ibv_cq_init_attr(vma_ibv_cq_init_attr* attr)
@@ -340,6 +353,18 @@ static inline void ibv_flow_spec_tcp_udp_set(vma_ibv_flow_spec_tcp_udp* tcp_udp,
 	if(tcp_udp->val.src_port) tcp_udp->mask.src_port = FS_MASK_ON_16;
 	tcp_udp->val.dst_port = dst_port;
 	if(tcp_udp->val.dst_port) tcp_udp->mask.dst_port = FS_MASK_ON_16;
+}
+
+static inline void ibv_flow_spec_flow_tag_set(vma_ibv_flow_spec_action_tag* flow_tag, uint32_t tag_id)
+{
+	NOT_IN_USE(tag_id);
+	if (flow_tag == NULL)
+		return;
+#ifdef DEFINED_IBV_EXP_FLOW_TAG
+	flow_tag->type = IBV_EXP_FLOW_SPEC_ACTION_TAG;
+	flow_tag->size = sizeof(vma_ibv_flow_spec_action_tag);
+	flow_tag->tag_id = tag_id;
+#endif //DEFINED_IBV_EXP_FLOW_TAG
 }
 
 #endif


### PR DESCRIPTION
Implementation is:
- using socket FD as tag_id, excluding mapping tag_id -> socked fd for
  performance considerations;
- dynamic probing for flow_tag support on port initialization;
- fast path for UC TCP/UPD to bypass most of packet checks and RFS dispatch

We would check and ignore flow_tag_id set by adapter in case some
rule has disabled flow_tag support for this socket for "fast path".
Such packets still may be valid for adapters without flow_tag_id
support or multicast cases. So it will require additional full
check performed by normal data path.

It has allowed to use flow_tag for sockfd=0. The case might be possible when closing
default fd=0 happen after VMA initialization, so system can return new sockfd=0.
flow_tag_id=0 is invalid and we increment sockfd and use it as tag_ig with
appropriate change during dispatching. This effectively limiting our valid range to
FLOW_TAG_MASK-1.

This commit has disabling flow_tag support for multicast flows, it is partially
enabled in separate commit.

It also has disabled flow_tag support for non vmapoll modes.

Signed-off-by: Oleg Kuporosov <olegk@mellanox.com>