### PR TITLE
issue: 990837 Improvements in packet inspections for UDP

### DIFF
--- a/src/vma/dev/cq_mgr.inl
+++ b/src/vma/dev/cq_mgr.inl
@@ -46,7 +46,7 @@ inline void cq_mgr::process_recv_buffer(mem_buf_desc_t* p_mem_buf_desc, void* pv
 	// Assume locked!!!
 
 	// Pass the Rx buffer ib_comm_mgr for further IP processing
-	if (!m_p_ring->rx_process_buffer(p_mem_buf_desc, m_transport_type, pv_fd_ready_array)) {
+	if (!m_p_ring->rx_process_buffer(p_mem_buf_desc, pv_fd_ready_array)) {
 		// If buffer is dropped by callback - return to RX pool
 		reclaim_recv_buffer_helper(p_mem_buf_desc);
 	}

--- a/src/vma/dev/ring_simple.cpp
+++ b/src/vma/dev/ring_simple.cpp
@@ -721,20 +721,23 @@ const char* priv_igmp_type_tostr(uint8_t igmptype)
 }
 
 // calling sockinfo callback with RFS bypass
-static inline bool check_rx_packet(sockinfo *si, mem_buf_desc_t* p_rx_wc_buf_desc)
+//
+static inline bool check_rx_packet(sockinfo *si, mem_buf_desc_t* p_rx_wc_buf_desc, void *fd_ready_array)
 {
 	// Dispatching: Notify new packet to the FIRST registered receiver ONLY
-	p_rx_wc_buf_desc->reset_ref_count();
 #ifdef RDTSC_MEASURE_RX_DISPATCH_PACKET
 	RDTSC_TAKE_START(g_rdtsc_instr_info_arr[RDTSC_FLOW_RX_DISPATCH_PACKET]);
 #endif //RDTSC_MEASURE_RX_DISPATCH_PACKET
 
+	p_rx_wc_buf_desc->reset_ref_count();
 	p_rx_wc_buf_desc->inc_ref_count();
-	si->rx_input_cb(p_rx_wc_buf_desc, NULL);
+
+	si->rx_input_cb(p_rx_wc_buf_desc,fd_ready_array);
 
 #ifdef RDTSC_MEASURE_RX_DISPATCH_PACKET
 	RDTSC_TAKE_END(g_rdtsc_instr_info_arr[RDTSC_FLOW_RX_DISPATCH_PACKET]);
 #endif //RDTSC_MEASURE_RX_DISPATCH_PACKET
+
 	// Check packet ref_count to see the last receiver is interested in this packet
 	if (p_rx_wc_buf_desc->dec_ref_count() > 1) {
 		// The sink will be responsible to return the buffer to CQ for reuse
@@ -744,339 +747,9 @@ static inline bool check_rx_packet(sockinfo *si, mem_buf_desc_t* p_rx_wc_buf_des
 	return false;
 }
 
-#ifdef DEFINED_VMAPOLL
-inline void ring_simple::vma_poll_process_recv_buffer(mem_buf_desc_t* p_rx_wc_buf_desc)
-{
-	//size_t sz_data = 0;
-	size_t transport_header_len = ETH_HDR_LEN;
-	uint16_t ip_hdr_len = 0;
-	uint16_t ip_tot_len = 0;
-	uint16_t ip_frag_off = 0;
-	uint16_t n_frag_offset = 0;
-	struct iphdr* p_ip_h = NULL;
-	struct udphdr* p_udp_h = NULL;
-	in_addr_t local_addr = p_rx_wc_buf_desc->rx.dst.sin_addr.s_addr;
-
-	NOT_IN_USE(ip_tot_len);
-	NOT_IN_USE(ip_frag_off);
-	NOT_IN_USE(n_frag_offset);
-	NOT_IN_USE(p_udp_h);
-	NOT_IN_USE(local_addr);
-
-	// This is an internal function (within ring and 'friends'). No need for lock mechanism.
-
-	if (likely(m_flow_tag_enabled && p_rx_wc_buf_desc->rx.flow_tag_id &&
-		  (p_rx_wc_buf_desc->rx.flow_tag_id != FLOW_TAG_MASK))) {
-		sockinfo* si = NULL;
-		// trying to get sockinfo per flow_tag_id-1 as it was incremented at attach
-		// to allow mapping sockfd=0
-		si = static_cast <sockinfo* >(g_p_fd_collection->get_sockfd(p_rx_wc_buf_desc->rx.flow_tag_id-1));
-
-		if (likely((si != NULL) && si->flow_tag_enabled())) { 
-			// will process packets with set flow_tag_id and enabled for the socket
-			p_ip_h = (struct iphdr*)(p_rx_wc_buf_desc->p_buffer + transport_header_len);
-			ip_hdr_len = 20; //(int)(p_ip_h->ihl)*4;
-			ip_tot_len = ntohs(p_ip_h->tot_len);
-
-			if (likely(si->tcp_flow_is_5t())) {
-				// we have a single 5tuple TCP connected socket, use simpler fast path
-				struct tcphdr* p_tcp_h = (struct tcphdr*)((uint8_t*)p_ip_h + ip_hdr_len);
-				size_t sz_payload = ip_tot_len - ip_hdr_len - p_tcp_h->doff*4;
-
-				// Update packet descriptor with datagram base address and length
-				p_rx_wc_buf_desc->rx.frag.iov_base = (uint8_t*)p_tcp_h + sizeof(struct tcphdr);
-				p_rx_wc_buf_desc->rx.frag.iov_len  = ip_tot_len - ip_hdr_len - sizeof(struct tcphdr);
-
-				p_rx_wc_buf_desc->rx.sz_payload                 = sz_payload;
-
-				p_rx_wc_buf_desc->rx.tcp.p_ip_h                 = p_ip_h;
-				p_rx_wc_buf_desc->rx.tcp.p_tcp_h                = p_tcp_h;
-				p_rx_wc_buf_desc->rx.tcp.n_transport_header_len = transport_header_len;
-				p_rx_wc_buf_desc->rx.n_frags = 1;
-
-/*				ring_logfunc("FAST PATH Rx TCP segment info: src_port=%d, dst_port=%d, flags='%s%s%s%s%s%s' seq=%u, ack=%u, win=%u, payload_sz=%u",
-					ntohs(p_tcp_h->source), ntohs(p_tcp_h->dest),
-					p_tcp_h->urg?"U":"", p_tcp_h->ack?"A":"", p_tcp_h->psh?"P":"",
-					p_tcp_h->rst?"R":"", p_tcp_h->syn?"S":"", p_tcp_h->fin?"F":"",
-					ntohl(p_tcp_h->seq), ntohl(p_tcp_h->ack_seq), ntohs(p_tcp_h->window),
-					sz_payload);
-*/
-				p_rx_wc_buf_desc->rx.vma_polled = true;
-				check_rx_packet(si, p_rx_wc_buf_desc);
-				p_rx_wc_buf_desc->rx.vma_polled = false;
-				return;
-			} else if (p_ip_h->protocol==IPPROTO_UDP) {
-				// Get the udp header pointer + udp payload size
-				p_udp_h = (struct udphdr*)((uint8_t*)p_ip_h + ip_hdr_len);
-				size_t sz_payload = ntohs(p_udp_h->len) - sizeof(struct udphdr);
-				// Update packet descriptor with datagram base address and length
-				p_rx_wc_buf_desc->rx.frag.iov_base = (uint8_t*)p_udp_h + sizeof(struct udphdr);
-				p_rx_wc_buf_desc->rx.frag.iov_len  = ip_tot_len - ip_hdr_len - sizeof(struct udphdr);
-
-				// Update the L4 info
-				p_rx_wc_buf_desc->rx.src.sin_port        = p_udp_h->source;
-				p_rx_wc_buf_desc->rx.dst.sin_port        = p_udp_h->dest;
-				p_rx_wc_buf_desc->rx.sz_payload          = sz_payload;
-
-				// Update the L3 info
-				p_rx_wc_buf_desc->rx.src.sin_family      = AF_INET;
-				p_rx_wc_buf_desc->rx.src.sin_addr.s_addr = p_ip_h->saddr;
-				p_rx_wc_buf_desc->rx.n_frags = 1;
-
-/*				ring_logfunc("FAST PATH Rx UDP datagram info: src_port=%d, dst_port=%d, payload_sz=%d, csum=%#x",
-					     ntohs(p_udp_h->source), ntohs(p_udp_h->dest), sz_payload, p_udp_h->check);
-*/
-				p_rx_wc_buf_desc->rx.vma_polled = true;
-				check_rx_packet(si, p_rx_wc_buf_desc);
-				p_rx_wc_buf_desc->rx.vma_polled = false;
-				return;
-			}
-		}
-	}
-
-	// Validate buffer size
-	size_t sz_data = p_rx_wc_buf_desc->sz_data;
-	if (unlikely(sz_data > p_rx_wc_buf_desc->sz_buffer)) {
-		if (sz_data == IP_FRAG_FREED) {
-			ring_logfuncall("Rx buffer dropped - old fragment part");
-		} else {
-			ring_logwarn("Rx buffer dropped - buffer too small (%d, %d)", sz_data, p_rx_wc_buf_desc->sz_buffer);
-		}
-		return;
-	}
-
-	m_cq_moderation_info.bytes += sz_data;
-	++m_cq_moderation_info.packets;
-
-	m_ring_stat_static.n_rx_byte_count += sz_data;
-	++m_ring_stat_static.n_rx_pkt_count;
-
-	// Validate transport type headers
-
-	// Get the data buffer start pointer to the Ethernet header pointer
-	struct ethhdr* p_eth_h = (struct ethhdr*)(p_rx_wc_buf_desc->p_buffer);
-	ring_logfunc("Rx buffer Ethernet dst=" ETH_HW_ADDR_PRINT_FMT " <- src=" ETH_HW_ADDR_PRINT_FMT " type=%#x",
-			ETH_HW_ADDR_PRINT_ADDR(p_eth_h->h_dest),
-			ETH_HW_ADDR_PRINT_ADDR(p_eth_h->h_source),
-			htons(p_eth_h->h_proto));
-
-	uint16_t* p_h_proto = &p_eth_h->h_proto;
-
-	// Handle VLAN header as next protocol
-	struct vlanhdr* p_vlan_hdr = NULL;
-	uint16_t packet_vlan = 0;
-	if (*p_h_proto == htons(ETH_P_8021Q)) {
-		p_vlan_hdr = (struct vlanhdr*)((uint8_t*)p_eth_h + transport_header_len);
-		transport_header_len = ETH_VLAN_HDR_LEN;
-		p_h_proto = &p_vlan_hdr->h_vlan_encapsulated_proto;
-		packet_vlan = (htons(p_vlan_hdr->h_vlan_TCI) & VLAN_VID_MASK);
-	}
-
-	//TODO: Remove this code when handling vlan in flow steering will be available. Change this code if vlan stripping is performed.
-	if((m_partition & VLAN_VID_MASK) != packet_vlan) {
-		ring_logfunc("Rx buffer dropped- Mismatched vlan. Packet vlan = %d, Local vlan = %d", packet_vlan, m_partition & VLAN_VID_MASK);
-		return;
-	}
-
-	// Validate IP header as next protocol
-	if (unlikely(*p_h_proto != htons(ETH_P_IP))) {
-		ring_logwarn("Rx buffer dropped - Invalid Ethr Type (%#x : %#x)", p_eth_h->h_proto, htons(ETH_P_IP));
-		return;
-	}
-
-
-
-	// Jump to IP header - Skip IB (GRH and IPoIB) or Ethernet (MAC) header sizes
-	sz_data -= transport_header_len;
-
-	// Validate size for IPv4 header
-	if (unlikely(sz_data < sizeof(struct iphdr))) {
-		ring_logwarn("Rx buffer dropped - buffer too small for IPv4 header (%d, %d)", sz_data, sizeof(struct iphdr));
-		return;
-	}
-
-	// Get the ip header pointer
-	p_ip_h = (struct iphdr*)(p_rx_wc_buf_desc->p_buffer + transport_header_len);
-
-	// Drop all non IPv4 packets
-	if (unlikely(p_ip_h->version != IPV4_VERSION)) {
-		ring_logwarn("Rx packet dropped - not IPV4 packet (got version: %#x)", p_ip_h->version);
-		return;
-	}
-
-	// Check that received buffer size is not smaller then the ip datagram total size
-	ip_tot_len = ntohs(p_ip_h->tot_len);
-	if (unlikely(sz_data < ip_tot_len)) {
-		ring_logwarn("Rx packet dropped - buffer too small for received datagram (RxBuf:%d IP:%d)", sz_data, ip_tot_len);
-		ring_loginfo("Rx packet info (buf->%p, bufsize=%d), id=%d", p_rx_wc_buf_desc->p_buffer, p_rx_wc_buf_desc->sz_data, ntohs(p_ip_h->id));
-		vlog_print_buffer(VLOG_INFO, "rx packet data: ", "\n", (const char*)p_rx_wc_buf_desc->p_buffer, min(112, (int)p_rx_wc_buf_desc->sz_data));
-		return;
-	} else if (sz_data > ip_tot_len) {
-		p_rx_wc_buf_desc->sz_data -= (sz_data - ip_tot_len);
-		sz_data = ip_tot_len;
-	}
-
-	// Read fragmentation parameters
-	ip_frag_off = ntohs(p_ip_h->frag_off);
-	n_frag_offset = (ip_frag_off & FRAGMENT_OFFSET) * 8;
-
-	ring_logfunc("Rx ip packet info: dst=%d.%d.%d.%d, src=%d.%d.%d.%d, packet_sz=%d, offset=%d, id=%d, proto=%s[%d] (local if: %d.%d.%d.%d)",
-			NIPQUAD(p_ip_h->daddr), NIPQUAD(p_ip_h->saddr),
-			sz_data, n_frag_offset, ntohs(p_ip_h->id),
-			iphdr_protocol_type_to_str(p_ip_h->protocol), p_ip_h->protocol,
-			NIPQUAD(local_addr));
-
-	// Check that the ip datagram has at least the udp header size for the first ip fragment (besides the ip header)
-	ip_hdr_len = (int)(p_ip_h->ihl)*4;
-	if (unlikely((n_frag_offset == 0) && (ip_tot_len < (ip_hdr_len + sizeof(struct udphdr))))) {
-		ring_logwarn("Rx packet dropped - ip packet too small (%d bytes)- udp header cut!", ip_tot_len);
-		return;
-	}
-
-	// Handle fragmentation
-	p_rx_wc_buf_desc->rx.n_frags = 1;
-	if (unlikely((ip_frag_off & MORE_FRAGMENTS_FLAG) || n_frag_offset)) { // Currently we don't expect to receive fragments
-		//for disabled fragments handling:
-		/*ring_logwarn("Rx packet dropped - VMA doesn't support fragmentation in receive flow!");
-		ring_logwarn("packet info: dst=%d.%d.%d.%d, src=%d.%d.%d.%d, packet_sz=%d, frag_offset=%d, id=%d, proto=%s[%d], transport type=%s, (local if: %d.%d.%d.%d)",
-				NIPQUAD(p_ip_h->daddr), NIPQUAD(p_ip_h->saddr),
-				sz_data, n_frag_offset, ntohs(p_ip_h->id),
-				iphdr_protocol_type_to_str(p_ip_h->protocol), p_ip_h->protocol, (transport_type ? "ETH" : "IB"),
-				NIPQUAD(local_addr));
-		return false;*/
-#if 1 //handle fragments
-		// Update fragments descriptor with datagram base address and length
-		p_rx_wc_buf_desc->rx.frag.iov_base = (uint8_t*)p_ip_h + ip_hdr_len;
-		p_rx_wc_buf_desc->rx.frag.iov_len  = ip_tot_len - ip_hdr_len;
-
-		// Add ip fragment packet to out fragment manager
-		mem_buf_desc_t* new_buf = NULL;
-		int ret = -1;
-		if (g_p_ip_frag_manager)
-			ret = g_p_ip_frag_manager->add_frag(p_ip_h, p_rx_wc_buf_desc, &new_buf);
-		if (ret < 0)  // Finished with error
-			return;
-		if (!new_buf)  // This is fragment
-			return;
-
-		// Re-calc all ip related values for new ip packet of head fragmentation list
-		p_rx_wc_buf_desc = new_buf;
-		sz_data -= transport_header_len; // Jump to IP header (Skip IB (GRH and IPoIB) or Ethernet (MAC) header size
-		p_ip_h = (struct iphdr*)(p_rx_wc_buf_desc->p_buffer + transport_header_len);
-		ip_hdr_len = (int)(p_ip_h->ihl)*4;
-		ip_tot_len = ntohs(p_ip_h->tot_len);
-
-		mem_buf_desc_t *tmp;
-		for (tmp = p_rx_wc_buf_desc; tmp; tmp = tmp->p_next_desc) {
-			++p_rx_wc_buf_desc->rx.n_frags;
-		}
-#endif
-	}
-
-//We want to enable loopback between processes for IB
-#if 0
-	//AlexV: We don't support Tx MC Loopback today!
-	if (p_ip_h->saddr == m_local_if) {
-		ring_logfunc("Rx udp datagram discarded - mc loop disabled");
-		return false;
-	}
-#endif
-	rfs* p_rfs = NULL;
-
-	// Update the L3 info
-	p_rx_wc_buf_desc->rx.src.sin_family      = AF_INET;
-	p_rx_wc_buf_desc->rx.src.sin_addr.s_addr = p_ip_h->saddr;
-	p_rx_wc_buf_desc->rx.dst.sin_family      = AF_INET;
-	p_rx_wc_buf_desc->rx.dst.sin_addr.s_addr = p_ip_h->daddr;
-
-	switch (p_ip_h->protocol) {
-	case IPPROTO_UDP:
-	{
-		// Get the udp header pointer + udp payload size
-		p_udp_h = (struct udphdr*)((uint8_t*)p_ip_h + ip_hdr_len);
-		size_t sz_payload = ntohs(p_udp_h->len) - sizeof(struct udphdr);
-		ring_logfunc("Rx udp datagram info: src_port=%d, dst_port=%d, payload_sz=%d, csum=%#x",
-				ntohs(p_udp_h->source), ntohs(p_udp_h->dest), sz_payload, p_udp_h->check);
-
-		// Update packet descriptor with datagram base address and length
-		p_rx_wc_buf_desc->rx.frag.iov_base = (uint8_t*)p_udp_h + sizeof(struct udphdr);
-		p_rx_wc_buf_desc->rx.frag.iov_len  = ip_tot_len - ip_hdr_len - sizeof(struct udphdr);
-
-		// Update the L3 info
-		p_rx_wc_buf_desc->rx.udp.local_if        = m_local_if;
-
-		// Update the L4 info
-		p_rx_wc_buf_desc->rx.src.sin_port        = p_udp_h->source;
-		p_rx_wc_buf_desc->rx.dst.sin_port        = p_udp_h->dest;
-		p_rx_wc_buf_desc->rx.sz_payload          = sz_payload;
-
-		// Find the relevant hash map and pass the packet to the rfs for dispatching
-		if (!(IN_MULTICAST_N(p_rx_wc_buf_desc->rx.dst.sin_addr.s_addr))) {	// This is UDP UC packet
-			p_rfs = m_flow_udp_uc_map.get((flow_spec_udp_uc_key_t){p_rx_wc_buf_desc->rx.dst.sin_port}, NULL);
-		} else {	// This is UDP MC packet
-			p_rfs = m_flow_udp_mc_map.get((flow_spec_udp_mc_key_t){p_rx_wc_buf_desc->rx.dst.sin_addr.s_addr,
-				p_rx_wc_buf_desc->rx.dst.sin_port}, NULL);
-		}
-	}
-	break;
-
-	case IPPROTO_TCP:
-	{
-		// Get the tcp header pointer + tcp payload size
-		struct tcphdr* p_tcp_h = (struct tcphdr*)((uint8_t*)p_ip_h + ip_hdr_len);
-		size_t sz_payload = ip_tot_len - ip_hdr_len - p_tcp_h->doff*4;
-		ring_logfunc("Rx TCP segment info: src_port=%d, dst_port=%d, flags='%s%s%s%s%s%s' seq=%u, ack=%u, win=%u, payload_sz=%u",
-				ntohs(p_tcp_h->source), ntohs(p_tcp_h->dest),
-				p_tcp_h->urg?"U":"", p_tcp_h->ack?"A":"", p_tcp_h->psh?"P":"",
-				p_tcp_h->rst?"R":"", p_tcp_h->syn?"S":"", p_tcp_h->fin?"F":"",
-				ntohl(p_tcp_h->seq), ntohl(p_tcp_h->ack_seq), ntohs(p_tcp_h->window),
-				sz_payload);
-
-		// Update packet descriptor with datagram base address and length
-		p_rx_wc_buf_desc->rx.frag.iov_base = (uint8_t*)p_tcp_h + sizeof(struct tcphdr);
-		p_rx_wc_buf_desc->rx.frag.iov_len  = ip_tot_len - ip_hdr_len - sizeof(struct tcphdr);
-
-		// Update the L4 info
-		p_rx_wc_buf_desc->rx.src.sin_port        = p_tcp_h->source;
-		p_rx_wc_buf_desc->rx.dst.sin_port        = p_tcp_h->dest;
-		p_rx_wc_buf_desc->rx.sz_payload          = sz_payload;
-
-		p_rx_wc_buf_desc->rx.tcp.p_ip_h = p_ip_h;
-		p_rx_wc_buf_desc->rx.tcp.p_tcp_h = p_tcp_h;
-
-		// Find the relevant hash map and pass the packet to the rfs for dispatching
-		p_rfs = m_flow_tcp_map.get((flow_spec_tcp_key_t){p_rx_wc_buf_desc->rx.src.sin_addr.s_addr,
-			p_rx_wc_buf_desc->rx.dst.sin_port, p_rx_wc_buf_desc->rx.src.sin_port}, NULL);
-
-		p_rx_wc_buf_desc->rx.tcp.n_transport_header_len = transport_header_len;
-
-		if (unlikely(p_rfs == NULL)) {	// If we didn't find a match for TCP 5T, look for a match with TCP 3T
-			p_rfs = m_flow_tcp_map.get((flow_spec_tcp_key_t){0, p_rx_wc_buf_desc->rx.dst.sin_port, 0}, NULL);
-		}
-	}
-	break;
-
-	default:
-		ring_logwarn("Rx packet dropped - undefined protocol = %d", p_ip_h->protocol);
-		return;
-	}
-
-	if (unlikely(p_rfs == NULL)) {
-		ring_logdbg("Rx packet dropped - rfs object not found: dst:%d.%d.%d.%d:%d, src%d.%d.%d.%d:%d, proto=%s[%d]",
-				NIPQUAD(p_rx_wc_buf_desc->rx.dst.sin_addr.s_addr), ntohs(p_rx_wc_buf_desc->rx.dst.sin_port),
-				NIPQUAD(p_rx_wc_buf_desc->rx.src.sin_addr.s_addr), ntohs(p_rx_wc_buf_desc->rx.src.sin_port),
-				iphdr_protocol_type_to_str(p_ip_h->protocol), p_ip_h->protocol);
-		return;
-	}
-	p_rx_wc_buf_desc->rx.vma_polled = true;
-	p_rfs->rx_dispatch_packet(p_rx_wc_buf_desc, NULL);
-	p_rx_wc_buf_desc->rx.vma_polled = false;
-}
-#endif // DEFINED_VMAPOLL
-
 // All CQ wce come here for some basic sanity checks and then are distributed to the correct ring handler
 // Return values: false = Reuse this data buffer & mem_buf_desc
-bool ring_simple::rx_process_buffer(mem_buf_desc_t* p_rx_wc_buf_desc, transport_type_t transport_type, void* pv_fd_ready_array /*=NULL*/)
+bool ring_simple::rx_process_buffer(mem_buf_desc_t* p_rx_wc_buf_desc, void* pv_fd_ready_array)
 {
 	size_t sz_data = 0;
 	size_t transport_header_len = ETH_HDR_LEN;
@@ -1092,7 +765,6 @@ bool ring_simple::rx_process_buffer(mem_buf_desc_t* p_rx_wc_buf_desc, transport_
 	NOT_IN_USE(ip_frag_off);
 	NOT_IN_USE(n_frag_offset);
 	NOT_IN_USE(p_udp_h);
-	NOT_IN_USE(transport_type);
 #endif // DEFINED_VMAPOLL
 
 	// This is an internal function (within ring and 'friends'). No need for lock mechanism.
@@ -1133,7 +805,7 @@ bool ring_simple::rx_process_buffer(mem_buf_desc_t* p_rx_wc_buf_desc, transport_
 					ntohl(p_tcp_h->seq), ntohl(p_tcp_h->ack_seq), ntohs(p_tcp_h->window),
 					sz_payload);
 */
-				return check_rx_packet(si, p_rx_wc_buf_desc);
+				return check_rx_packet(si, p_rx_wc_buf_desc, pv_fd_ready_array);
 
 			} else if (p_ip_h->protocol==IPPROTO_UDP) {
 				// Get the udp header pointer + udp payload size
@@ -1156,7 +828,7 @@ bool ring_simple::rx_process_buffer(mem_buf_desc_t* p_rx_wc_buf_desc, transport_
 /*				ring_logfunc("FAST PATH Rx UDP datagram info: src_port=%d, dst_port=%d, payload_sz=%d, csum=%#x",
 					     ntohs(p_udp_h->source), ntohs(p_udp_h->dest), sz_payload, p_udp_h->check);
 */
-				return check_rx_packet(si, p_rx_wc_buf_desc);
+				return check_rx_packet(si, p_rx_wc_buf_desc, pv_fd_ready_array);
 			}
 		}
 	}
@@ -1179,7 +851,7 @@ bool ring_simple::rx_process_buffer(mem_buf_desc_t* p_rx_wc_buf_desc, transport_
 	++m_ring_stat_static.n_rx_pkt_count;
 
 	// Validate transport type headers
-	switch (transport_type) {
+	switch (m_transport_type) {
 	case VMA_TRANSPORT_IB:
 	{
 		// Get the data buffer start pointer to the ipoib header pointer
@@ -1245,7 +917,7 @@ bool ring_simple::rx_process_buffer(mem_buf_desc_t* p_rx_wc_buf_desc, transport_
 	}
 	break;
 	default:
-		ring_logwarn("Rx buffer dropped - Unknown transport type %d", transport_type);
+		ring_logwarn("Rx buffer dropped - Unknown transport type %d", m_transport_type);
 		return false;
 	}
 
@@ -1304,7 +976,7 @@ bool ring_simple::rx_process_buffer(mem_buf_desc_t* p_rx_wc_buf_desc, transport_
 		ring_logwarn("packet info: dst=%d.%d.%d.%d, src=%d.%d.%d.%d, packet_sz=%d, frag_offset=%d, id=%d, proto=%s[%d], transport type=%s, (local if: %d.%d.%d.%d)",
 				NIPQUAD(p_ip_h->daddr), NIPQUAD(p_ip_h->saddr),
 				sz_data, n_frag_offset, ntohs(p_ip_h->id),
-				iphdr_protocol_type_to_str(p_ip_h->protocol), p_ip_h->protocol, (transport_type ? "ETH" : "IB"),
+				iphdr_protocol_type_to_str(p_ip_h->protocol), p_ip_h->protocol, (m_transport_type ? "ETH" : "IB"),
 				NIPQUAD(local_addr));
 		return false;*/
 #if 1 //handle fragments
@@ -1439,7 +1111,7 @@ bool ring_simple::rx_process_buffer(mem_buf_desc_t* p_rx_wc_buf_desc, transport_
 		ring_logdbg("Rx IGMP packet info: type=%s (%d), group=%d.%d.%d.%d, code=%d",
 				priv_igmp_type_tostr(p_igmp_h->igmp_type), p_igmp_h->igmp_type,
 				NIPQUAD(p_igmp_h->igmp_group.s_addr), p_igmp_h->igmp_code);
-		if (transport_type == VMA_TRANSPORT_IB  || m_b_sysvar_eth_mc_l2_only_rules) {
+		if (m_transport_type == VMA_TRANSPORT_IB  || m_b_sysvar_eth_mc_l2_only_rules) {
 			ring_logdbg("Transport type is IB (or eth_mc_l2_only_rules), passing igmp packet to igmp_manager to process");
 			if(g_p_igmp_mgr) {
 				(g_p_igmp_mgr->process_igmp_packet(p_ip_h, m_local_if));
@@ -1522,7 +1194,8 @@ int ring_simple::vma_poll(struct vma_completion_t *vma_completions, unsigned int
 				 * may be it is not so critical
 				 */
 				if (likely(m_p_cq_mgr_rx->vma_poll_and_process_element_rx(&desc))) {
-					vma_poll_process_recv_buffer(desc);
+					desc->rx.vma_polled = true;
+					rx_process_buffer(desc, NULL);
 					if (m_vma_poll_completion->events) {
 						m_vma_poll_completion++;
 						i++;

--- a/src/vma/dev/ring_simple.h
+++ b/src/vma/dev/ring_simple.h
@@ -102,7 +102,7 @@ protected:
 #ifdef DEFINED_VMAPOLL	
 	inline void 		vma_poll_process_recv_buffer(mem_buf_desc_t* p_rx_wc_buf_desc);
 #endif // DEFINED_VMAPOLL	
-	bool			rx_process_buffer(mem_buf_desc_t* p_rx_wc_buf_desc, transport_type_t m_transport_type, void* pv_fd_ready_array);
+	bool			rx_process_buffer(mem_buf_desc_t* p_rx_wc_buf_desc, void* pv_fd_ready_array);
 	void			print_flow_to_rfs_udp_uc_map(flow_spec_udp_uc_map_t *p_flow_map);
 	void			print_flow_to_rfs_tcp_map(flow_spec_tcp_map_t *p_flow_map);
 	//	void	print_ring_flow_to_rfs_map(flow_spec_map_t *p_flow_map);

--- a/src/vma/sock/pkt_rcvr_sink.h
+++ b/src/vma/sock/pkt_rcvr_sink.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001-2016 Mellanox Technologies, Ltd. All rights reserved.
+ * Copyright (c) 2001-2017 Mellanox Technologies, Ltd. All rights reserved.
  *
  * This software is available to you under a choice of one of two
  * licenses.  You may choose to be licensed under the terms of the GNU
@@ -57,7 +57,7 @@ public:
 	// Callback from lower layer notifying new receive packets
 	// Return: 'true' if object queuing this receive packet
 	//         'false' if not interested in this receive packet
-	virtual bool rx_input_cb(mem_buf_desc_t* p_rx_pkt_mem_buf_desc_info, void* pv_fd_ready_array = NULL) = 0;
+	virtual bool rx_input_cb(mem_buf_desc_t* p_rx_pkt_mem_buf_desc_info, void* pv_fd_ready_array) = 0;
 
 	// Callback from lower layer notifying completion of RX registration process
 	virtual void rx_add_ring_cb(flow_tuple_with_local_if &flow_key, ring* p_ring, bool is_migration = false) = 0;

--- a/src/vma/sock/sockinfo.cpp
+++ b/src/vma/sock/sockinfo.cpp
@@ -457,6 +457,7 @@ bool sockinfo::attach_receiver(flow_tuple_with_local_if &flow_key)
 		si_logdbg("Failed to attach %s to ring %p", flow_key.to_str(), p_nd_resources->p_ring);
 		return false;
 	}
+	set_rx_packet_processor();
 	lock_rx_q();
 	BULLSEYE_EXCLUDE_BLOCK_END
 

--- a/src/vma/sock/sockinfo.h
+++ b/src/vma/sock/sockinfo.h
@@ -246,7 +246,7 @@ protected:
 	// According to bounded information we need to attach to all UC relevant flows
 	// If local_ip is ANY then we need to attach to all offloaded interfaces OR to the one our connected_ip is routed to
 	bool			attach_as_uc_receiver(role_t role, bool skip_rules = false);
-
+	virtual void		set_rx_packet_processor(void) = 0;
 	transport_t 		find_target_family(role_t role, struct sockaddr *sock_addr_first, struct sockaddr *sock_addr_second = NULL);
 
 	// This callback will notify that socket is ready to receive and map the cq.

--- a/src/vma/sock/sockinfo_tcp.cpp
+++ b/src/vma/sock/sockinfo_tcp.cpp
@@ -1899,6 +1899,7 @@ bool sockinfo_tcp::rx_input_cb(mem_buf_desc_t* p_rx_pkt_mem_buf_desc_info, void*
 #ifdef DEFINED_VMAPOLL		
 	m_vma_poll_completion = NULL;
 	m_vma_poll_last_buff_lst = NULL;
+	p_rx_pkt_mem_buf_desc_info->rx.vma_polled = false;
 #endif // DEFINED_VMAPOLL			
 
 	while (dropped_count--) {

--- a/src/vma/sock/sockinfo_tcp.h
+++ b/src/vma/sock/sockinfo_tcp.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001-2016 Mellanox Technologies, Ltd. All rights reserved.
+ * Copyright (c) 2001-2017 Mellanox Technologies, Ltd. All rights reserved.
  *
  * This software is available to you under a choice of one of two
  * licenses.  You may choose to be licensed under the terms of the GNU
@@ -147,7 +147,9 @@ public:
 	static err_t ip_output_syn_ack(struct pbuf *p, void* v_p_conn, int is_rexmit, uint8_t is_dummy);
 	static void tcp_state_observer(void* pcb_container, enum tcp_state new_state);
 
-	virtual bool rx_input_cb(mem_buf_desc_t* p_rx_pkt_mem_buf_desc_info, void* pv_fd_ready_array = NULL);
+	virtual bool rx_input_cb(mem_buf_desc_t* p_rx_pkt_mem_buf_desc_info, void* pv_fd_ready_array);
+	virtual void set_rx_packet_processor(void) { }
+
 	static struct pbuf * tcp_tx_pbuf_alloc(void* p_conn);
 	static void tcp_tx_pbuf_free(void* p_conn, struct pbuf *p_buff);
 	static struct tcp_seg * tcp_seg_alloc(void* p_conn);

--- a/src/vma/sock/sockinfo_udp.cpp
+++ b/src/vma/sock/sockinfo_udp.cpp
@@ -365,6 +365,7 @@ tscval_t g_si_tscv_last_poll = 0;
 
 sockinfo_udp::sockinfo_udp(int fd) throw (vma_exception) :
 	sockinfo(fd)
+	,m_rx_packet_processor(&sockinfo_udp::rx_process_udp_packet_full)
 	,m_mc_tx_if(INADDR_ANY)
 	,m_b_mc_tx_loop(safe_mce_sys().tx_mc_loopback_default) // default value is 'true'. User can change this with config parameter SYS_VAR_TX_MC_LOOPBACK
 	,m_n_mc_ttl(DEFAULT_MC_TTL)
@@ -385,6 +386,9 @@ sockinfo_udp::sockinfo_udp(int fd) throw (vma_exception) :
 	,m_n_sysvar_rx_cq_drain_rate_nsec(safe_mce_sys().rx_cq_drain_rate_nsec)
 	,m_n_sysvar_rx_delta_tsc_between_cq_polls(safe_mce_sys().rx_delta_tsc_between_cq_polls)
 	,m_reuseaddr(false)
+	,m_sockopt_mapped(false)
+	,m_is_connected(false)
+	,m_multicast(false)
 {
 	si_udp_logfunc("");
 
@@ -583,6 +587,9 @@ int sockinfo_udp::connect(const struct sockaddr *__to, socklen_t __tolen)
 			return 0; // zero returned from orig_connect()
 		}
 		BULLSEYE_EXCLUDE_BLOCK_END
+
+		m_is_connected = true; // will inspect for SRC
+
 		on_sockname_change(name, *namelen);
 
 		si_udp_logdbg("bound to %s", m_bound.to_str());
@@ -608,6 +615,7 @@ int sockinfo_udp::connect(const struct sockaddr *__to, socklen_t __tolen)
 			m_p_socket_stats->connected_ip = INADDR_ANY;
 			m_connected.set_in_port(INPORT_ANY);
 			m_p_socket_stats->connected_port = INPORT_ANY;
+			m_is_connected = false; // will skip inspection for SRC
 			return 0;
 		}
 		BULLSEYE_EXCLUDE_BLOCK_END
@@ -1108,6 +1116,7 @@ int sockinfo_udp::setsockopt(int __level, int __optname, __const void *__optval,
 				si_udp_logdbg("found UDP_MAP_ADD socket fd for port %d. fd is %d", ntohs(port_socket.port), port_socket.fd);			
 				m_port_map.push_back(port_socket);
 			}
+			m_sockopt_mapped = true;
 			m_port_map_lock.unlock();
 			return 0;
 
@@ -1120,6 +1129,7 @@ int sockinfo_udp::setsockopt(int __level, int __optname, __const void *__optval,
 			si_udp_logdbg("stopping de-muxing packets to port %d", ntohs(port));
 			m_port_map_lock.lock();
 			m_port_map.erase(std::remove(m_port_map.begin(), m_port_map.end(), port), m_port_map.end());
+			m_sockopt_mapped = false;
 			m_port_map_lock.unlock();
 			return 0;
 		} // case IPPROTO_UDP
@@ -1775,57 +1785,24 @@ bool sockinfo_udp::tx_check_if_would_not_block()
     #pragma BullseyeCoverage on
 #endif
 
-bool sockinfo_udp::rx_input_cb(mem_buf_desc_t* p_desc, void* pv_fd_ready_array)
+/**
+ * sockinfo_udp::inspect_uc_packet inspects the input packet for basic rules,
+ * common for all cases. Its applicable for UC case as well.
+ */
+inline bool sockinfo_udp::inspect_uc_packet(mem_buf_desc_t* p_desc)
 {
 	// Check that sockinfo is bound to the packets dest port
+	// This protects the case where a socket is closed and a new one is rapidly opened
+	// receiving the same socket id.
+	// In this case packets arriving for the old sockets should be dropped.
+	// This distinction assumes that the OS guarantees the old and new sockets to receive different
+	// port numbers from bind().
+	// If the user requests to bind the new socket to the same port number as the old one it will be
+	// impossible to identify packets designated for the old socket in this way.
 	if (unlikely(p_desc->rx.dst.sin_port != m_bound.get_in_port())) {
 		si_udp_logfunc("rx packet discarded - not socket's bound port (pkt: %d, sock:%s)",
-		           ntohs(p_desc->rx.dst.sin_port), m_bound.to_str_in_port());
+			   ntohs(p_desc->rx.dst.sin_port), m_bound.to_str_in_port());
 		return false;
-	}
-
-	if (m_connected.get_in_port() != INPORT_ANY && m_connected.get_in_addr() != INADDR_ANY) {
-		if (unlikely(m_connected.get_in_port() != p_desc->rx.src.sin_port)) {
-			si_udp_logfunc("rx packet discarded - not socket's connected port (pkt: %d, sock:%s)",
-				   ntohs(p_desc->rx.src.sin_port), m_connected.to_str_in_port());
-			return false;
-		}
-
-		if (unlikely(m_connected.get_in_addr() != p_desc->rx.src.sin_addr.s_addr)) {
-			si_udp_logfunc("rx packet discarded - not socket's connected port (pkt: [%d:%d:%d:%d], sock:[%s])",
-				   NIPQUAD(p_desc->rx.src.sin_addr.s_addr), m_connected.to_str_in_addr());
-			return false;
-		}
-	}
-
-	// if loopback is disabled, discard loopback packets.
-	// in linux, loopback control (set by setsockopt) is done in TX flow.
-	// since we currently can't control it in TX, we behave like windows, which filter on RX
-	if (unlikely(!m_b_mc_tx_loop && p_desc->rx.udp.local_if == p_desc->rx.src.sin_addr.s_addr)) {
-		si_udp_logfunc("rx packet discarded - loopback is disabled (pkt: [%d:%d:%d:%d], sock:%s)",
-			NIPQUAD(p_desc->rx.src.sin_addr.s_addr), m_bound.to_str_in_addr());
-		return false;
-	}
-
-	// Check port mapping - redirecting packets to another socket
-	while (!m_port_map.empty()) {
-		m_port_map_lock.lock();
-		if (m_port_map.empty()) {
-			m_port_map_lock.unlock();
-			break;
-		}
-		m_port_map_index = ((m_port_map_index + 1) >= m_port_map.size() ? 0 : (m_port_map_index + 1));
-		int new_port = m_port_map[m_port_map_index].port;
-		socket_fd_api* sock_api = g_p_fd_collection->get_sockfd(m_port_map[m_port_map_index].fd);
-		if (!sock_api || sock_api->get_type()!=FD_TYPE_SOCKET) {
-			m_port_map.erase(std::remove(m_port_map.begin(), m_port_map.end(), m_port_map[m_port_map_index].port));
-			if(m_port_map_index) m_port_map_index--;
-			m_port_map_lock.unlock();
-			continue;
-		}
-		m_port_map_lock.unlock();
-		p_desc->rx.dst.sin_port = new_port;
-		return ((sockinfo_udp*)sock_api)->rx_input_cb(p_desc, pv_fd_ready_array);
 	}
 
 	// Check if sockinfo rx byte quato reached - then disregard this packet
@@ -1840,7 +1817,45 @@ bool sockinfo_udp::rx_input_cb(mem_buf_desc_t* p_desc, void* pv_fd_ready_array)
 		si_udp_logfunc("rx packet discarded - fd closed");
 		return false;
 	}
+	return true;
+}
 
+/**
+ *	Inspects UDP packets in case socket was connected
+ *
+ */
+inline bool sockinfo_udp::inspect_connected(mem_buf_desc_t* p_desc)
+{
+	if ((m_connected.get_in_port() != INPORT_ANY) && (m_connected.get_in_addr() != INADDR_ANY)) {
+		if (unlikely(m_connected.get_in_port() != p_desc->rx.src.sin_port)) {
+			si_udp_logfunc("rx packet discarded - not socket's connected port (pkt: %d, sock:%s)",
+				   ntohs(p_desc->rx.src.sin_port), m_connected.to_str_in_port());
+			return false;
+		}
+
+		if (unlikely(m_connected.get_in_addr() != p_desc->rx.src.sin_addr.s_addr)) {
+			si_udp_logfunc("rx packet discarded - not socket's connected port (pkt: [%d:%d:%d:%d], sock:[%s])",
+				   NIPQUAD(p_desc->rx.src.sin_addr.s_addr), m_connected.to_str_in_addr());
+			return false;
+		}
+	}
+	return true;
+}
+
+/**
+ *	Inspects multicast packets
+ *
+ */
+inline bool sockinfo_udp::inspect_mc_packet(mem_buf_desc_t* p_desc)
+{
+	// if loopback is disabled, discard loopback packets.
+	// in linux, loopback control (set by setsockopt) is done in TX flow.
+	// since we currently can't control it in TX, we behave like windows, which filter on RX
+	if (unlikely(!m_b_mc_tx_loop && p_desc->rx.udp.local_if == p_desc->rx.src.sin_addr.s_addr)) {
+		si_udp_logfunc("rx packet discarded - loopback is disabled (pkt: [%d:%d:%d:%d], sock:%s)",
+			NIPQUAD(p_desc->rx.src.sin_addr.s_addr), m_bound.to_str_in_addr());
+		return false;
+	}
 	if (m_mc_num_grp_with_src_filter) {
 		in_addr_t mc_grp = p_desc->rx.dst.sin_addr.s_addr;
 		if (IN_MULTICAST_N(mc_grp)) {
@@ -1854,6 +1869,14 @@ bool sockinfo_udp::rx_input_cb(mem_buf_desc_t* p_desc, void* pv_fd_ready_array)
 			}
 		}
 	}
+	return true;
+}
+
+/**
+ * Function to process SW & HW timestamps
+ */
+inline void sockinfo_udp::process_timestamps(mem_buf_desc_t* p_desc)
+{
 	// keep the sw_timestamp the same to all sockets
 	if ((m_b_rcvtstamp ||
 		 (m_n_tsing_flags &
@@ -1869,60 +1892,52 @@ bool sockinfo_udp::rx_input_cb(mem_buf_desc_t* p_desc, void* pv_fd_ready_array)
 			owner_ring->convert_hw_time_to_system_time(p_desc->rx.hw_raw_timestamp, &p_desc->rx.udp.hw_timestamp);
 		}
 	}
+}
 
-	vma_recv_callback_retval_t callback_retval = VMA_PACKET_RECV;
-	if (m_rx_callback) {
-		mem_buf_desc_t *tmp;
-		vma_info_t pkt_info;
-		int nr_frags = 0;
+/**
+ *	Performs inspection by registered user callback
+ *
+ */
+inline vma_recv_callback_retval_t sockinfo_udp::inspect_by_user_cb(mem_buf_desc_t* p_desc)
+{
+	vma_info_t pkt_info;
 
-		pkt_info.struct_sz = sizeof(pkt_info);
-		pkt_info.packet_id = (void*)p_desc;
-		pkt_info.src = &p_desc->rx.src;
-		pkt_info.dst = &p_desc->rx.dst;
-		pkt_info.socket_ready_queue_pkt_count = m_p_socket_stats->n_rx_ready_pkt_count;
-		pkt_info.socket_ready_queue_byte_count = m_p_socket_stats->n_rx_ready_byte_count;
-		if (m_n_tsing_flags & SOF_TIMESTAMPING_RAW_HARDWARE) {
-			pkt_info.hw_timestamp = p_desc->rx.udp.hw_timestamp;
-		}
-		if (p_desc->rx.udp.sw_timestamp.tv_sec) {
-			pkt_info.sw_timestamp = p_desc->rx.udp.sw_timestamp;
-		}
+	pkt_info.struct_sz = sizeof(pkt_info);
+	pkt_info.packet_id = (void*)p_desc;
+	pkt_info.src = &p_desc->rx.src;
+	pkt_info.dst = &p_desc->rx.dst;
+	pkt_info.socket_ready_queue_pkt_count = m_p_socket_stats->n_rx_ready_pkt_count;
+	pkt_info.socket_ready_queue_byte_count = m_p_socket_stats->n_rx_ready_byte_count;
 
-		// fill io vector array with data buffer pointers
-		iovec iov[p_desc->rx.n_frags];
-		nr_frags = 0;
-		for (tmp = p_desc; tmp; tmp = tmp->p_next_desc) {
-			iov[nr_frags++] = tmp->rx.frag;
-		}
-
-		// call user callback
-		callback_retval = m_rx_callback(m_fd, nr_frags, iov,
-		                                &pkt_info, m_rx_callback_context);
-
-		if (callback_retval == VMA_PACKET_DROP) {
-			si_udp_logfunc("rx packet discarded - by user callback");
-			return false;
-		}
+	if (m_n_tsing_flags & SOF_TIMESTAMPING_RAW_HARDWARE) {
+		pkt_info.hw_timestamp = p_desc->rx.udp.hw_timestamp;
+	}
+	if (p_desc->rx.udp.sw_timestamp.tv_sec) {
+		pkt_info.sw_timestamp = p_desc->rx.udp.sw_timestamp;
 	}
 
-	// Yes, we want to keep this packet!
-	// And we must increment ref_counter before pushing this packet into the ready queue
-	//  to prevent race condition with the 'if( (--ref_count) <= 0)' in ib_comm_mgr
-	p_desc->inc_ref_count();
+	// fill io vector array with data buffer pointers
+	iovec iov[p_desc->rx.n_frags];
+	int nr_frags = 0;
+
+	for (mem_buf_desc_t *tmp = p_desc; tmp; tmp = tmp->p_next_desc) {
+		iov[nr_frags++] = tmp->rx.frag;
+	}
+
+	// call user callback
+	return m_rx_callback(m_fd, nr_frags, iov, &pkt_info, m_rx_callback_context);
+}
 
 #ifdef DEFINED_VMAPOLL
-	/* Update vma_completion with
-	 * VMA_POLL_PACKET related data
-	 */
+/* Update vma_completion with
+ * VMA_POLL_PACKET related data
+ */
+inline void sockinfo_udp::fill_completion(mem_buf_desc_t* p_desc)
+{
 	struct vma_completion_t *completion;
-	mem_buf_desc_t *tmp_p;
 
 	/* Try to process vma_poll() completion directly */
-	if (p_desc->rx.vma_polled) {
-		m_vma_poll_completion = m_p_rx_ring->get_comp();
-		m_vma_poll_last_buff_lst = NULL;
-	}
+	m_vma_poll_completion = m_p_rx_ring->get_comp();
 
 	if (m_vma_poll_completion) {
 		completion = m_vma_poll_completion;
@@ -1930,25 +1945,32 @@ bool sockinfo_udp::rx_input_cb(mem_buf_desc_t* p_desc, void* pv_fd_ready_array)
 		completion = &m_ec.completion;
 	}
 
-	completion->packet.buff_lst = (struct vma_buff_t*)p_desc;
-	completion->packet.total_len = 0;
-	completion->src = p_desc->rx.src;
 	completion->packet.num_bufs = p_desc->rx.n_frags;
+	completion->packet.total_len = 0;
 
-	for(tmp_p = p_desc; tmp_p; tmp_p = tmp_p->p_next_desc) {
-		completion->packet.buff_lst = (struct vma_buff_t*)tmp_p;
-		completion->packet.buff_lst->next = (struct vma_buff_t*)tmp_p->p_next_desc;
-		completion->packet.buff_lst->len = p_desc->rx.frag.iov_len;
+	for(mem_buf_desc_t *tmp_p=p_desc; tmp_p; tmp_p=tmp_p->p_next_desc) {
+		completion->packet.total_len        += tmp_p->rx.sz_payload;
+		completion->packet.buff_lst          = (struct vma_buff_t*)tmp_p;
+		completion->packet.buff_lst->next    = (struct vma_buff_t*)tmp_p->p_next_desc;
 		completion->packet.buff_lst->payload = p_desc->rx.frag.iov_base;
-		completion->packet.total_len += tmp_p->rx.sz_payload;
+		completion->packet.buff_lst->len     = p_desc->rx.frag.iov_len;
 	}
+	completion->src = p_desc->rx.src;
 	NOTIFY_ON_EVENTS(this, VMA_POLL_PACKET);
 
 	m_vma_poll_completion = NULL;
-		m_vma_poll_last_buff_lst = NULL;
-#else		
+	m_vma_poll_last_buff_lst = NULL;
+}
+#endif //DEFINED_VMAPOLL
+
+/**
+ *	Performs packet processing for NON-VMAPOLL cases and store packet
+ *	in ready queue.
+ */
+inline void sockinfo_udp::update_ready(mem_buf_desc_t* p_desc, void* pv_fd_ready_array, vma_recv_callback_retval_t cb_ret)
+{
 	// In ZERO COPY case we let the user's application manage the ready queue
-	if (callback_retval != VMA_PACKET_HOLD) {
+	if (cb_ret != VMA_PACKET_HOLD) {
 		m_lock_rcv.lock();
 		// Save rx packet info in our ready list
 		m_rx_pkt_ready_list.push_back(p_desc);
@@ -1956,8 +1978,10 @@ bool sockinfo_udp::rx_input_cb(mem_buf_desc_t* p_desc, void* pv_fd_ready_array)
 		m_rx_ready_byte_count += p_desc->rx.sz_payload;
 		m_p_socket_stats->n_rx_ready_pkt_count++;
 		m_p_socket_stats->n_rx_ready_byte_count += p_desc->rx.sz_payload;
-		m_p_socket_stats->counters.n_rx_ready_pkt_max = max((uint32_t)m_p_socket_stats->n_rx_ready_pkt_count, m_p_socket_stats->counters.n_rx_ready_pkt_max);
-		m_p_socket_stats->counters.n_rx_ready_byte_max = max((uint32_t)m_p_socket_stats->n_rx_ready_byte_count, m_p_socket_stats->counters.n_rx_ready_byte_max);
+		m_p_socket_stats->counters.n_rx_ready_pkt_max = max((uint32_t)m_p_socket_stats->n_rx_ready_pkt_count, 
+								    m_p_socket_stats->counters.n_rx_ready_pkt_max);
+		m_p_socket_stats->counters.n_rx_ready_byte_max = max((uint32_t)m_p_socket_stats->n_rx_ready_byte_count,
+								     m_p_socket_stats->counters.n_rx_ready_byte_max);
 		do_wakeup();
 		m_lock_rcv.unlock();
 	} else {
@@ -1974,11 +1998,124 @@ bool sockinfo_udp::rx_input_cb(mem_buf_desc_t* p_desc, void* pv_fd_ready_array)
 	io_mux_call::update_fd_array((fd_array_t*)pv_fd_ready_array, m_fd);
 
 	si_udp_logfunc("rx ready count = %d packets / %d bytes", m_n_rx_pkt_ready_list_count, m_p_socket_stats->n_rx_ready_byte_count);
+}
 
-	// Yes we like this packet - keep it!
-#endif // DEFINED_VMAPOLL
+/**
+ *	Performs full inspection and processing for generic UDP
+ *	It will be bypassing some inspections if appropriate flags were
+ *	not set.
+ */
+inline bool sockinfo_udp::rx_process_udp_packet_full(mem_buf_desc_t* p_desc, void* pv_fd_ready_array)
+{
+	if (!inspect_uc_packet(p_desc))
+		return false;
 
-return true;
+	if (m_is_connected && !inspect_connected(p_desc))
+		return false;
+
+	if (m_multicast && !inspect_mc_packet(p_desc))
+		return false;
+
+	if (m_sockopt_mapped) {
+		// Check port mapping - redirecting packets to another socket
+		while (!m_port_map.empty()) {
+			m_port_map_lock.lock();
+			if (m_port_map.empty()) {
+				m_port_map_lock.unlock();
+				break;
+			}
+			m_port_map_index = ((m_port_map_index + 1) >= m_port_map.size() ? 0 : (m_port_map_index + 1));
+			int new_port = m_port_map[m_port_map_index].port;
+			socket_fd_api* sock_api = g_p_fd_collection->get_sockfd(m_port_map[m_port_map_index].fd);
+			if (!sock_api || sock_api->get_type()!=FD_TYPE_SOCKET) {
+				m_port_map.erase(std::remove(m_port_map.begin(), m_port_map.end(), m_port_map[m_port_map_index].port));
+				if (m_port_map_index)
+					m_port_map_index--;
+				m_port_map_lock.unlock();
+				continue;
+			}
+			m_port_map_lock.unlock();
+			p_desc->rx.dst.sin_port = new_port;
+			return ((sockinfo_udp*)sock_api)->rx_process_udp_packet_full(p_desc, pv_fd_ready_array);
+		}
+	}
+
+	process_timestamps(p_desc);
+
+	vma_recv_callback_retval_t cb_ret = VMA_PACKET_RECV;
+	if (m_rx_callback && ((cb_ret=inspect_by_user_cb(p_desc))==VMA_PACKET_DROP)) {
+		si_udp_logfunc("rx packet discarded - by user callback");
+		return false;
+	}
+	// Yes, we want to keep this packet!
+	// And we must increment ref_counter before pushing this packet into the ready queue
+	//  to prevent race condition with the 'if( (--ref_count) <= 0)' in ib_comm_mgr
+	p_desc->inc_ref_count();
+
+#ifdef DEFINED_VMAPOLL
+	if (p_desc->rx.vma_polled) {
+		fill_completion(p_desc);
+		p_desc->rx.vma_polled = false;
+	} else
+#endif
+	{
+		update_ready(p_desc, pv_fd_ready_array, cb_ret);
+	}
+	return true;
+}
+
+/**
+ *	Performs inspection and processing for simple UC UDP case
+ *	bypassing all other inspections
+ */
+inline bool sockinfo_udp::rx_process_udp_packet_partial(mem_buf_desc_t* p_desc, void* pv_fd_ready_array)
+{
+	if (!inspect_uc_packet(p_desc))
+		return false;
+
+	process_timestamps(p_desc);
+
+	vma_recv_callback_retval_t cb_ret = VMA_PACKET_RECV;
+	if (m_rx_callback && ((cb_ret=inspect_by_user_cb(p_desc))==VMA_PACKET_DROP)) {
+		si_udp_logfunc("rx packet discarded - by user callback");
+		return false;
+	}
+	// Yes, we want to keep this packet!
+	// And we must increment ref_counter before pushing this packet into the ready queue
+	//  to prevent race condition with the 'if( (--ref_count) <= 0)' in ib_comm_mgr
+	p_desc->inc_ref_count();
+
+#ifdef DEFINED_VMAPOLL
+	if (p_desc->rx.vma_polled) {
+		fill_completion(p_desc);
+		p_desc->rx.vma_polled = false;
+	} else
+#endif
+	{
+		update_ready(p_desc, pv_fd_ready_array, cb_ret);
+	}
+	return true;
+}
+
+/**
+ *	set packet inspector and processor
+ */
+inline void sockinfo_udp::set_rx_packet_processor(void)
+{
+	si_udp_logdbg("is_connected: %d mapped: %d multicast: %d",
+		      m_is_connected, m_sockopt_mapped, m_multicast);
+	// Select partial or full packet processing.
+	// Full packet processing is selected in case of:
+	// - connect() was done on the UDP socket
+	//   In this case the UDP 3-tuple is not sufficient for the packet matching.
+	// - In the case that socket mapping is enabled extra processing is required
+	// - Multicast packets
+	// For simple UC traffic reduced packet processing is selected.
+	if (m_is_connected || m_sockopt_mapped || m_multicast) {
+		m_rx_packet_processor = &sockinfo_udp::rx_process_udp_packet_full;
+	} else {
+		m_rx_packet_processor = &sockinfo_udp::rx_process_udp_packet_partial;
+	}
 }
 
 void sockinfo_udp::rx_add_ring_cb(flow_tuple_with_local_if &flow_key, ring* p_ring, bool is_migration /* = false */)
@@ -2219,6 +2356,7 @@ int sockinfo_udp::mc_change_membership(const mc_pending_pram *p_mc_pram)
 		}
 		vma_stats_mc_group_add(mc_grp, m_p_socket_stats);
 		original_os_setsockopt_helper( &mreq_src, pram_size, p_mc_pram->optname);
+		m_multicast = true;
 		break;
 	}
 	case IP_ADD_SOURCE_MEMBERSHIP:
@@ -2231,6 +2369,7 @@ int sockinfo_udp::mc_change_membership(const mc_pending_pram *p_mc_pram)
 		vma_stats_mc_group_add(mc_grp, m_p_socket_stats);
 		pram_size = sizeof(ip_mreq_source);
 		original_os_setsockopt_helper( &mreq_src, pram_size, p_mc_pram->optname);
+		m_multicast = true;
 		break;
 	}
 	case IP_DROP_MEMBERSHIP:
@@ -2241,6 +2380,7 @@ int sockinfo_udp::mc_change_membership(const mc_pending_pram *p_mc_pram)
 			return -1;
 		}
 		vma_stats_mc_group_remove(mc_grp, m_p_socket_stats);
+		m_multicast = false;
 		break;
 	}
 	case IP_DROP_SOURCE_MEMBERSHIP:
@@ -2248,6 +2388,7 @@ int sockinfo_udp::mc_change_membership(const mc_pending_pram *p_mc_pram)
 		flow_tuple_with_local_if flow_key(mc_grp, m_bound.get_in_port(), 0, 0, PROTO_UDP, mc_if);
 		pram_size = sizeof(ip_mreq_source);
 		original_os_setsockopt_helper( &mreq_src, pram_size, p_mc_pram->optname);
+		m_multicast = false;
 		if (1 == m_mc_memberships_map[mc_grp].size()) { //Last source in the group
 			if (!detach_receiver(flow_key)) {
 				return -1;


### PR DESCRIPTION
The goal of these changes is to reduce amount of UDP packet inspections
for VMAPOLL/FlowTag modes with possible extending for other IOMUX
modes to improve processing time and reduce latency:

- Solid design of rx_input_cb() was replaced by new set of functions for
  packet inspection and processing on sockinfo_udp layer. This allows to
  create reduced custom processing for trivial UC case. Processing with
  full inspection still exist but also controls by several bool modes set
  in appropriate management functions.

- On Ring level vma_poll_process_recv_buffer() was excluded and replaced
  by call rx_process_buffer used for other non-VMAPOLL modes. Its allows
  to improve maintenance as well as better I-cache locality especially
  for mixed modes.

Signed-off-by: Oleg Kuporosov <olegk@mellanox.com>