### PR TITLE
issue: 987687 Request buffer for next packet after send ring_buffer()

### DIFF
--- a/src/vma/dev/wqe_send_handler.cpp
+++ b/src/vma/dev/wqe_send_handler.cpp
@@ -43,15 +43,14 @@ wqe_send_handler::~wqe_send_handler()
 
 void wqe_send_handler::init_inline_wqe(vma_ibv_send_wr &wqe_to_init, struct ibv_sge* sge_list, uint32_t num_sge)
 {
-	memset(&wqe_to_init, 0, sizeof(wqe_to_init));
-
-	wqe_to_init.num_sge = num_sge;
-	vma_send_wr_opcode(wqe_to_init) = VMA_IBV_WR_SEND;
-	wqe_to_init.next = NULL;
-	wqe_to_init.sg_list = sge_list;
-	wqe_to_init.wr_id = 0;
-	enable_hw_csum(wqe_to_init);
+	init_not_inline_wqe(wqe_to_init, sge_list, num_sge);
 	enable_inline(wqe_to_init);
+}
+
+void wqe_send_handler::init_not_inline_wqe(vma_ibv_send_wr &wqe_to_init, struct ibv_sge* sge_list, uint32_t num_sge)
+{
+	init_wqe(wqe_to_init, sge_list, num_sge);
+	enable_hw_csum(wqe_to_init);
 }
 
 void wqe_send_handler::init_wqe(vma_ibv_send_wr &wqe_to_init, struct ibv_sge* sge_list, uint32_t num_sge)

--- a/src/vma/dev/wqe_send_handler.h
+++ b/src/vma/dev/wqe_send_handler.h
@@ -30,10 +30,8 @@
  * SOFTWARE.
  */
 
-
 #include "vma/util/to_str.h"
 #include "vma/util/verbs_extra.h"
-#include <string.h>
 
 #ifndef IB_WQE_TEMPLATE_H
 #define IB_WQE_TEMPLATE_H
@@ -46,6 +44,7 @@ public:
 
 	void init_wqe(vma_ibv_send_wr &wqe_to_init, struct ibv_sge* sge_list, uint32_t num_sge);
 	void init_inline_wqe(vma_ibv_send_wr &wqe_to_init, struct ibv_sge* sge_list, uint32_t num_sge);
+	void init_not_inline_wqe(vma_ibv_send_wr &wqe_to_init, struct ibv_sge* sge_list, uint32_t num_sge);
 
 	inline vma_ibv_wr_opcode set_opcode(vma_ibv_send_wr &wqe, vma_ibv_wr_opcode opcode) {
 		vma_ibv_wr_opcode last_opcode = vma_send_wr_opcode(wqe);
@@ -62,13 +61,6 @@ public:
 #endif
 
 	inline void enable_inline (vma_ibv_send_wr &send_wqe) { vma_send_wr_send_flags(send_wqe) |= VMA_IBV_SEND_INLINE; }
-#if _BullseyeCoverage
-    #pragma BullseyeCoverage off
-#endif
-	inline void disable_inline (vma_ibv_send_wr &send_wqe) { vma_send_wr_send_flags(send_wqe) &= ~VMA_IBV_SEND_INLINE; }
-#if _BullseyeCoverage
-    #pragma BullseyeCoverage on
-#endif
 };
 
 #endif /* IB_WQE_TEMPLATE_H */

--- a/src/vma/dev/wqe_send_ib_handler.cpp
+++ b/src/vma/dev/wqe_send_ib_handler.cpp
@@ -62,6 +62,13 @@ void wqe_send_ib_handler::init_inline_ib_wqe(vma_ibv_send_wr &wqe_to_init, struc
 	init_path_record(wqe_to_init, ah, rem_qkey, rem_qpn);
 }
 
+void wqe_send_ib_handler::init_not_inline_ib_wqe(vma_ibv_send_wr &wqe_to_init, struct ibv_sge* sge_list, uint32_t num_sge,
+		    struct ibv_ah *ah, uint32_t rem_qpn, uint32_t rem_qkey)
+{
+	wqe_send_handler::init_not_inline_wqe(wqe_to_init, sge_list, num_sge);
+	init_path_record(wqe_to_init, ah, rem_qkey, rem_qpn);
+}
+
 //code coverage
 #if 0
 void wqe_send_ib_handler::enable_imm_data(vma_ibv_send_wr &send_wqe)

--- a/src/vma/dev/wqe_send_ib_handler.h
+++ b/src/vma/dev/wqe_send_ib_handler.h
@@ -50,9 +50,9 @@ public:
 	virtual ~wqe_send_ib_handler();
 
 
-	void init_ib_wqe(vma_ibv_send_wr &wqe_to_init, struct ibv_sge* sge_list, uint32_t num_sge,
-			     struct ibv_ah *ah, uint32_t rem_qpn, uint32_t rem_qkey);
+	void init_ib_wqe(vma_ibv_send_wr &wqe_to_init, struct ibv_sge* sge_list, uint32_t num_sge, struct ibv_ah *ah, uint32_t rem_qpn, uint32_t rem_qkey);
 	void init_inline_ib_wqe(vma_ibv_send_wr & wqe_to_init, struct ibv_sge *sge_list, uint32_t num_sge, struct ibv_ah *ah, uint32_t rem_qpn, uint32_t rem_qkey);
+	void init_not_inline_ib_wqe(vma_ibv_send_wr & wqe_to_init, struct ibv_sge *sge_list, uint32_t num_sge, struct ibv_ah *ah, uint32_t rem_qpn, uint32_t rem_qkey);
 	void enable_imm_data(vma_ibv_send_wr &send_wqe);
 	void disable_imm_data(vma_ibv_send_wr &send_wqe);
 

--- a/src/vma/proto/dst_entry.cpp
+++ b/src/vma/proto/dst_entry.cpp
@@ -114,6 +114,7 @@ void dst_entry::init_members()
 	m_num_sge = 0;
 	memset(&m_inline_send_wqe, 0, sizeof(m_inline_send_wqe));
 	memset(&m_not_inline_send_wqe, 0, sizeof(m_not_inline_send_wqe));
+	memset(&m_fragmented_send_wqe, 0, sizeof(m_not_inline_send_wqe));
 	m_p_send_wqe_handler = NULL;
 	memset(&m_sge, 0, sizeof(m_sge));
 	m_tos = 0;
@@ -357,7 +358,8 @@ bool dst_entry::conf_l2_hdr_and_snd_wqe_eth()
 		dst_logpanic("%s Failed to allocate send WQE handler", to_str().c_str());
 	}
 	m_p_send_wqe_handler->init_inline_wqe(m_inline_send_wqe, get_sge_lst_4_inline_send(), get_inline_sge_num());
-	m_p_send_wqe_handler->init_wqe(m_not_inline_send_wqe, get_sge_lst_4_not_inline_send(), 1);
+	m_p_send_wqe_handler->init_not_inline_wqe(m_not_inline_send_wqe, get_sge_lst_4_not_inline_send(), 1);
+	m_p_send_wqe_handler->init_wqe(m_fragmented_send_wqe, get_sge_lst_4_not_inline_send(), 1);
 
 	net_device_val_eth *netdevice_eth = dynamic_cast<net_device_val_eth*>(m_p_net_dev_val);
 	BULLSEYE_EXCLUDE_BLOCK_START
@@ -418,7 +420,8 @@ bool  dst_entry::conf_l2_hdr_and_snd_wqe_ib()
 		}
 		BULLSEYE_EXCLUDE_BLOCK_END
 		((wqe_send_ib_handler *)(m_p_send_wqe_handler))->init_inline_ib_wqe(m_inline_send_wqe, get_sge_lst_4_inline_send(), get_inline_sge_num(), ah, qpn, qkey);
-		((wqe_send_ib_handler*)(m_p_send_wqe_handler))->init_ib_wqe(m_not_inline_send_wqe, get_sge_lst_4_not_inline_send(), 1, ah, qpn, qkey);
+		((wqe_send_ib_handler*)(m_p_send_wqe_handler))->init_not_inline_ib_wqe(m_not_inline_send_wqe, get_sge_lst_4_not_inline_send(), 1, ah, qpn, qkey);
+		((wqe_send_ib_handler*)(m_p_send_wqe_handler))->init_ib_wqe(m_fragmented_send_wqe, get_sge_lst_4_not_inline_send(), 1, ah, qpn, qkey);
 		m_header.configure_ipoib_headers();
 		init_sge();
 

--- a/src/vma/proto/dst_entry.h
+++ b/src/vma/proto/dst_entry.h
@@ -67,7 +67,7 @@ public:
 
 	virtual bool 	prepare_to_send(bool skip_rules=false, bool is_connect=false);
 	virtual ssize_t slow_send(const iovec* p_iov, size_t sz_iov, bool is_dummy, bool b_blocked = true, bool is_rexmit = false, int flags = 0, socket_fd_api* sock = 0, tx_call_t call_type = TX_UNDEF) = 0 ;
-	virtual ssize_t fast_send(const struct iovec* p_iov, const ssize_t sz_iov, bool is_dummy, bool b_blocked = true, bool is_rexmit = false, bool dont_inline = false) = 0;
+	virtual ssize_t fast_send(const struct iovec* p_iov, const ssize_t sz_iov, bool is_dummy, bool b_blocked = true, bool is_rexmit = false) = 0;
 
 	bool		try_migrate_ring(lock_base& socket_lock);
 
@@ -108,6 +108,7 @@ protected:
 	lock_mutex_recursive 	m_slow_path_lock;
 	vma_ibv_send_wr 	m_inline_send_wqe;
 	vma_ibv_send_wr 	m_not_inline_send_wqe;
+	vma_ibv_send_wr 	m_fragmented_send_wqe;
 	wqe_send_handler*	m_p_send_wqe_handler;
 	ibv_sge 		m_sge[MCE_DEFAULT_TX_NUM_SGE];
 	uint8_t 		m_num_sge;
@@ -153,7 +154,7 @@ protected:
 	virtual ssize_t 	pass_buff_to_neigh(const iovec *p_iov, size_t & sz_iov, uint16_t packet_id = 0);
 	virtual void 		configure_ip_header(header *h, uint16_t packet_id = 0);
 	virtual void 		configure_headers() { conf_hdrs_and_snd_wqe();};
-	virtual bool 		conf_hdrs_and_snd_wqe();
+	bool 			conf_hdrs_and_snd_wqe();
 	virtual bool 		conf_l2_hdr_and_snd_wqe_eth();
 	virtual bool 		conf_l2_hdr_and_snd_wqe_ib();
 	virtual void 		init_sge() {};

--- a/src/vma/proto/dst_entry_tcp.cpp
+++ b/src/vma/proto/dst_entry_tcp.cpp
@@ -64,7 +64,7 @@ transport_t dst_entry_tcp::get_transport(sockaddr_in to)
 	return TRANS_VMA;
 }
 
-ssize_t dst_entry_tcp::fast_send(const struct iovec* p_iov, const ssize_t sz_iov, bool is_dummy, bool b_blocked /*= true*/, bool is_rexmit /*= false*/, bool dont_inline /*= false*/)
+ssize_t dst_entry_tcp::fast_send(const struct iovec* p_iov, const ssize_t sz_iov, bool is_dummy, bool b_blocked /*= true*/, bool is_rexmit /*= false*/)
 {
 	tx_packet_template_t* p_pkt;
 	mem_buf_desc_t *p_mem_buf_desc;
@@ -109,9 +109,8 @@ ssize_t dst_entry_tcp::fast_send(const struct iovec* p_iov, const ssize_t sz_iov
 					p_tcp_iov[0].p_desc->lwip_pbuf.pbuf.payload, hdr_alignment_diff);
 		}
 
-		if (!dont_inline && (total_packet_len < m_max_inline)) { // inline send
+		if (total_packet_len < m_max_inline) { // inline send
 			m_p_send_wqe = &m_inline_send_wqe;
-
 		} else {
 			m_p_send_wqe = &m_not_inline_send_wqe;
 		}
@@ -244,14 +243,6 @@ void dst_entry_tcp::configure_headers()
 {
 	m_header.init();
 	dst_entry::configure_headers();
-}
-
-bool dst_entry_tcp::conf_hdrs_and_snd_wqe()
-{
-	bool ret_val = dst_entry::conf_hdrs_and_snd_wqe();
-	m_p_send_wqe_handler->enable_hw_csum(m_not_inline_send_wqe);
-
-	return ret_val;
 }
 
 ssize_t dst_entry_tcp::pass_buff_to_neigh(const iovec * p_iov, size_t & sz_iov, uint16_t packet_id)

--- a/src/vma/proto/dst_entry_tcp.h
+++ b/src/vma/proto/dst_entry_tcp.h
@@ -49,7 +49,7 @@ public:
 	dst_entry_tcp(in_addr_t dst_ip, uint16_t dst_port, uint16_t src_port, int owner_fd);
 	virtual ~dst_entry_tcp();
 
-	virtual ssize_t fast_send(const struct iovec* p_iov, const ssize_t sz_iov, bool is_dummy, bool b_blocked = true, bool is_rexmit = false, bool dont_inline = false);
+	virtual ssize_t fast_send(const struct iovec* p_iov, const ssize_t sz_iov, bool is_dummy, bool b_blocked = true, bool is_rexmit = false);
 	ssize_t slow_send(const iovec* p_iov, size_t sz_iov, bool is_dummy, bool b_blocked = true, bool is_rexmit = false, int flags = 0, socket_fd_api* sock = 0, tx_call_t call_type = TX_UNDEF);
 	ssize_t slow_send_neigh(const iovec* p_iov, size_t sz_iov);
 
@@ -64,7 +64,6 @@ protected:
 	virtual ibv_sge*	get_sge_lst_4_not_inline_send() { return m_sge; };
 
 	virtual void		configure_headers();
-	virtual bool		conf_hdrs_and_snd_wqe();
 	virtual ssize_t 	pass_buff_to_neigh(const iovec *p_iov, size_t & sz_iov, uint16_t packet_id = 0);
 
 private:

--- a/src/vma/proto/dst_entry_udp.cpp
+++ b/src/vma/proto/dst_entry_udp.cpp
@@ -133,6 +133,10 @@ inline ssize_t dst_entry_udp::fast_send_not_fragmented(const iovec* p_iov, const
 		p_pkt->hdr.m_ip_hdr.id = 0;
 		p_pkt->hdr.m_ip_hdr.tot_len = htons(m_header.m_ip_header_len + sz_udp_payload);
 
+		// Update the payload addr + len
+		m_sge[1].length = sz_data_payload + hdr_len;
+		m_sge[1].addr = (uintptr_t)(p_mem_buf_desc->p_buffer + (uint8_t)m_header.m_transport_header_tx_offset);
+
 		// Calc payload start point (after the udp header if present else just after ip header)
 		uint8_t* p_payload = p_mem_buf_desc->p_buffer + m_header.m_transport_header_tx_offset + hdr_len;
 
@@ -146,9 +150,6 @@ inline ssize_t dst_entry_udp::fast_send_not_fragmented(const iovec* p_iov, const
 			return -1;
 		}
 		BULLSEYE_EXCLUDE_BLOCK_END
-
-		m_sge[1].addr = (uintptr_t)(p_mem_buf_desc->p_buffer + (uint8_t)m_header.m_transport_header_tx_offset);
-		m_sge[1].length = sz_data_payload + hdr_len;
 	}
 
 #ifdef VMA_NO_HW_CSUM

--- a/src/vma/proto/dst_entry_udp.h
+++ b/src/vma/proto/dst_entry_udp.h
@@ -43,7 +43,7 @@ public:
 	virtual ~dst_entry_udp();
 
 	virtual ssize_t 	slow_send(const iovec* p_iov, size_t sz_iov, bool is_dummy, bool b_blocked = true, bool is_rexmit = false, int flags = 0, socket_fd_api* sock = 0, tx_call_t call_type = TX_UNDEF);
-	virtual ssize_t 	fast_send(const struct iovec* p_iov, const ssize_t sz_iov, bool is_dummy, bool b_blocked = true, bool is_rexmit = false, bool dont_inline = false);
+	virtual ssize_t 	fast_send(const struct iovec* p_iov, const ssize_t sz_iov, bool is_dummy, bool b_blocked = true, bool is_rexmit = false);
 
 protected:
 	virtual transport_t 	get_transport(sockaddr_in to);
@@ -58,6 +58,10 @@ protected:
 	size_t m_n_tx_ip_id;
 
 private:
+
+	inline ssize_t fast_send_not_fragmented(const iovec* p_iov, const ssize_t sz_iov, bool is_dummy, bool b_blocked, size_t sz_udp_payload, ssize_t sz_data_payload);
+	ssize_t fast_send_fragmented(const iovec* p_iov, const ssize_t sz_iov, bool is_dummy, bool b_blocked, size_t sz_udp_payload, ssize_t sz_data_payload);
+
 	const uint32_t m_n_sysvar_tx_bufs_batch_udp;
 	const bool m_b_sysvar_tx_nonblocked_eagains;
 	const thread_mode_t	m_sysvar_thread_mode;


### PR DESCRIPTION
for not inline packets

For not inline packet (size > ~180 bytes), we request the packet buffer
during fast send.
This could be implemented as we do for inline packets: request the
buffer for the next packet after send_ring_buffer (while the packet has
be sent to the wire).

Signed-off-by: Liran Oz <lirano@mellanox.com>