### PR TITLE
922411: fix using fork in vma

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -830,7 +830,7 @@ fi
 AM_CONDITIONAL([HAVE_LIBNL], [test "$have_libnl" = "yes"])
 
 AC_CHECK_LIB([rdmacm], [rdma_lib_reset],
-		[AC_DEFINE([RDMA_LIB_RESET], [1], [rdma_lib_reset enabled])], [])
+		[AC_DEFINE([DEFINED_RDMA_LIB_RESET], [1], [rdma_lib_reset enabled])], [])
 
 AC_CONFIG_FILES([
 		Makefile

--- a/configure.ac
+++ b/configure.ac
@@ -829,6 +829,9 @@ fi
 
 AM_CONDITIONAL([HAVE_LIBNL], [test "$have_libnl" = "yes"])
 
+AC_CHECK_LIB([rdmacm], [rdma_lib_reset],
+		[AC_DEFINE([RDMA_LIB_RESET], [1], [rdma_lib_reset enabled])], [])
+
 AC_CONFIG_FILES([
 		Makefile
 		src/Makefile

--- a/src/vma/sock/sock-redirect.cpp
+++ b/src/vma/sock/sock-redirect.cpp
@@ -2107,12 +2107,10 @@ pid_t fork(void)
 
 		safe_mce_sys().get_env_params();
 		vlog_start("VMA", safe_mce_sys().log_level, safe_mce_sys().log_filename, safe_mce_sys().log_details, safe_mce_sys().log_colors);
-#ifdef DEFINED_RDMA_LIB_RESET
-		if (rdma_lib_reset()) {
+		if (vma_rdma_lib_reset()) {
 			srdr_logerr("Child Process: rdma_lib_reset failed %m",
 					errno);
 		}
-#endif
 		srdr_logdbg_exit("Child Process: starting with %d", getpid());
 		g_is_forked_child = false;
 		sock_redirect_main();
@@ -2167,12 +2165,10 @@ int daemon(int __nochdir, int __noclose)
 
 		safe_mce_sys().get_env_params();
 		vlog_start("VMA", safe_mce_sys().log_level, safe_mce_sys().log_filename, safe_mce_sys().log_details, safe_mce_sys().log_colors);
-#ifdef DEFINED_RDMA_LIB_RESET
-		if (rdma_lib_reset()) {
+		if (vma_rdma_lib_reset()) {
 			srdr_logerr("Child Process: rdma_lib_reset failed %m",
 					errno);
 		}
-#endif
 		srdr_logdbg_exit("Child Process: starting with %d", getpid());
 		g_is_forked_child = false;
 		sock_redirect_main();

--- a/src/vma/sock/sock-redirect.cpp
+++ b/src/vma/sock/sock-redirect.cpp
@@ -2107,6 +2107,12 @@ pid_t fork(void)
 
 		safe_mce_sys().get_env_params();
 		vlog_start("VMA", safe_mce_sys().log_level, safe_mce_sys().log_filename, safe_mce_sys().log_details, safe_mce_sys().log_colors);
+#ifdef RDMA_LIB_RESET
+		if (rdma_lib_reset()) {
+			srdr_logerr("Child Process: rdma_lib_reset failed %m",
+					errmo);
+		}
+#endif
 		srdr_logdbg_exit("Child Process: starting with %d", getpid());
 		g_is_forked_child = false;
 		sock_redirect_main();

--- a/src/vma/sock/sock-redirect.cpp
+++ b/src/vma/sock/sock-redirect.cpp
@@ -2107,10 +2107,10 @@ pid_t fork(void)
 
 		safe_mce_sys().get_env_params();
 		vlog_start("VMA", safe_mce_sys().log_level, safe_mce_sys().log_filename, safe_mce_sys().log_details, safe_mce_sys().log_colors);
-#ifdef RDMA_LIB_RESET
+#ifdef DEFINED_RDMA_LIB_RESET
 		if (rdma_lib_reset()) {
 			srdr_logerr("Child Process: rdma_lib_reset failed %m",
-					errmo);
+					errno);
 		}
 #endif
 		srdr_logdbg_exit("Child Process: starting with %d", getpid());
@@ -2167,6 +2167,12 @@ int daemon(int __nochdir, int __noclose)
 
 		safe_mce_sys().get_env_params();
 		vlog_start("VMA", safe_mce_sys().log_level, safe_mce_sys().log_filename, safe_mce_sys().log_details, safe_mce_sys().log_colors);
+#ifdef DEFINED_RDMA_LIB_RESET
+		if (rdma_lib_reset()) {
+			srdr_logerr("Child Process: rdma_lib_reset failed %m",
+					errno);
+		}
+#endif
 		srdr_logdbg_exit("Child Process: starting with %d", getpid());
 		g_is_forked_child = false;
 		sock_redirect_main();

--- a/src/vma/util/verbs_extra.cpp
+++ b/src/vma/util/verbs_extra.cpp
@@ -314,3 +314,14 @@ int priv_ibv_query_flow_tag_supported(struct ibv_qp *qp, uint8_t port_num)
 	return res;
 }
 
+
+int vma_rdma_lib_reset() {
+#ifdef DEFINED_RDMA_LIB_RESET
+	vlog_printf(VLOG_DEBUG, "rdma_lib_reset called");
+	return rdma_lib_reset();
+#else
+	vlog_printf(VLOG_DEBUG, "rdma_lib_reset don't exists returning 0");
+	return 0;
+#endif
+}
+

--- a/src/vma/util/verbs_extra.h
+++ b/src/vma/util/verbs_extra.h
@@ -302,6 +302,16 @@ typedef struct ibv_exp_flow_spec_action_tag_dummy {}	vma_ibv_flow_spec_action_ta
 #endif //DEFINED_IBV_EXP_FLOW_TAG
 #endif
 
+#ifdef DEFINED_RDMA_LIB_RESET
+static inline int vma_rdma_lib_reset() {
+	return rdma_lib_reset();
+}
+#else
+static inline int vma_rdma_lib_reset() {
+	return 0;
+}
+#endif
+
 static inline void init_vma_ibv_cq_init_attr(vma_ibv_cq_init_attr* attr)
 {
 #ifdef DEFINED_IBV_EXP_CQ_TIMESTAMP

--- a/src/vma/util/verbs_extra.h
+++ b/src/vma/util/verbs_extra.h
@@ -302,15 +302,7 @@ typedef struct ibv_exp_flow_spec_action_tag_dummy {}	vma_ibv_flow_spec_action_ta
 #endif //DEFINED_IBV_EXP_FLOW_TAG
 #endif
 
-#ifdef DEFINED_RDMA_LIB_RESET
-static inline int vma_rdma_lib_reset() {
-	return rdma_lib_reset();
-}
-#else
-static inline int vma_rdma_lib_reset() {
-	return 0;
-}
-#endif
+int vma_rdma_lib_reset();
 
 static inline void init_vma_ibv_cq_init_attr(vma_ibv_cq_init_attr* attr)
 {


### PR DESCRIPTION
This fix uses the new rdmacm API to reset rdma context
and enable VMA to run in the child process

Signed-off-by: Rafi Wiener <rafiw@mellanox.com>