### PR TITLE
issue: 987802 Integration FlowTag for epoll() with POLL CQ PRM

### DIFF
--- a/src/vma/dev/cq_mgr_mlx5.cpp
+++ b/src/vma/dev/cq_mgr_mlx5.cpp
@@ -206,7 +206,9 @@ inline void cq_mgr_mlx5::cqe64_to_mem_buff_desc(volatile struct mlx5_cqe64 *cqe,
 		case MLX5_CQE_RESP_SEND_INV:
 		{
 			status = BS_OK;
-			p_rx_wc_buf_desc->sz_data = ntohl(cqe->byte_cnt);
+			/* Time stamp */
+			p_rx_wc_buf_desc->rx.hw_raw_timestamp = cqe->timestamp;
+			p_rx_wc_buf_desc->rx.flow_tag_id      = vma_get_flow_tag(cqe);
 
 #ifdef DEFINED_MLX5_HW_ETH_WQE_HEADER
 			/* Checksum */
@@ -214,8 +216,7 @@ inline void cq_mgr_mlx5::cqe64_to_mem_buff_desc(volatile struct mlx5_cqe64 *cqe,
 #else
 			p_rx_wc_buf_desc->rx.is_sw_csum_need = true;
 #endif
-			/* Time stamp */
-			p_rx_wc_buf_desc->rx.hw_raw_timestamp = cqe->timestamp;
+			p_rx_wc_buf_desc->sz_data = ntohl(cqe->byte_cnt);
 			return;
 		}
 		case MLX5_CQE_INVALID: /* No cqe!*/


### PR DESCRIPTION
- FlowTag in epool() mode was integrated with POLL CQ PRM;
- Initializations of mem_buf_desc_t were changed in accordance with data
  mapping to improve cache locality;
- Excluded reset of mem_buf_desc_t ref.counter from dispatch and check
  functions as it is performed in initial.
