### PR TITLE
issue: 1011829 Add VMA_TCP_NODELAY parameter which automatically disable

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -163,6 +163,7 @@ Example:
  VMA DETAILS: TCP Timer Resolution (msec)    100                        [VMA_TCP_TIMER_RESOLUTION_MSEC]
  VMA DETAILS: TCP control thread             0 (Disabled)               [VMA_TCP_CTL_THREAD]
  VMA DETAILS: TCP timestamp option           0                          [VMA_TCP_TIMESTAMP_OPTION]
+ VMA DETAILS: TCP nodelay                    0                          [VMA_TCP_NODELAY]
  VMA DETAILS: Exception handling mode        -1 (just log debug message) [VMA_EXCEPTION_HANDLING]
  VMA DETAILS: Avoid sys-calls on tcp fd      Disabled                   [VMA_AVOID_SYS_CALLS_ON_TCP_FD]
  VMA DETAILS: Delay after join (msec)        0                          [VMA_WAIT_AFTER_JOIN_MSEC]
@@ -273,6 +274,7 @@ latency
      VMA_CQ_AIM_MAX_COUNT = 128               (default: 560)
      VMA_CQ_AIM_INTERVAL_MSEC = Disable       (default: 250)
      VMA_CQ_KEEP_QP_FULL = Disable            (default: Enable)
+     VMA_TCP_NODELAY = Enable                 (default: Disable)
      VMA_AVOID_SYS_CALLS_ON_TCP_FD = Enable   (default: Disable)
      VMA_INTERNAL_THREAD_AFFINITY = 0         (default: -1)
      VMA_THREAD_MODE = Single                 (default: Multi spin lock)
@@ -698,6 +700,16 @@ Use value of 1 for enable.
 Use value of 2 for OS follow up.
 Disabled by default (enabling causing a slight performance
 degradation of ~50-100 nano sec per half round trip)
+
+VMA_TCP_NODELAY
+If set, disable the Nagle algorithm for each tcp socket.
+This means that segments are always sent as soon as possible, even if there is
+only a small amount of data.
+For more info about TCP_NODELAY flag, Please refer to tcp manual page.
+Valid Values are:
+Use value of 0 to disable.
+Use value of 1 for enable.
+Default value is disabled.
 
 VMA_RX_SW_CSUM
 This parameter enables/disables software checksum validation for ingress TCP/UDP IP packets.

--- a/src/vma/main.cpp
+++ b/src/vma/main.cpp
@@ -547,6 +547,7 @@ void print_vma_global_settings()
 	VLOG_PARAM_NUMBER("TCP Timer Resolution (msec)", safe_mce_sys().tcp_timer_resolution_msec, MCE_DEFAULT_TCP_TIMER_RESOLUTION_MSEC, SYS_VAR_TCP_TIMER_RESOLUTION_MSEC);
 	VLOG_PARAM_NUMSTR("TCP control thread", safe_mce_sys().tcp_ctl_thread, MCE_DEFAULT_TCP_CTL_THREAD, SYS_VAR_TCP_CTL_THREAD, ctl_thread_str(safe_mce_sys().tcp_ctl_thread));
 	VLOG_PARAM_NUMBER("TCP timestamp option", safe_mce_sys().tcp_ts_opt, MCE_DEFAULT_TCP_TIMESTAMP_OPTION, SYS_VAR_TCP_TIMESTAMP_OPTION);
+	VLOG_PARAM_NUMBER("TCP nodelay", safe_mce_sys().tcp_nodelay, MCE_DEFAULT_TCP_NODELAY, SYS_VAR_TCP_NODELAY);
 	VLOG_PARAM_NUMSTR(vma_exception_handling::getName(), (int)safe_mce_sys().exception_handling, vma_exception_handling::MODE_DEFAULT, vma_exception_handling::getSysVar(), safe_mce_sys().exception_handling.to_str());
 	VLOG_PARAM_STRING("Avoid sys-calls on tcp fd", safe_mce_sys().avoid_sys_calls_on_tcp_fd, MCE_DEFAULT_AVOID_SYS_CALLS_ON_TCP_FD, SYS_VAR_AVOID_SYS_CALLS_ON_TCP_FD, safe_mce_sys().avoid_sys_calls_on_tcp_fd ? "Enabled" : "Disabled");
 	VLOG_PARAM_STRING("Allow privileged sock opt", safe_mce_sys().allow_privileged_sock_opt, MCE_DEFAULT_ALLOW_PRIVILEGED_SOCK_OPT, SYS_VAR_ALLOW_PRIVILEGED_SOCK_OPT, safe_mce_sys().allow_privileged_sock_opt ? "Enabled" : "Disabled");

--- a/src/vma/util/sys_vars.cpp
+++ b/src/vma/util/sys_vars.cpp
@@ -463,6 +463,7 @@ void mce_sys_var::get_env_params()
 	internal_thread_tcp_timer_handling = MCE_DEFAULT_INTERNAL_THREAD_TCP_TIMER_HANDLING;
 	tcp_ctl_thread		= MCE_DEFAULT_TCP_CTL_THREAD;
 	tcp_ts_opt		= MCE_DEFAULT_TCP_TIMESTAMP_OPTION;
+	tcp_nodelay		= MCE_DEFAULT_TCP_NODELAY;
 //	exception_handling is handled by its CTOR
 	avoid_sys_calls_on_tcp_fd = MCE_DEFAULT_AVOID_SYS_CALLS_ON_TCP_FD;
 	allow_privileged_sock_opt = MCE_DEFAULT_ALLOW_PRIVILEGED_SOCK_OPT;
@@ -524,6 +525,7 @@ void mce_sys_var::get_env_params()
 		cq_keep_qp_full		= false; //MCE_DEFAULT_CQ_KEEP_QP_FULL(true)
 		thread_mode		= THREAD_MODE_SINGLE;
 		mem_alloc_type          = ALLOC_TYPE_HUGEPAGES;
+		tcp_nodelay		= true; // MCE_DEFAULT_TCP_NODELAY
 		strcpy(internal_thread_affinity_str, "0"); //MCE_DEFAULT_INTERNAL_THREAD_AFFINITY_STR;
 		break;
 
@@ -547,6 +549,7 @@ void mce_sys_var::get_env_params()
 		progress_engine_interval_msec = 100; //MCE_DEFAULT_PROGRESS_ENGINE_INTERVAL_MSEC (10)
 		select_poll_os_ratio          = 100; //MCE_DEFAULT_SELECT_POLL_OS_RATIO (10)
 		select_poll_os_force	      = 1;   //MCE_DEFAULT_SELECT_POLL_OS_FORCE (0)
+		tcp_nodelay	      	      = true; // MCE_DEFAULT_TCP_NODELAY
 		break;
 
 	case MCE_SPEC_29WEST_LBM_29:
@@ -961,6 +964,10 @@ void mce_sys_var::get_env_params()
 			vlog_printf(VLOG_WARNING,"TCP timestamp option value is out of range [%d] (min=%d, max=%d). using default [%d]\n", tcp_ts_opt, TCP_TS_OPTION_DISABLE , TCP_TS_OPTION_LAST - 1, MCE_DEFAULT_TCP_TIMESTAMP_OPTION);
 			tcp_ts_opt = MCE_DEFAULT_TCP_TIMESTAMP_OPTION;
 		}
+	}
+
+	if ((env_ptr = getenv(SYS_VAR_TCP_NODELAY)) != NULL) {
+		tcp_nodelay = atoi(env_ptr) ? true : false;
 	}
 
 	// TODO: this should be replaced by calling "exception_handling.init()" that will be called from init()

--- a/src/vma/util/sys_vars.h
+++ b/src/vma/util/sys_vars.h
@@ -376,6 +376,7 @@ struct mce_sys_var {
 	uint32_t	tcp_timer_resolution_msec;
 	tcp_ctl_thread_t tcp_ctl_thread;
 	tcp_ts_opt_t	tcp_ts_opt;
+	bool	tcp_nodelay;
 	vma_exception_handling exception_handling;
 	bool		avoid_sys_calls_on_tcp_fd;
 	bool		allow_privileged_sock_opt;
@@ -504,6 +505,7 @@ extern mce_sys_var & safe_mce_sys();
 #define SYS_VAR_TCP_TIMER_RESOLUTION_MSEC		"VMA_TCP_TIMER_RESOLUTION_MSEC"
 #define SYS_VAR_TCP_CTL_THREAD				"VMA_TCP_CTL_THREAD"
 #define SYS_VAR_TCP_TIMESTAMP_OPTION			"VMA_TCP_TIMESTAMP_OPTION"
+#define SYS_VAR_TCP_NODELAY				"VMA_TCP_NODELAY"
 #define SYS_VAR_VMA_EXCEPTION_HANDLING			(vma_exception_handling::getSysVar())
 #define SYS_VAR_AVOID_SYS_CALLS_ON_TCP_FD		"VMA_AVOID_SYS_CALLS_ON_TCP_FD"
 #define SYS_VAR_ALLOW_PRIVILEGED_SOCK_OPT		"VMA_ALLOW_PRIVILEGED_SOCK_OPT"
@@ -632,6 +634,7 @@ extern mce_sys_var & safe_mce_sys();
 #define MCE_DEFAULT_TCP_TIMER_RESOLUTION_MSEC		(100)
 #define MCE_DEFAULT_TCP_CTL_THREAD			(CTL_THREAD_DISABLE)
 #define MCE_DEFAULT_TCP_TIMESTAMP_OPTION		(TCP_TS_OPTION_DISABLE)
+#define MCE_DEFAULT_TCP_NODELAY			(false)
 #define MCE_DEFAULT_VMA_EXCEPTION_HANDLING	(vma_exception_handling::MODE_DEFAULT)
 #define MCE_DEFAULT_AVOID_SYS_CALLS_ON_TCP_FD		(false)
 #define MCE_DEFAULT_ALLOW_PRIVILEGED_SOCK_OPT		(true)


### PR DESCRIPTION
the Nagle algorithm for each tcp socket

If set, disable the Nagle algorithm for each tcp socket.
This means that segments are always sent as soon as possible, even if
there is only a small amount of data.
For more info about TCP_NODELAY flag, Please refer to tcp manual page.
This parameter will be enabled while using VMA_SPEC=latency/ultra-latency.
Default value is disabled.

Signed-off-by: Liran Oz <lirano@mellanox.com>