### PR TITLE
issue: 1006374 Tx path optimizations

### DIFF
--- a/src/vma/dev/cq_mgr.cpp
+++ b/src/vma/dev/cq_mgr.cpp
@@ -872,7 +872,7 @@ int cq_mgr::vma_poll_and_process_element_rx(mem_buf_desc_t **p_desc_lst)
 	}
 	else if (cqe_err) {
 		/* Return nothing in case error wc
-		 * It is difference with poll_and_process_helper_rx()
+		 * It is difference with poll_and_process_element_rx()
 		 */
 		mlx5_poll_and_process_error_element_rx(cqe_err, NULL);
 		*p_desc_lst = NULL;
@@ -897,7 +897,7 @@ int cq_mgr::vma_poll_and_process_element_rx(mem_buf_desc_t **p_desc_lst)
 }
 #endif // DEFINED_VMAPOLL
 
-int cq_mgr::poll_and_process_helper_rx(uint64_t* p_cq_poll_sn, void* pv_fd_ready_array)
+int cq_mgr::poll_and_process_element_rx(uint64_t* p_cq_poll_sn, void* pv_fd_ready_array)
 {
 	// Assume locked!!!
 	cq_logfuncall("");
@@ -991,7 +991,7 @@ int cq_mgr::poll_and_process_helper_rx(uint64_t* p_cq_poll_sn, void* pv_fd_ready
 #endif // DEFINED_VMAPOLL
 }
 
-int cq_mgr::poll_and_process_helper_tx(uint64_t* p_cq_poll_sn)
+int cq_mgr::poll_and_process_element_tx(uint64_t* p_cq_poll_sn)
 {
 	// Assume locked!!!
 	cq_logfuncall("");
@@ -1208,18 +1208,6 @@ inline volatile struct mlx5_cqe64 *cq_mgr::mlx5_get_cqe64(volatile struct mlx5_c
 	return cqe;
 }
 #endif // DEFINED_VMAPOLL
-
-int cq_mgr::poll_and_process_element_rx(uint64_t* p_cq_poll_sn, void* pv_fd_ready_array /*=NULL*/)
-{
-	cq_logfuncall("");
-	return poll_and_process_helper_rx(p_cq_poll_sn, pv_fd_ready_array);
-}
-
-int cq_mgr::poll_and_process_element_tx(uint64_t* p_cq_poll_sn)
-{
-	cq_logfuncall("");
-	return poll_and_process_helper_tx(p_cq_poll_sn);
-}
 
 #if _BullseyeCoverage
     #pragma BullseyeCoverage off
@@ -1536,9 +1524,9 @@ int cq_mgr::wait_for_notification_and_process_element(uint64_t* p_cq_poll_sn, vo
 
 			// Now try processing the ready element
 			if (m_b_is_rx) {
-				ret = poll_and_process_helper_rx(p_cq_poll_sn, pv_fd_ready_array);
+				ret = poll_and_process_element_rx(p_cq_poll_sn, pv_fd_ready_array);
 			} else {
-				ret = poll_and_process_helper_tx(p_cq_poll_sn);
+				ret = poll_and_process_element_tx(p_cq_poll_sn);
 			}
 		} ENDIF_VERBS_FAILURE;
 	}

--- a/src/vma/dev/cq_mgr.h
+++ b/src/vma/dev/cq_mgr.h
@@ -258,17 +258,11 @@ private:
 	mem_buf_desc_t*	process_cq_element_tx(vma_ibv_wc* p_wce);
 	mem_buf_desc_t*	process_cq_element_rx(vma_ibv_wc* p_wce);
 
-	/**
-	 * Helper function wrapping the poll and the process functionality in single call
-	 */
-	//a sub helper for poll_and_process_helper_rx in order to shorten the function
-	void		handle_tcp_ctl_packets(uint32_t rx_processed, void* pv_fd_ready_array);
 #ifdef DEFINED_VMAPOLL	
 	int		vma_poll_and_process_element_rx(mem_buf_desc_t **p_desc_lst);
 #endif // DEFINED_VMAPOLL	
-	int		poll_and_process_helper_rx(uint64_t* p_cq_poll_sn, void* pv_fd_ready_array = NULL);
-	int		poll_and_process_helper_tx(uint64_t* p_cq_poll_sn);
 
+	void		handle_tcp_ctl_packets(uint32_t rx_processed, void* pv_fd_ready_array);
 	inline void	compensate_qp_poll_failed();
 	// Returns true if the given buffer was used,
 	//false if the given buffer was not used.

--- a/src/vma/dev/qp_mgr.cpp
+++ b/src/vma/dev/qp_mgr.cpp
@@ -67,12 +67,14 @@ qp_mgr::qp_mgr(const ring_simple* p_ring, const ib_ctx_handler* p_context, const
 	m_n_sysvar_rx_num_wr_to_post_recv(safe_mce_sys().rx_num_wr_to_post_recv),
 	m_n_sysvar_tx_num_wr_to_signal(safe_mce_sys().tx_num_wr_to_signal),
 	m_n_sysvar_rx_prefetch_bytes_before_poll(safe_mce_sys().rx_prefetch_bytes_before_poll),
-	m_curr_rx_wr(0), m_last_posted_rx_wr_id(0), m_n_unsignaled_count(0), m_n_tx_count(0),
+	m_curr_rx_wr(0), m_last_posted_rx_wr_id(0),
 	m_p_last_tx_mem_buf_desc(NULL), m_p_prev_rx_desc_pushed(NULL),
 	m_n_ip_id_base(0), m_n_ip_id_offset(0)
 {
 	m_ibv_rx_sg_array = new ibv_sge[m_n_sysvar_rx_num_wr_to_post_recv];
 	m_ibv_rx_wr_array = new ibv_recv_wr[m_n_sysvar_rx_num_wr_to_post_recv];
+	set_unsignaled_count();
+
 #ifdef DEFINED_VMAPOLL
 	m_rq_wqe_counter = 0;
 	m_sq_wqe_counter = 0;
@@ -248,7 +250,7 @@ void qp_mgr::up()
 	release_tx_buffers();
 
 	/* clean any link to completions with error we might have */
-	m_n_unsignaled_count = 0;
+	set_unsignaled_count();
 	m_p_last_tx_mem_buf_desc = NULL;
 
 	modify_qp_to_ready_state();
@@ -410,7 +412,7 @@ void qp_mgr::trigger_completion_for_all_sent_packets()
 		qp_logdbg("IBV_SEND_SIGNALED");
 
 		// Close the Tx unsignaled send list
-		m_n_unsignaled_count = 0;
+		set_unsignaled_count();
 		m_p_last_tx_mem_buf_desc = NULL;
 
 		if (!m_p_ring->m_tx_num_wr_free) {
@@ -637,39 +639,12 @@ void qp_mgr::mlx5_init_sq()
 int qp_mgr::send(vma_ibv_send_wr* p_send_wqe)
 {
 	mem_buf_desc_t* p_mem_buf_desc = (mem_buf_desc_t *)p_send_wqe->wr_id;
-	bool is_signaled;
-	int ret;
 
-#ifdef DEFINED_VMAPOLL
-	is_signaled = ++m_n_unsignaled_count >= NUM_TX_WRE_TO_SIGNAL_MAX;	
-#else
-	is_signaled = ++m_n_unsignaled_count >= m_n_sysvar_tx_num_wr_to_signal;
-#endif
-
-
-	// Link this new mem_buf_desc to the previous one sent
-	p_mem_buf_desc->p_next_desc = m_p_last_tx_mem_buf_desc;
-
-	if (is_signaled) {
-		m_n_unsignaled_count = 0;
-		m_p_last_tx_mem_buf_desc = NULL;
 #ifndef DEFINED_VMAPOLL	// not defined
+	if (!m_n_unsignaled_count) {
 		vma_send_wr_send_flags(*p_send_wqe) = (vma_ibv_send_flags)(vma_send_wr_send_flags(*p_send_wqe) | VMA_IBV_SEND_SIGNALED);
-#endif		
-		qp_logfunc("IBV_SEND_SIGNALED");
-
-		if (m_p_ahc_head) { // need to destroy ah
-			//save the orig owner
-			qp_logdbg("mark with signal!");
-			m_p_ahc_tail->m_next_owner = p_mem_buf_desc->p_desc_owner;
-			p_mem_buf_desc->p_desc_owner = m_p_ahc_head;
-			m_p_ahc_head = m_p_ahc_tail = NULL;
-		}
 	}
-	else {
-		m_p_last_tx_mem_buf_desc = p_mem_buf_desc;
-	}
-	++m_n_tx_count;
+#endif
 
 #ifdef VMA_TIME_MEASURE
 	TAKE_T_TX_POST_SEND_START;
@@ -706,7 +681,22 @@ int qp_mgr::send(vma_ibv_send_wr* p_send_wqe)
 	TAKE_T_TX_POST_SEND_END;
 #endif
 
-	if (is_signaled) {
+	// Link this new mem_buf_desc to the previous one sent
+	p_mem_buf_desc->p_next_desc = m_p_last_tx_mem_buf_desc;
+
+	if (!m_n_unsignaled_count--) {
+		int ret;
+
+		set_unsignaled_count();
+		m_p_last_tx_mem_buf_desc = NULL;
+
+		if (m_p_ahc_head) { // need to destroy ah
+			//save the orig owner
+			qp_logdbg("mark with signal!");
+			m_p_ahc_tail->m_next_owner = p_mem_buf_desc->p_desc_owner;
+			p_mem_buf_desc->p_desc_owner = m_p_ahc_head;
+			m_p_ahc_head = m_p_ahc_tail = NULL;
+		}
 
 		// Clear the SINGAL request
 #ifndef DEFINED_VMAPOLL	// not defined
@@ -715,7 +705,6 @@ int qp_mgr::send(vma_ibv_send_wr* p_send_wqe)
 
 		// Poll the Tx CQ
 		uint64_t dummy_poll_sn = 0;
-		m_n_tx_count = 0;
 		ret = m_p_cq_mgr_tx->poll_and_process_element_tx(&dummy_poll_sn);
 		BULLSEYE_EXCLUDE_BLOCK_START
 		if (ret < 0) {
@@ -723,12 +712,20 @@ int qp_mgr::send(vma_ibv_send_wr* p_send_wqe)
 		}
 		BULLSEYE_EXCLUDE_BLOCK_END
 		qp_logfunc("polling succeeded on tx cq_mgr (%d wce)", ret);
+	} else {
+		m_p_last_tx_mem_buf_desc = p_mem_buf_desc;
 	}
 
 	return 0;
-
 }
 
+inline void qp_mgr::set_unsignaled_count() {
+#ifdef DEFINED_VMAPOLL
+	m_n_unsignaled_count = NUM_TX_WRE_TO_SIGNAL_MAX - 1;
+#else
+	m_n_unsignaled_count = m_n_sysvar_tx_num_wr_to_signal - 1;
+#endif
+}
 
 void qp_mgr_eth::modify_qp_to_ready_state()
 {

--- a/src/vma/dev/qp_mgr.h
+++ b/src/vma/dev/qp_mgr.h
@@ -197,7 +197,6 @@ protected:
 
 	// send wr
 	uint32_t		m_n_unsignaled_count;
-	uint32_t		m_n_tx_count;
 	mem_buf_desc_t*		m_p_last_tx_mem_buf_desc; // Remembered so we can list several mem_buf_desc_t on a single notification request
 
 	mem_buf_desc_t*		m_p_prev_rx_desc_pushed;
@@ -210,6 +209,7 @@ protected:
 
 	int 			configure(struct ibv_comp_channel* p_rx_comp_event_channel);
 	virtual int		prepare_ibv_qp(vma_ibv_qp_init_attr& qp_init_attr) = 0;
+	inline void		set_unsignaled_count();
 };
 
 

--- a/src/vma/dev/ring.h
+++ b/src/vma/dev/ring.h
@@ -313,7 +313,7 @@ public:
 	virtual void		mem_buf_desc_return_to_owner_tx(mem_buf_desc_t* p_mem_buf_desc) = 0;
 	virtual void		mem_buf_desc_return_single_to_owner_tx(mem_buf_desc_t* p_mem_buf_desc) = 0;
 
-	virtual void		inc_ring_stats(ring_user_id_t id) = 0;
+	virtual void		inc_tx_retransmissions(ring_user_id_t id) = 0;
 	virtual bool		is_member(mem_buf_desc_owner* rng) = 0;
 	virtual bool		is_active_member(mem_buf_desc_owner* rng, ring_user_id_t id) = 0;
 	ring*			get_parent() { return m_parent; };

--- a/src/vma/dev/ring_bond.cpp
+++ b/src/vma/dev/ring_bond.cpp
@@ -383,11 +383,11 @@ int ring_bond::request_notification(cq_type_t cq_type, uint64_t poll_sn)
 	return ret;
 }
 
-void ring_bond::inc_ring_stats(ring_user_id_t id)
+void ring_bond::inc_tx_retransmissions(ring_user_id_t id)
 {
 	ring_simple* active_ring = m_active_rings[id];
 	if (likely(active_ring))
-		active_ring->inc_ring_stats(id);
+		active_ring->inc_tx_retransmissions(id);
 }
 
 bool ring_bond::reclaim_recv_buffers(descq_t *rx_reuse)

--- a/src/vma/dev/ring_bond.h
+++ b/src/vma/dev/ring_bond.h
@@ -57,7 +57,7 @@ public:
 	virtual void		restart(ring_resource_creation_info_t* p_ring_info);
 	virtual mem_buf_desc_t* mem_buf_tx_get(ring_user_id_t id, bool b_block, int n_num_mem_bufs = 1);
 	virtual int		mem_buf_tx_release(mem_buf_desc_t* p_mem_buf_desc_list, bool b_accounting, bool trylock = false);
-	virtual void		inc_ring_stats(ring_user_id_t id);
+	virtual void		inc_tx_retransmissions(ring_user_id_t id);
 	virtual void		send_ring_buffer(ring_user_id_t id, vma_ibv_send_wr* p_send_wqe, bool b_block);
 	virtual void		send_lwip_buffer(ring_user_id_t id, vma_ibv_send_wr* p_send_wqe, bool b_block);
 	virtual void		mem_buf_desc_return_single_to_owner_tx(mem_buf_desc_t* p_mem_buf_desc);

--- a/src/vma/dev/ring_simple.cpp
+++ b/src/vma/dev/ring_simple.cpp
@@ -2180,7 +2180,7 @@ bool ring_simple::is_up() {
 	return m_up;
 }
 
-void ring_simple::inc_ring_stats(ring_user_id_t id) {
+void ring_simple::inc_tx_retransmissions(ring_user_id_t id) {
 	NOT_IN_USE(id);
 	m_p_ring_stat->n_tx_retransmits++;
 }

--- a/src/vma/dev/ring_simple.cpp
+++ b/src/vma/dev/ring_simple.cpp
@@ -1459,7 +1459,7 @@ int ring_simple::request_notification(cq_type_t cq_type, uint64_t poll_sn)
 int ring_simple::poll_and_process_element_rx(uint64_t* p_cq_poll_sn, void* pv_fd_ready_array /*NULL*/)
 {
 	int ret = 0;
-	RING_TRY_LOCK_RUN_AND_UPDATE_RET(m_lock_ring_rx, m_p_cq_mgr_rx->poll_and_process_helper_rx(p_cq_poll_sn, pv_fd_ready_array));
+	RING_TRY_LOCK_RUN_AND_UPDATE_RET(m_lock_ring_rx, m_p_cq_mgr_rx->poll_and_process_element_rx(p_cq_poll_sn, pv_fd_ready_array));
 	return ret;
 }
 

--- a/src/vma/dev/ring_simple.cpp
+++ b/src/vma/dev/ring_simple.cpp
@@ -1774,8 +1774,8 @@ inline int ring_simple::send_buffer(vma_ibv_send_wr* p_send_wqe, bool b_block)
 {
 	int ret = 0;
 	if (likely(m_tx_num_wr_free > 0)) {
-		--m_tx_num_wr_free;
 		ret = m_p_qp_mgr->send(p_send_wqe);
+		--m_tx_num_wr_free;
 	} else if (is_available_qp_wr(b_block)) {
 		ret = m_p_qp_mgr->send(p_send_wqe);
 	} else {
@@ -1800,25 +1800,21 @@ bool ring_simple::get_hw_dummy_send_support(ring_user_id_t id, vma_ibv_send_wr* 
 void ring_simple::send_ring_buffer(ring_user_id_t id, vma_ibv_send_wr* p_send_wqe, bool b_block)
 {
 	NOT_IN_USE(id);
-	m_lock_ring_tx.lock();
+	auto_unlocker lock(m_lock_ring_tx);
 	p_send_wqe->sg_list[0].lkey = m_tx_lkey;	// The ring keeps track of the current device lkey (In case of bonding event...)
 	int ret = send_buffer(p_send_wqe, b_block);
 	send_status_handler(ret, p_send_wqe);
-	m_lock_ring_tx.unlock();
-	return;
 }
 
 void ring_simple::send_lwip_buffer(ring_user_id_t id, vma_ibv_send_wr* p_send_wqe, bool b_block)
 {
 	NOT_IN_USE(id);
-	m_lock_ring_tx.lock();
+	auto_unlocker lock(m_lock_ring_tx);
 	p_send_wqe->sg_list[0].lkey = m_tx_lkey; // The ring keeps track of the current device lkey (In case of bonding event...)
 	mem_buf_desc_t* p_mem_buf_desc = (mem_buf_desc_t*)(p_send_wqe->wr_id);
 	p_mem_buf_desc->lwip_pbuf.pbuf.ref++;
 	int ret = send_buffer(p_send_wqe, b_block);
 	send_status_handler(ret, p_send_wqe);
-	m_lock_ring_tx.unlock();
-	return;
 }
 
 void ring_simple::flow_udp_uc_del_all()
@@ -1997,10 +1993,10 @@ mem_buf_desc_t* ring_simple::get_tx_buffers(uint32_t n_num_mem_bufs)
 		if (request_more_tx_buffers(count)) {
 			m_tx_num_bufs += count;
 		}
-	}
 
-	if (unlikely(m_tx_pool.size() < n_num_mem_bufs)) {
-		return head;
+		if (unlikely(m_tx_pool.size() < n_num_mem_bufs)) {
+			return head;
+		}
 	}
 
 	head = m_tx_pool.get_and_pop_back();

--- a/src/vma/dev/ring_simple.h
+++ b/src/vma/dev/ring_simple.h
@@ -73,7 +73,7 @@ public:
 	void			stop_active_qp_mgr();
 	virtual mem_buf_desc_t*	mem_buf_tx_get(ring_user_id_t id, bool b_block, int n_num_mem_bufs = 1);
 	virtual int		mem_buf_tx_release(mem_buf_desc_t* p_mem_buf_desc_list, bool b_accounting, bool trylock = false);
-	virtual void		inc_ring_stats(ring_user_id_t id);
+	virtual void		inc_tx_retransmissions(ring_user_id_t id);
 	virtual void		send_ring_buffer(ring_user_id_t id, vma_ibv_send_wr* p_send_wqe, bool b_block);
 	virtual void		send_lwip_buffer(ring_user_id_t id, vma_ibv_send_wr* p_send_wqe, bool b_block);
 	virtual void		mem_buf_desc_return_single_to_owner_tx(mem_buf_desc_t* p_mem_buf_desc);

--- a/src/vma/lwip/tcp.c
+++ b/src/vma/lwip/tcp.c
@@ -1134,6 +1134,7 @@ void tcp_pcb_init (struct tcp_pcb* pcb, u8_t prio)
 
 	pcb->keep_cnt_sent = 0;
 	pcb->enable_ts_opt = enable_ts_option;
+	pcb->seg_alloc = NULL;
 	pcb->pbuf_alloc = NULL;
 }
 
@@ -1166,6 +1167,11 @@ tcp_tx_pbuf_alloc(struct tcp_pcb * pcb, u16_t length, pbuf_type type)
 
 void tcp_tx_preallocted_buffers_free(struct tcp_pcb * pcb)
 {
+	if (pcb->seg_alloc) {
+		tcp_tx_seg_free(pcb, pcb->seg_alloc);
+		pcb->seg_alloc = NULL;
+	}
+
 	if (pcb->pbuf_alloc) {
 		tcp_tx_pbuf_free(pcb, pcb->pbuf_alloc);
 		pcb->pbuf_alloc = NULL;

--- a/src/vma/lwip/tcp.c
+++ b/src/vma/lwip/tcp.c
@@ -1145,6 +1145,7 @@ tcp_tx_pbuf_alloc(struct tcp_pcb * pcb, u16_t length, pbuf_type type)
 
 	if (!pcb->pbuf_alloc) {
 
+		// pbuf_alloc is not valid, we should allocate a new pbuf.
 		p = external_tcp_tx_pbuf_alloc(pcb);
 		if (!p) return NULL;
 
@@ -1155,6 +1156,7 @@ tcp_tx_pbuf_alloc(struct tcp_pcb * pcb, u16_t length, pbuf_type type)
 		/* set flags */
 		p->flags = 0;
 	} else {
+		// pbuf_alloc is valid, we dont need to allocate a new pbuf element.
 		p = pcb->pbuf_alloc;
 		pcb->pbuf_alloc = NULL;
 	}
@@ -1165,6 +1167,7 @@ tcp_tx_pbuf_alloc(struct tcp_pcb * pcb, u16_t length, pbuf_type type)
 	return p;
 }
 
+// Release preallocated buffers
 void tcp_tx_preallocted_buffers_free(struct tcp_pcb * pcb)
 {
 	if (pcb->seg_alloc) {

--- a/src/vma/lwip/tcp.h
+++ b/src/vma/lwip/tcp.h
@@ -364,12 +364,13 @@ struct tcp_pcb {
   struct tcp_seg *unsent;   /* Unsent (queued) segments. */
   struct tcp_seg *last_unsent;   /* Last unsent (queued) segment. */
   struct tcp_seg *unacked;  /* Sent but unacknowledged segments. */
-  struct tcp_seg *last_unacked;  /* Lase element in unacknowledged segments list. */
+  struct tcp_seg *last_unacked;  /* Last element in unacknowledged segments list. */
 #if TCP_QUEUE_OOSEQ  
   struct tcp_seg *ooseq;    /* Received out of sequence segments. */
 #endif /* TCP_QUEUE_OOSEQ */
 
   struct pbuf *refused_data; /* Data previously received but not yet taken by upper layer */
+  struct pbuf *pbuf_alloc; /* Available pbuf element for use */
 
 #if LWIP_CALLBACK_API
   /* Function to be called when more send buffer space is available. */

--- a/src/vma/lwip/tcp.h
+++ b/src/vma/lwip/tcp.h
@@ -370,6 +370,7 @@ struct tcp_pcb {
 #endif /* TCP_QUEUE_OOSEQ */
 
   struct pbuf *refused_data; /* Data previously received but not yet taken by upper layer */
+  struct tcp_seg *seg_alloc; /* Available tcp_seg element for use */
   struct pbuf *pbuf_alloc; /* Available pbuf element for use */
 
 #if LWIP_CALLBACK_API

--- a/src/vma/lwip/tcp.h
+++ b/src/vma/lwip/tcp.h
@@ -503,6 +503,10 @@ void             tcp_abort (struct tcp_pcb *pcb);
 err_t            tcp_close   (struct tcp_pcb *pcb);
 err_t            tcp_shutdown(struct tcp_pcb *pcb, int shut_rx, int shut_tx);
 
+/* Flags for "apiflags" parameter in tcp_write */
+#define TCP_WRITE_FLAG_COPY 0x01
+#define TCP_WRITE_FLAG_MORE 0x02
+
 err_t            tcp_write   (struct tcp_pcb *pcb, const void *dataptr, u32_t len,
                               u8_t is_dummy);
 

--- a/src/vma/lwip/tcp.h
+++ b/src/vma/lwip/tcp.h
@@ -501,12 +501,8 @@ void             tcp_abort (struct tcp_pcb *pcb);
 err_t            tcp_close   (struct tcp_pcb *pcb);
 err_t            tcp_shutdown(struct tcp_pcb *pcb, int shut_rx, int shut_tx);
 
-/* Flags for "apiflags" parameter in tcp_write */
-#define TCP_WRITE_FLAG_COPY 0x01
-#define TCP_WRITE_FLAG_MORE 0x02
-
 err_t            tcp_write   (struct tcp_pcb *pcb, const void *dataptr, u32_t len,
-                              u8_t apiflags, u8_t is_dummy);
+                              u8_t is_dummy);
 
 void             tcp_setprio (struct tcp_pcb *pcb, u8_t prio);
 

--- a/src/vma/lwip/tcp_impl.h
+++ b/src/vma/lwip/tcp_impl.h
@@ -60,7 +60,8 @@ void             L3_level_tcp_input   (struct pbuf *p, struct tcp_pcb *pcb);
 /* Used within the TCP code only: */
 struct tcp_pcb * tcp_alloc   (u8_t prio);
 struct pbuf *    tcp_tx_pbuf_alloc(struct tcp_pcb * pcb, u16_t length, pbuf_type type);
-void		 tcp_tx_pbuf_free(struct tcp_pcb * pcb, struct pbuf * pbuf);
+void             tcp_tx_preallocted_buffers_free(struct tcp_pcb * pcb);
+void             tcp_tx_pbuf_free(struct tcp_pcb * pcb, struct pbuf * pbuf);
 void             tcp_abandon (struct tcp_pcb *pcb, int reset);
 err_t            tcp_send_empty_ack(struct tcp_pcb *pcb);
 void             tcp_rexmit  (struct tcp_pcb *pcb);

--- a/src/vma/lwip/tcp_out.c
+++ b/src/vma/lwip/tcp_out.c
@@ -174,30 +174,39 @@ tcp_create_segment(struct tcp_pcb *pcb, struct pbuf *p, u8_t flags, u32_t seqno,
   struct tcp_seg *seg;
   u8_t optlen = LWIP_TCP_OPT_LENGTH(optflags);
 
-#if LWIP_3RD_PARTY_BUFS
-  if ((seg = external_tcp_seg_alloc(pcb)) == NULL) {
-#else
-  if ((seg = (struct tcp_seg *)memp_malloc(MEMP_TCP_SEG)) == NULL) {
-#endif
-    LWIP_DEBUGF(TCP_OUTPUT_DEBUG | 2, ("tcp_create_segment: no memory.\n"));
-    tcp_tx_pbuf_free(pcb, p);
-    return NULL;
+  if (!pcb->seg_alloc) {
+    if ((seg = external_tcp_seg_alloc(pcb)) == NULL) {
+      LWIP_DEBUGF(TCP_OUTPUT_DEBUG | 2, ("tcp_create_segment: no memory.\n"));
+      tcp_tx_pbuf_free(pcb, p);
+      return NULL;
+    }
+
+    seg->next = NULL;
+#if TCP_OVERSIZE_DBGCHECK
+    seg->oversize_left = 0;
+#endif /* TCP_OVERSIZE_DBGCHECK */
+#if TCP_CHECKSUM_ON_COPY
+    seg->chksum = 0;
+    seg->chksum_swapped = 0;
+    /* check optflags */
+    LWIP_ASSERT("invalid optflags passed: TF_SEG_DATA_CHECKSUMMED",
+              (optflags & TF_SEG_DATA_CHECKSUMMED) == 0);
+#endif /* TCP_CHECKSUM_ON_COPY */
+
+    if (p == NULL) {
+      // Fetch tcp segment for next request
+      seg->p = NULL;
+      return seg;
+    }
+  } else {
+    seg = pcb->seg_alloc;
+    pcb->seg_alloc = NULL;
   }
+
   seg->flags = optflags;
-  seg->next = NULL;
   seg->p = p;
   seg->dataptr = p->payload;
   seg->len = p->tot_len - optlen;
-#if TCP_OVERSIZE_DBGCHECK
-  seg->oversize_left = 0;
-#endif /* TCP_OVERSIZE_DBGCHECK */
-#if TCP_CHECKSUM_ON_COPY
-  seg->chksum = 0;
-  seg->chksum_swapped = 0;
-  /* check optflags */
-  LWIP_ASSERT("invalid optflags passed: TF_SEG_DATA_CHECKSUMMED",
-              (optflags & TF_SEG_DATA_CHECKSUMMED) == 0);
-#endif /* TCP_CHECKSUM_ON_COPY */
   seg->seqno = seqno;
 
   /* build TCP header */
@@ -1136,6 +1145,12 @@ tcp_output(struct tcp_pcb *pcb)
 #endif /* TCP_OVERSIZE */
 
   pcb->flags &= ~TF_NAGLEMEMERR;
+
+  // Fetch buffers for the next packet.
+  if (!pcb->seg_alloc) {
+	  // Fetch tcp segment for the next packet.
+	  pcb->seg_alloc = tcp_create_segment(pcb, NULL, 0, 0, 0);
+  }
 
   if (!pcb->pbuf_alloc) {
 	  // Fetch pbuf for the next packet.

--- a/src/vma/lwip/tcp_out.c
+++ b/src/vma/lwip/tcp_out.c
@@ -466,7 +466,7 @@ tcp_write(struct tcp_pcb *pcb, const void *arg, u32_t len, u8_t is_dummy)
        * can use PBUF_RAW here since the data appears in the middle of
        * a segment. A header will never be prepended. */
       /* Data is copied */
-      if ((concat_p = tcp_pbuf_prealloc(seglen, space, &oversize, pcb, 1, 1)) == NULL) {
+      if ((concat_p = tcp_pbuf_prealloc(seglen, space, &oversize, pcb, TCP_WRITE_FLAG_MORE, 1)) == NULL) {
     	  LWIP_DEBUGF(TCP_OUTPUT_DEBUG | 2,
     			  ("tcp_write : could not allocate memory for pbuf copy size %"U16_F"\n",
     					  seglen));
@@ -507,7 +507,7 @@ tcp_write(struct tcp_pcb *pcb, const void *arg, u32_t len, u8_t is_dummy)
 
     /* If copy is set, memory should be allocated and data copied
      * into pbuf */
-    if ((p = tcp_pbuf_prealloc(seglen + optlen, mss_local, &oversize, pcb, 1, queue == NULL)) == NULL) {
+    if ((p = tcp_pbuf_prealloc(seglen + optlen, mss_local, &oversize, pcb, TCP_WRITE_FLAG_MORE, queue == NULL)) == NULL) {
     	LWIP_DEBUGF(TCP_OUTPUT_DEBUG | 2, ("tcp_write : could not allocate memory for pbuf copy size %"U16_F"\n", seglen));
     	goto memerr;
     }

--- a/src/vma/lwip/tcp_out.c
+++ b/src/vma/lwip/tcp_out.c
@@ -175,6 +175,7 @@ tcp_create_segment(struct tcp_pcb *pcb, struct pbuf *p, u8_t flags, u32_t seqno,
   u8_t optlen = LWIP_TCP_OPT_LENGTH(optflags);
 
   if (!pcb->seg_alloc) {
+    // seg_alloc is not valid, we should allocate a new segment.
     if ((seg = external_tcp_seg_alloc(pcb)) == NULL) {
       LWIP_DEBUGF(TCP_OUTPUT_DEBUG | 2, ("tcp_create_segment: no memory.\n"));
       tcp_tx_pbuf_free(pcb, p);
@@ -194,11 +195,12 @@ tcp_create_segment(struct tcp_pcb *pcb, struct pbuf *p, u8_t flags, u32_t seqno,
 #endif /* TCP_CHECKSUM_ON_COPY */
 
     if (p == NULL) {
-      // Fetch tcp segment for next request
+      // Request a new segment in order to update seg_alloc for the next packet.
       seg->p = NULL;
       return seg;
     }
   } else {
+    // seg_alloc is valid, we dont need to allocate a new segment element.
     seg = pcb->seg_alloc;
     pcb->seg_alloc = NULL;
   }

--- a/src/vma/lwip/tcp_out.c
+++ b/src/vma/lwip/tcp_out.c
@@ -1136,6 +1136,12 @@ tcp_output(struct tcp_pcb *pcb)
 #endif /* TCP_OVERSIZE */
 
   pcb->flags &= ~TF_NAGLEMEMERR;
+
+  if (!pcb->pbuf_alloc) {
+	  // Fetch pbuf for the next packet.
+	  pcb->pbuf_alloc = tcp_tx_pbuf_alloc(pcb, 0, PBUF_RAM);
+  }
+
   return ERR_OK;
 }
 

--- a/src/vma/proto/dst_entry.cpp
+++ b/src/vma/proto/dst_entry.cpp
@@ -76,6 +76,7 @@ dst_entry::~dst_entry()
 	}
 
 	if (m_p_ring) {
+		// m_p_tx_mem_buf_desc_head will always be NULL for TCP.
 		if (m_p_tx_mem_buf_desc_head) {
 			m_p_ring->mem_buf_tx_release(m_p_tx_mem_buf_desc_head, true);
 			m_p_tx_mem_buf_desc_head = NULL;

--- a/src/vma/proto/dst_entry.cpp
+++ b/src/vma/proto/dst_entry.cpp
@@ -51,7 +51,8 @@
 dst_entry::dst_entry(in_addr_t dst_ip, uint16_t dst_port, uint16_t src_port, int owner_fd):
 	m_dst_ip(dst_ip), m_dst_port(dst_port), m_src_port(src_port), m_bound_ip(0),
 	m_so_bindtodevice_ip(0), m_route_src_ip(0), m_pkt_src_ip(0), m_ring_alloc_logic(owner_fd, this), 
-	m_p_tx_mem_buf_desc_list(NULL), m_b_tx_mem_buf_desc_list_pending(false), m_id(0)
+	m_p_tx_mem_buf_desc_head(NULL), m_p_tx_mem_buf_desc_list(NULL), m_b_tx_mem_buf_desc_list_pending(false),
+	m_id(0)
 {
 	dst_logdbg("dst:%s:%d src: %d", m_dst_ip.to_str().c_str(), ntohs(m_dst_port), ntohs(m_src_port));
 	init_members();
@@ -75,6 +76,11 @@ dst_entry::~dst_entry()
 	}
 
 	if (m_p_ring) {
+		if (m_p_tx_mem_buf_desc_head) {
+			m_p_ring->mem_buf_tx_release(m_p_tx_mem_buf_desc_head, true);
+			m_p_tx_mem_buf_desc_head = NULL;
+		}
+
 		if (m_p_tx_mem_buf_desc_list) {
 			m_p_ring->mem_buf_tx_release(m_p_tx_mem_buf_desc_list, true);
 			m_p_tx_mem_buf_desc_list = NULL;
@@ -319,6 +325,10 @@ bool dst_entry::release_ring()
 	bool ret_val = false;
 	if (m_p_net_dev_val) {
 		if (m_p_ring) {
+			if (m_p_tx_mem_buf_desc_head) {
+				m_p_ring->mem_buf_tx_release(m_p_tx_mem_buf_desc_head, true);
+				m_p_tx_mem_buf_desc_head = NULL;
+			}
 			if (m_p_tx_mem_buf_desc_list) {
 				m_p_ring->mem_buf_tx_release(m_p_tx_mem_buf_desc_list, true);
 				m_p_tx_mem_buf_desc_list = NULL;
@@ -560,8 +570,14 @@ bool dst_entry::prepare_to_send(bool skip_rules, bool is_connect)
 								     m_dst_ip.get_in_addr(),
 								     m_src_port,
 								     m_dst_port);
-					m_p_ring->mem_buf_tx_release(m_p_tx_mem_buf_desc_list, true);
-					m_p_tx_mem_buf_desc_list = NULL;
+					if (m_p_tx_mem_buf_desc_head) {
+						m_p_ring->mem_buf_tx_release(m_p_tx_mem_buf_desc_head, true);
+						m_p_tx_mem_buf_desc_head = NULL;
+					}
+					if (m_p_tx_mem_buf_desc_list) {
+						m_p_ring->mem_buf_tx_release(m_p_tx_mem_buf_desc_list, true);
+						m_p_tx_mem_buf_desc_list = NULL;
+					}
 					resolved = true;
 				}
 			}
@@ -634,11 +650,18 @@ void dst_entry::do_ring_migration(lock_base& socket_lock)
 	m_max_inline = m_p_ring->get_max_tx_inline();
 	m_max_inline = std::min(m_max_inline, m_p_net_dev_val->get_mtu() + (uint32_t)m_header.m_transport_header_len);
 
+	mem_buf_desc_t* tmp_head = m_p_tx_mem_buf_desc_head;
+	m_p_tx_mem_buf_desc_head = NULL;
+
 	mem_buf_desc_t* tmp_list = m_p_tx_mem_buf_desc_list;
 	m_p_tx_mem_buf_desc_list = NULL;
 
 	m_slow_path_lock.unlock();
 	socket_lock.unlock();
+
+	if (tmp_head) {
+		old_ring->mem_buf_tx_release(tmp_head, true);
+	}
 
 	if (tmp_list) {
 		old_ring->mem_buf_tx_release(tmp_list, true);
@@ -724,15 +747,21 @@ bool dst_entry::alloc_neigh_val(transport_type_t tranport)
 
 void dst_entry::return_buffers_pool()
 {
-	if (m_p_tx_mem_buf_desc_list == NULL) {
+	bool pending = true;
+	if (!m_p_tx_mem_buf_desc_head && !m_p_tx_mem_buf_desc_list) {
 		return;
 	}
 
-	if (m_b_tx_mem_buf_desc_list_pending && m_p_ring &&
-		m_p_ring->mem_buf_tx_release(m_p_tx_mem_buf_desc_list, true, true)) {
-		m_p_tx_mem_buf_desc_list = NULL;
-		set_tx_buff_list_pending(false);
-	} else {
-		set_tx_buff_list_pending(true);
+	if (m_b_tx_mem_buf_desc_list_pending && m_p_ring) {
+		if (m_p_tx_mem_buf_desc_head && m_p_ring->mem_buf_tx_release(m_p_tx_mem_buf_desc_head, true, true)) {
+			m_p_tx_mem_buf_desc_head = NULL;
+			pending = false;
+		}
+		if (m_p_tx_mem_buf_desc_list && m_p_ring->mem_buf_tx_release(m_p_tx_mem_buf_desc_list, true, true)) {
+			m_p_tx_mem_buf_desc_list = NULL;
+			pending = false;
+		}
 	}
+
+	set_tx_buff_list_pending(pending);
 }

--- a/src/vma/proto/dst_entry.h
+++ b/src/vma/proto/dst_entry.h
@@ -122,6 +122,7 @@ protected:
 	bool 			m_b_force_os;
 	ring*			m_p_ring;
 	ring_allocation_logic_tx m_ring_alloc_logic;
+	mem_buf_desc_t* 	m_p_tx_mem_buf_desc_head;
 	mem_buf_desc_t* 	m_p_tx_mem_buf_desc_list;
 	int			m_b_tx_mem_buf_desc_list_pending;
 	header 			m_header;

--- a/src/vma/proto/dst_entry_tcp.cpp
+++ b/src/vma/proto/dst_entry_tcp.cpp
@@ -182,6 +182,7 @@ ssize_t dst_entry_tcp::fast_send(const struct iovec* p_iov, const ssize_t sz_iov
                         total_packet_len- p_tcp_h->doff*4 -34);
 #endif
 
+	// Request tx buffers for the next packets
 	if (unlikely(m_p_tx_mem_buf_desc_list == NULL)) {
 		m_p_tx_mem_buf_desc_list = m_p_ring->mem_buf_tx_get(m_id, b_blocked, m_n_sysvar_tx_bufs_batch_tcp);
 	}

--- a/src/vma/sock/sockinfo.cpp
+++ b/src/vma/sock/sockinfo.cpp
@@ -77,7 +77,7 @@ sockinfo::sockinfo(int fd) throw (vma_exception):
 		m_rx_reuse_buf_postponed(false),
 		m_rx_ring_map_lock(MODULE_NAME "::m_rx_ring_map_lock"),
 		m_ring_alloc_logic(fd, this),
-		m_n_rx_pkt_ready_list_count(0), m_rx_pkt_ready_offset(0), m_rx_ready_byte_count(0),
+		m_n_rx_pkt_ready_list_count(0), m_rx_pkt_ready_offset(0),
 		m_n_sysvar_rx_num_buffs_reuse(safe_mce_sys().rx_bufs_batch),
 		m_n_sysvar_rx_poll_num(safe_mce_sys().rx_poll_num),
 		m_rx_callback(NULL),
@@ -1051,8 +1051,6 @@ void sockinfo::move_owned_rx_ready_descs(const mem_buf_desc_owner* p_desc_owner,
 		}
 		m_n_rx_pkt_ready_list_count--;
 		m_p_socket_stats->n_rx_ready_pkt_count--;
-
-		m_rx_ready_byte_count -= temp->rx.sz_payload;
 		m_p_socket_stats->n_rx_ready_byte_count -= temp->rx.sz_payload;
 		toq->push_back(temp);
 	}

--- a/src/vma/sock/sockinfo.h
+++ b/src/vma/sock/sockinfo.h
@@ -182,7 +182,6 @@ protected:
 	 */
 	int						m_n_rx_pkt_ready_list_count;
 	size_t 					m_rx_pkt_ready_offset;
-	size_t					m_rx_ready_byte_count;
 
 	const int				m_n_sysvar_rx_num_buffs_reuse;
 	const int32_t				m_n_sysvar_rx_poll_num;
@@ -397,7 +396,6 @@ protected:
 			//save_stats_rx_offload(total_rx); //TODO??
 		}
 		else {
-			m_rx_ready_byte_count -= total_rx;
 			m_p_socket_stats->n_rx_ready_byte_count -= total_rx;
 			post_deqeue(relase_buff);
 			save_stats_rx_offload(total_rx);

--- a/src/vma/sock/sockinfo_tcp.cpp
+++ b/src/vma/sock/sockinfo_tcp.cpp
@@ -754,7 +754,7 @@ retry_write:
 				si_tcp_logdbg("returning with: EINTR");
 				goto err;
 			}
-			err = tcp_write(&m_pcb, (char *)p_iov[i].iov_base + pos, tx_size, 3, is_dummy);
+			err = tcp_write(&m_pcb, (char *)p_iov[i].iov_base + pos, tx_size, is_dummy);
 			if (unlikely(err != ERR_OK)) {
 				if (unlikely(err == ERR_CONN)) { // happens when remote drops during big write
 					si_tcp_logdbg("connection closed: tx'ed = %d", total_tx);
@@ -859,7 +859,7 @@ err_t sockinfo_tcp::ip_output(struct pbuf *p, void* v_p_conn, int is_rexmit, uin
 			p = p->next;
 		}
 
-		// We don't expect pbuf chain at all since we enabled  TCP_WRITE_FLAG_COPY and TCP_WRITE_FLAG_MORE in lwip
+		// We don't expect pbuf chain at all
 		if (p) {
 			vlog_printf(VLOG_ERROR, "pbuf chain size > 64!!! silently dropped.");
 			return ERR_OK;
@@ -909,12 +909,11 @@ err_t sockinfo_tcp::ip_output_syn_ack(struct pbuf *p, void* v_p_conn, int is_rex
 			p = p->next;
 		}
 
-#if 1 // We don't expcet pbuf chain at all since we enabled  TCP_WRITE_FLAG_COPY and TCP_WRITE_FLAG_MORE in lwip
+		// We don't expect pbuf chain at all
 		if (p) {
 			vlog_printf(VLOG_ERROR, "pbuf chain size > 64!!! silently dropped.");
 			return ERR_OK;
 		}
-#endif
 	}
 
 	if (is_rexmit)

--- a/src/vma/sock/sockinfo_tcp.cpp
+++ b/src/vma/sock/sockinfo_tcp.cpp
@@ -64,7 +64,6 @@
 #undef  __INFO__
 #define __INFO__                m_fd
 
-
 #define si_tcp_logpanic             __log_info_panic
 #define si_tcp_logerr               __log_info_err
 #define si_tcp_logwarn              __log_info_warn
@@ -73,7 +72,7 @@
 #define si_tcp_logfunc              __log_info_func
 #define si_tcp_logfuncall           __log_info_funcall
 
-
+#define BLOCK_THIS_RUN(blocking, flags) (blocking && !(flags & MSG_DONTWAIT))
 #define TCP_SEG_COMPENSATION 64
 
 tcp_seg_pool *g_tcp_seg_pool = NULL;

--- a/src/vma/sock/sockinfo_tcp.cpp
+++ b/src/vma/sock/sockinfo_tcp.cpp
@@ -285,6 +285,8 @@ sockinfo_tcp::~sockinfo_tcp()
 
 	destructor_helper();
 
+	tcp_tx_preallocted_buffers_free(&m_pcb);
+
 	if (m_tcp_seg_in_use) {
 		si_tcp_logwarn("still %d tcp segs in use!", m_tcp_seg_in_use);
 	}

--- a/src/vma/sock/sockinfo_tcp.cpp
+++ b/src/vma/sock/sockinfo_tcp.cpp
@@ -642,13 +642,12 @@ ssize_t sockinfo_tcp::tx(const tx_call_t call_type, const struct iovec* p_iov, c
 	int ret = 0;
 	int poll_count = 0;
 	bool is_dummy = IS_DUMMY_PACKET(flags);
-	bool block_this_run = m_b_blocking && !(flags & MSG_DONTWAIT);
 
 	if (unlikely(m_sock_offload != TCP_SOCK_LWIP)) {
 #ifdef VMA_TIME_MEASURE
 		INC_GO_TO_OS_TX_COUNT;
 #endif
-		
+
 		ret = socket_fd_api::tx_os(call_type, p_iov, sz_iov, flags, __to, __tolen);
 		save_stats_tx_os(ret);
 		return ret;
@@ -682,7 +681,7 @@ retry_is_ready:
 #ifdef VMA_TIME_MEASURE
 		INC_ERR_TX_COUNT;
 #endif
-		
+
 		return -1;
 	}
 	si_tcp_logfunc("tx: iov=%p niovs=%d dummy=%d", p_iov, sz_iov, is_dummy);
@@ -704,41 +703,41 @@ retry_is_ready:
 
 		pos = 0;
 		while (pos < p_iov[i].iov_len) {
-			if (unlikely(!is_rts())) {
-				si_tcp_logdbg("TX on disconnected socket");
-				ret = -1;
-				errno = ECONNRESET;
-				goto err;
-			}
 			//tx_size = tx_wait();
-                        tx_size = tcp_sndbuf(&m_pcb);
-                        if (tx_size == 0) { 
-                                //force out TCP data before going on wait()
-                                tcp_output(&m_pcb);
+			tx_size = tcp_sndbuf(&m_pcb);
+			if (tx_size == 0) {
+				if (unlikely(!is_rts())) {
+					si_tcp_logdbg("TX on disconnected socket");
+					ret = -1;
+					errno = ECONNRESET;
+					goto err;
+				}
+				//force out TCP data before going on wait()
+				tcp_output(&m_pcb);
 
-                                if (!block_this_run) {
-                                        // non blocking socket should return inorder not to tx_wait()
-                                        if ( total_tx ) {
-                                                m_tx_consecutive_eagain_count = 0;
-                                                goto done;
-                                        }
-                                        else {
-                                                m_tx_consecutive_eagain_count++;
-                                                if (m_tx_consecutive_eagain_count >= TX_CONSECUTIVE_EAGAIN_THREASHOLD) {
-                                                        // in case of zero sndbuf and non-blocking just try once polling CQ for ACK
-                                                        rx_wait(poll_count, false);
-                                                        m_tx_consecutive_eagain_count = 0;
-                                                }
-                                                ret = -1;
-                                                errno = EAGAIN;
-                                                goto err;
-                                        }
-                                }
+				if (!BLOCK_THIS_RUN(m_b_blocking, flags)) {
+					// non blocking socket should return inorder not to tx_wait()
+					if ( total_tx ) {
+						m_tx_consecutive_eagain_count = 0;
+						goto done;
+					}
+					else {
+						m_tx_consecutive_eagain_count++;
+						if (m_tx_consecutive_eagain_count >= TX_CONSECUTIVE_EAGAIN_THREASHOLD) {
+							// in case of zero sndbuf and non-blocking just try once polling CQ for ACK
+							rx_wait(poll_count, false);
+							m_tx_consecutive_eagain_count = 0;
+						}
+						ret = -1;
+						errno = EAGAIN;
+						goto err;
+					}
+				}
 
-                                tx_size = tx_wait(ret, block_this_run);
-                                if (ret < 0)
-                                        goto err;
-                        }
+				tx_size = tx_wait(ret, BLOCK_THIS_RUN(m_b_blocking, flags));
+				if (ret < 0)
+					goto err;
+			}
 
 			if (tx_size > p_iov[i].iov_len - pos)
 				tx_size = p_iov[i].iov_len - pos;
@@ -781,19 +780,19 @@ retry_write:
 					INC_ERR_TX_COUNT;
 #endif					
 					return -1;
-					*/
+					 */
 				}
 				if (total_tx > 0) 
 					goto done;
 
-				ret = rx_wait(poll_count, block_this_run);
+				ret = rx_wait(poll_count, BLOCK_THIS_RUN(m_b_blocking, flags));
 				if (ret < 0)
 					goto err;
 
 				//AlexV:Avoid from going to sleep, for the blocked socket of course, since
 				// progress engine may consume an arrived credit and it will not wakeup the
 				//transmit thread.
-				if (block_this_run) {
+				if (BLOCK_THIS_RUN(m_b_blocking, flags)) {
 					poll_count = 0;
 				}
 				//tcp_output(m_sock); // force data out
@@ -836,7 +835,7 @@ err:
 		m_p_socket_stats->counters.n_tx_errors++;
 	unlock_tcp_con();
 	return ret;
-	
+
 }
 
 err_t sockinfo_tcp::ip_output(struct pbuf *p, void* v_p_conn, int is_rexmit, uint8_t is_dummy)
@@ -860,26 +859,27 @@ err_t sockinfo_tcp::ip_output(struct pbuf *p, void* v_p_conn, int is_rexmit, uin
 			p = p->next;
 		}
 
-#if 1 // We don't expcet pbuf chain at all since we enabled  TCP_WRITE_FLAG_COPY and TCP_WRITE_FLAG_MORE in lwip
+		// We don't expect pbuf chain at all since we enabled  TCP_WRITE_FLAG_COPY and TCP_WRITE_FLAG_MORE in lwip
 		if (p) {
 			vlog_printf(VLOG_ERROR, "pbuf chain size > 64!!! silently dropped.");
 			return ERR_OK;
 		}
-#endif
 	}
-
-	if (p_dst->try_migrate_ring(p_si_tcp->m_tcp_con_lock)) {
-		p_si_tcp->m_p_socket_stats->counters.n_tx_migrations++;
-	}
-
-	if (is_rexmit)
-		p_si_tcp->m_p_socket_stats->counters.n_tx_retransmits++;
 
 	if (likely((p_dst->is_valid()))) {
 		p_dst->fast_send(p_iovec, count, is_dummy, false, is_rexmit);
 	} else {
 		p_dst->slow_send(p_iovec, count, is_dummy, false, is_rexmit);
 	}
+
+	if (p_dst->try_migrate_ring(p_si_tcp->m_tcp_con_lock)) {
+		p_si_tcp->m_p_socket_stats->counters.n_tx_migrations++;
+	}
+
+	if (is_rexmit) {
+		p_si_tcp->m_p_socket_stats->counters.n_tx_retransmits++;
+	}
+
 	return ERR_OK;
 }
 

--- a/src/vma/sock/sockinfo_tcp.cpp
+++ b/src/vma/sock/sockinfo_tcp.cpp
@@ -284,6 +284,7 @@ sockinfo_tcp::~sockinfo_tcp()
 
 	destructor_helper();
 
+	// Release preallocated buffers
 	tcp_tx_preallocted_buffers_free(&m_pcb);
 
 	if (m_tcp_seg_in_use) {

--- a/src/vma/sock/sockinfo_tcp.h
+++ b/src/vma/sock/sockinfo_tcp.h
@@ -48,8 +48,6 @@
 
 #include "sockinfo.h"
 
-#define BLOCK_THIS_RUN(blocking, flags) (blocking && !(flags & MSG_DONTWAIT))
-
 /**
  * Tcp socket states: rdma_offload or os_passthrough. in rdma_offload:
  * init --/bind()/ --> bound -- /listen()/ --> accept_ready -- /accept()may go to connected/ --> connected

--- a/src/vma/sock/sockinfo_tcp.h
+++ b/src/vma/sock/sockinfo_tcp.h
@@ -48,6 +48,8 @@
 
 #include "sockinfo.h"
 
+#define BLOCK_THIS_RUN(blocking, flags) (blocking && !(flags & MSG_DONTWAIT))
+
 /**
  * Tcp socket states: rdma_offload or os_passthrough. in rdma_offload:
  * init --/bind()/ --> bound -- /listen()/ --> accept_ready -- /accept()may go to connected/ --> connected

--- a/src/vma/sock/sockinfo_udp.h
+++ b/src/vma/sock/sockinfo_udp.h
@@ -243,7 +243,7 @@ private:
 	void 		save_stats_threadid_tx(); // ThreadId will only saved if logger is at least in DEBUG(4) level
 
 	void 		save_stats_rx_offload(int bytes);
-	void 		save_stats_tx_offload(int bytes, bool is_droped, bool is_dummy);
+	void 		save_stats_tx_offload(int bytes, bool is_dummy);
 
 	int 		rx_wait_helper(int &poll_count, bool is_blocking);
 	


### PR DESCRIPTION
The following PR includes 8 different commits :

- Remove cq_mgr::poll_and_process_helper_rx() and cq_mgr::poll_and_process_helper_tx().
- Optimize qp_mgr::send().
- Add m_p_tx_mem_buf_desc_head to dst_entry which holds the next buffer to be sent.
  This change is only implemented for UDP.
- Remove m_rx_ready_byte_count counter from sockinfo.
   This variable is a duplicate of m_p_socket_stats->n_rx_ready_byte_count.
- 1. Convert block_this_run from variable into DEFINE.
  2. Remove is_dropped counter from sockinfo_udp::tx()
  3. Remove debug checks from dst_entry_tcp:fast_send()
  4. Postpone performing the following actions after send() completes:
      Ring migration checks, retransmission counters update and number of free wr update.
- Remove redundant variable "apifalgs" from tcp_write()
  This caus us about three redundant if statements in the fast path.
- Add pbuf_alloc to lwip tcp.h which holds the next pbuff to be sent
- Add seg_alloc to lwip tcp.h which holds the next tcp_segment to be sent.

Signed-off-by: Liran Oz <lirano@mellanox.com>