### PR TITLE
issue: 1007291 Add new configuration parameter VMA_TCP_MSL

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -159,6 +159,7 @@ Example:
  VMA DETAILS: CQ Keeps QP Full               Enabled                    [VMA_CQ_KEEP_QP_FULL]
  VMA DETAILS: QP Compensation Level          256                        [VMA_QP_COMPENSATION_LEVEL]
  VMA DETAILS: Offloaded Sockets              Enabled                    [VMA_OFFLOADED_SOCKETS]
+ VMA DETAILS: TCP max segment lifetime (msec) 60000                      [VMA_TCP_MSL]
  VMA DETAILS: Timer Resolution (msec)        10                         [VMA_TIMER_RESOLUTION_MSEC]
  VMA DETAILS: TCP Timer Resolution (msec)    100                        [VMA_TCP_TIMER_RESOLUTION_MSEC]
  VMA DETAILS: TCP control thread             0 (Disabled)               [VMA_TCP_CTL_THREAD]
@@ -672,6 +673,10 @@ VMA_OFFLOADED_SOCKETS
 Create all sockets as offloaded/not-offloaded by default.
 Value of 1 is for offloaded, 0 for not-offloaded.
 Default value is 1 (Enabled)
+
+VMA_TCP_MSL
+Maximum Segment Lifetime, the time a TCP segment can exist in the internetwork system.
+Default value is 60000 (milli-sec)
 
 VMA_TIMER_RESOLUTION_MSEC
 Control VMA internal thread wakeup timer resolution (in milli seconds)

--- a/src/vma/lwip/tcp.c
+++ b/src/vma/lwip/tcp.c
@@ -854,7 +854,7 @@ tcp_slowtmr(struct tcp_pcb* pcb)
 
 	/* Check if this PCB has stayed too long in LAST-ACK */
 	if (get_tcp_state(pcb) == LAST_ACK) {
-	  if ((u32_t)(tcp_ticks - pcb->tmr) > 2 * TCP_MSL / TCP_SLOW_INTERVAL) {
+	  if ((u32_t)(tcp_ticks - pcb->tmr) > 2 * get_tcp_msl(pcb) / TCP_SLOW_INTERVAL) {
 		++pcb_remove;
 		err = ERR_ABRT;
 		LWIP_DEBUGF(TCP_DEBUG, ("tcp_slowtmr: removing pcb stuck in LAST-ACK\n"));
@@ -892,7 +892,7 @@ tcp_slowtmr(struct tcp_pcb* pcb)
 	pcb_remove = 0;
 
 	/* Check if this PCB has stayed long enough in TIME-WAIT */
-	if ((u32_t)(tcp_ticks - pcb->tmr) > 2 * TCP_MSL / TCP_SLOW_INTERVAL) {
+	if ((u32_t)(tcp_ticks - pcb->tmr) > 2 * get_tcp_msl(pcb) / TCP_SLOW_INTERVAL) {
 	  ++pcb_remove;
 	  /* err = ERR_ABRT; */ /* Note: suppress warning 'err' is never read */
 	}

--- a/src/vma/lwip/tcp.h
+++ b/src/vma/lwip/tcp.h
@@ -350,6 +350,8 @@ struct tcp_pcb {
   u32_t snd_sml_snt; /* maintain state for minshall's algorithm */
   u32_t snd_sml_add; /* maintain state for minshall's algorithm */
 
+  u32_t	tcp_msl;	/* maximum segment lifetime */
+
 #define TCP_SNDQUEUELEN_OVERFLOW (0xffffffU-3)
   u32_t snd_queuelen; /* Available buffer space for sending (in tcp_segs). */
   u32_t max_tcp_snd_queuelen; 
@@ -519,7 +521,7 @@ err_t            tcp_output  (struct tcp_pcb *pcb);
 
 #define get_tcp_state(pcb) ((pcb)->private_state)
 #define set_tcp_state(pcb, state) external_tcp_state_observer((pcb)->my_container, (pcb)->private_state = state)
-
+#define	get_tcp_msl(pcb) ((pcb)->tcp_msl)
 const char* tcp_debug_state_str(enum tcp_state s);
 
 

--- a/src/vma/main.cpp
+++ b/src/vma/main.cpp
@@ -543,6 +543,7 @@ void print_vma_global_settings()
 	VLOG_PARAM_STRING("CQ Keeps QP Full", safe_mce_sys().cq_keep_qp_full, MCE_DEFAULT_CQ_KEEP_QP_FULL, SYS_VAR_CQ_KEEP_QP_FULL, safe_mce_sys().cq_keep_qp_full ? "Enabled" : "Disabled");
 	VLOG_PARAM_NUMBER("QP Compensation Level", safe_mce_sys().qp_compensation_level, MCE_DEFAULT_QP_COMPENSATION_LEVEL, SYS_VAR_QP_COMPENSATION_LEVEL);
 	VLOG_PARAM_STRING("Offloaded Sockets", safe_mce_sys().offloaded_sockets, MCE_DEFAULT_OFFLOADED_SOCKETS, SYS_VAR_OFFLOADED_SOCKETS, safe_mce_sys().offloaded_sockets ? "Enabled" : "Disabled");
+	VLOG_PARAM_NUMBER("TCP max segment lifetime (msec)", safe_mce_sys().tcp_msl, MCE_DEFAULT_TCP_MSL, SYS_VAR_TCP_MSL);
 	VLOG_PARAM_NUMBER("Timer Resolution (msec)", safe_mce_sys().timer_resolution_msec, MCE_DEFAULT_TIMER_RESOLUTION_MSEC, SYS_VAR_TIMER_RESOLUTION_MSEC);
 	VLOG_PARAM_NUMBER("TCP Timer Resolution (msec)", safe_mce_sys().tcp_timer_resolution_msec, MCE_DEFAULT_TCP_TIMER_RESOLUTION_MSEC, SYS_VAR_TCP_TIMER_RESOLUTION_MSEC);
 	VLOG_PARAM_NUMSTR("TCP control thread", safe_mce_sys().tcp_ctl_thread, MCE_DEFAULT_TCP_CTL_THREAD, SYS_VAR_TCP_CTL_THREAD, ctl_thread_str(safe_mce_sys().tcp_ctl_thread));

--- a/src/vma/sock/sockinfo_tcp.cpp
+++ b/src/vma/sock/sockinfo_tcp.cpp
@@ -227,6 +227,7 @@ sockinfo_tcp::sockinfo_tcp(int fd) throw (vma_exception) :
 	si_tcp_logdbg("tcp socket created");
 
 	tcp_pcb_init(&m_pcb, TCP_PRIO_NORMAL);
+	m_pcb.tcp_msl = safe_mce_sys().tcp_msl;
 
 	si_tcp_logdbg("new pcb %p pcb state %d", &m_pcb, get_tcp_state(&m_pcb));
 	tcp_arg(&m_pcb, this);

--- a/src/vma/util/sys_vars.cpp
+++ b/src/vma/util/sys_vars.cpp
@@ -402,6 +402,7 @@ void mce_sys_var::get_env_params()
 	ring_migration_ratio_rx = MCE_DEFAULT_RING_MIGRATION_RATIO_RX;
 	ring_limit_per_interface= MCE_DEFAULT_RING_LIMIT_PER_INTERFACE;
 	tcp_max_syn_rate	= MCE_DEFAULT_TCP_MAX_SYN_RATE;
+	tcp_msl			= TCP_MSL_MAX;
 
 	tx_num_segs_tcp         = MCE_DEFAULT_TX_NUM_SEGS_TCP;
 	tx_num_bufs             = MCE_DEFAULT_TX_NUM_BUFS;
@@ -741,6 +742,9 @@ void mce_sys_var::get_env_params()
 
 	if ((env_ptr = getenv(SYS_VAR_TCP_MAX_SYN_RATE)) != NULL)
 		tcp_max_syn_rate = MIN(TCP_MAX_SYN_RATE_TOP_LIMIT, MAX(0, (int32_t)atoi(env_ptr)));
+
+	if ((env_ptr = getenv(SYS_VAR_TCP_MSL)) != NULL)
+		tcp_msl = MIN(TCP_MSL_MAX, MAX(0, (int32_t)atoi(env_ptr)));
 
 	if ((env_ptr = getenv(SYS_VAR_RX_NUM_BUFS)) != NULL)
 		rx_num_bufs = (uint32_t)atoi(env_ptr);

--- a/src/vma/util/sys_vars.h
+++ b/src/vma/util/sys_vars.h
@@ -312,6 +312,7 @@ struct mce_sys_var {
 	int		ring_migration_ratio_rx;
 	int		ring_limit_per_interface;
 	int		tcp_max_syn_rate;
+	int		tcp_msl;
 
 	uint32_t 	tx_num_segs_tcp;
 	uint32_t 	tx_num_bufs;
@@ -517,6 +518,7 @@ extern mce_sys_var & safe_mce_sys();
 #define SYS_VAR_CLOSE_ON_DUP2				"VMA_CLOSE_ON_DUP2"
 #define SYS_VAR_MTU					"VMA_MTU"
 #define SYS_VAR_TCP_MAX_SYN_RATE			"VMA_TCP_MAX_SYN_RATE"
+#define	SYS_VAR_TCP_MSL				"VMA_TCP_MSL"
 #define SYS_VAR_MSS					"VMA_MSS"
 #define SYS_VAR_TCP_CC_ALGO				"VMA_TCP_CC_ALGO"
 #define SYS_VAR_SPEC					"VMA_SPEC"
@@ -577,6 +579,7 @@ extern mce_sys_var & safe_mce_sys();
 #define MCE_DEFAULT_TX_BUFS_BATCH_TCP			(16)
 #define MCE_DEFAULT_TX_NUM_SGE				(2)
 #define MCE_DEFAULT_RX_NUM_BUFS				(200000)
+#define MCE_DEFAULT_TCP_MSL					(60000)
 #define MCE_DEFAULT_RX_BUFS_BATCH			(64)
 #ifdef DEFINED_VMAPOLL
 #define MCE_DEFAULT_RX_NUM_WRE				(1024)
@@ -686,6 +689,7 @@ extern mce_sys_var & safe_mce_sys();
 #define NUM_TX_WRE_TO_SIGNAL_MAX			64
 #define NUM_RX_WRE_TO_POST_RECV_MAX			1024
 #define TCP_MAX_SYN_RATE_TOP_LIMIT			100000
+#define TCP_MSL_MAX							60000
 #define DEFAULT_MC_TTL					64
 #define MAX_FREG_MEM_BUF				(MCE_DEFAULT_RX_NUM_BUFS/100)
 #define IBVERBS_ABI_VER_PARAM_FILE			"/sys/class/infiniband_verbs/abi_version"


### PR DESCRIPTION
This parameter set TCP Maximum Segment Lifetime, the time a TCP segment can exist in the internetwork system. Please review.
@OphirMunk @rosenbaumalex @igor-ivanov 
Signed-off-by: sergeyly <sergeyly@mellanox.com>