### PR TITLE
issue: 910917 vma crashes after installed on RH7.3 inbox driver

### DIFF
--- a/src/vma/main.cpp
+++ b/src/vma/main.cpp
@@ -877,12 +877,12 @@ int do_global_ctors()
 	catch (const vma_exception& error) {
 		vlog_printf(VLOG_DETAILS, "Error: %s", error.what());
 		free_libvma_resources();
-		return 1;
+		return -1;
 	}
 	catch (const std::exception& error ) {
 		vlog_printf(VLOG_ERROR, "%s", error.what());
 		free_libvma_resources();
-		return 1;
+		return -1;
 	}
 	return 0;
 }

--- a/src/vma/main.cpp
+++ b/src/vma/main.cpp
@@ -869,7 +869,7 @@ static void do_global_ctors_helper()
 //	igmp_test();
 }
 
-void do_global_ctors()
+int do_global_ctors()
 {
 	try {
 		do_global_ctors_helper();
@@ -877,11 +877,14 @@ void do_global_ctors()
 	catch (const vma_exception& error) {
 		vlog_printf(VLOG_DETAILS, "Error: %s", error.what());
 		free_libvma_resources();
+		return 1;
 	}
 	catch (const std::exception& error ) {
 		vlog_printf(VLOG_ERROR, "%s", error.what());
 		free_libvma_resources();
+		return 1;
 	}
+	return 0;
 }
 
 void reset_globals()

--- a/src/vma/netlink/netlink_compatibility.cpp
+++ b/src/vma/netlink/netlink_compatibility.cpp
@@ -106,6 +106,7 @@ int nl_cache_mngr_compatible_add(struct nl_cache_mngr*	mngr, const char* name, c
 	int err = nl_cache_mngr_add(mngr, name, cb, data, result);
 	BULLSEYE_EXCLUDE_BLOCK_START
 	if (err) {
+		errno = ELIBEXEC;
 		nl_logerr("Fail to add to cache manager, error=%s", nl_geterror(err));
 	}
 	BULLSEYE_EXCLUDE_BLOCK_END
@@ -190,6 +191,7 @@ nl_cache_mngr* nl_cache_mngr_compatible_alloc(nl_socket_handle* handle, int prot
 int nl_cache_mngr_compatible_add(struct nl_cache_mngr*	mngr, const char* name, change_func_t cb, void*	, struct nl_cache** result){
 	*result = nl_cache_mngr_add(mngr, name, cb);
 	if (*result == NULL) {
+		errno = ELIBEXEC;
 		nl_logerr("Fail adding to cache manager, error=%d %s\n",
 			nl_get_errno(), nl_geterror());
 		return -1;

--- a/src/vma/sock/sock-redirect.cpp
+++ b/src/vma/sock/sock-redirect.cpp
@@ -94,6 +94,14 @@ void assign_dlsym(T &ptr, const char *name) {
 
 #define FD_MAP_SIZE 		(g_p_fd_collection ? g_p_fd_collection->get_fd_map_size() : 1024)
 
+#define DO_GLOBAL_CTORS() do { \
+	int __res = do_global_ctors(); \
+	if (__res) { \
+		vlog_printf(VLOG_ERROR, "vma failed to start errno: %m\n", errno); \
+		return -1; \
+	} \
+} while (0)
+
 #define GET_ORIG_FUNC(__name) \
 	if (!orig_os_api.__name) { \
 		dlerror(); \
@@ -507,7 +515,7 @@ int vma_get_socket_rings_fds(int fd, int *ring_fds, int ring_fds_sz)
 extern "C"
 int vma_add_conf_rule(char *config_line)
 {
-	do_global_ctors();
+	DO_GLOBAL_CTORS();
 
 	srdr_logdbg("adding conf rule: %s", config_line);
 
@@ -522,7 +530,7 @@ int vma_add_conf_rule(char *config_line)
 extern "C"
 int vma_thread_offload(int offload, pthread_t tid)
 {
-	do_global_ctors();
+	DO_GLOBAL_CTORS();
 
 	if (g_p_fd_collection) {
 		g_p_fd_collection->offloading_rule_change_thread(offload, tid);
@@ -541,7 +549,7 @@ NOT_IN_USE(fd);
 NOT_IN_USE(log_level);
 	return 0;
 #else
-	do_global_ctors();
+	DO_GLOBAL_CTORS();
 
 	if (g_p_fd_collection) {
 		g_p_fd_collection->statistics_print(fd, log_level::from_int(log_level));
@@ -572,7 +580,7 @@ int socket_internal(int __domain, int __type, int __protocol, bool check_offload
 	bool offload_sockets = (__type & 0xf) == SOCK_DGRAM || (__type & 0xf) == SOCK_STREAM;
 
 	if (offload_sockets)
-		do_global_ctors();
+		DO_GLOBAL_CTORS();
 
 	dbg_check_if_need_to_send_mcpkt();
 
@@ -1646,7 +1654,7 @@ void vma_epoll_create(int epfd, int size)
 extern "C"
 int epoll_create(int __size)
 {
-	do_global_ctors();
+	DO_GLOBAL_CTORS();
 
 	if (__size <= 0 ) {
 		vlog_printf(VLOG_DEBUG, "%s: invalid size (size=%d) - must be a positive integer\n", __func__, __size);
@@ -1668,7 +1676,7 @@ int epoll_create(int __size)
 extern "C"
 int epoll_create1(int __flags)
 {
-	do_global_ctors();
+	DO_GLOBAL_CTORS();
 
 	int epfd = orig_os_api.epoll_create1(__flags);
 	vlog_printf(VLOG_DEBUG, "ENTER: %s(flags=%d) = %d\n",__func__, __flags, epfd);
@@ -1803,7 +1811,7 @@ int pipe(int __filedes[2])
 	bool offload_pipe = safe_mce_sys().mce_spec == MCE_SPEC_29WEST_LBM_29 ||
 			    safe_mce_sys().mce_spec == MCE_SPEC_WOMBAT_FH_LBM_554;
 	if (offload_pipe)
-		do_global_ctors();
+		DO_GLOBAL_CTORS();
 
 	int ret = orig_os_api.pipe(__filedes);
 	vlog_printf(VLOG_DEBUG, MODULE_HDR_ENTRY "%s(fd[%d,%d]) = %d\n", __func__, __filedes[0], __filedes[1], ret);

--- a/src/vma/sock/sock-redirect.cpp
+++ b/src/vma/sock/sock-redirect.cpp
@@ -97,7 +97,8 @@ void assign_dlsym(T &ptr, const char *name) {
 #define DO_GLOBAL_CTORS() do { \
 	int __res = do_global_ctors(); \
 	if (__res) { \
-		vlog_printf(VLOG_ERROR, "vma failed to start errno: %m\n", errno); \
+		vlog_printf(VLOG_ERROR, "%s vma failed to start errno: %m\n", \
+			__FUNCTION__, errno); \
 		return -1; \
 	} \
 } while (0)

--- a/src/vma/sock/sock-redirect.h
+++ b/src/vma/sock/sock-redirect.h
@@ -172,7 +172,7 @@ extern iomux_stats_t* g_p_select_stats;
 extern iomux_stats_t* g_p_poll_stats;
 extern iomux_stats_t* g_p_epoll_stats;
 
-void do_global_ctors();
+int do_global_ctors();
 void reset_globals();
 void handle_close(int fd, bool cleanup = false, bool passthrough = false);
 


### PR DESCRIPTION
This change adds an error print when VMA failed to run do_global_ctors.
Before this change there was no way of knowing about this failure.
one of the reasons for this failure can be libnl compatabilty issues.

Signed-off-by: Rafi Wiener <rafiw@mellanox.com>