### PR TITLE
issue: 1010718 Rx optimizations in mem_buf/ref_count initialization

### DIFF
--- a/src/vma/dev/buffer_pool.cpp
+++ b/src/vma/dev/buffer_pool.cpp
@@ -57,7 +57,7 @@ inline void buffer_pool::put_buffer_helper(mem_buf_desc_t *buff)
 	}
 #endif
 	buff->p_next_desc = m_p_head;
-	free_lwip_pbuf(&buff->lwip_pbuf);
+	buff->free_lwip_pbuf();
 	m_p_head = buff;
 	m_n_buffers++;
 	m_p_bpool_stat->n_buffer_pool_size++;

--- a/src/vma/dev/buffer_pool.h
+++ b/src/vma/dev/buffer_pool.h
@@ -41,11 +41,9 @@
 #include "dev/allocator.h"
 
 
-inline static void free_lwip_pbuf(struct pbuf_custom *pbuf_custom)
-{
-	pbuf_custom->pbuf.flags = 0;
-	pbuf_custom->pbuf.ref = 0;
-}
+class net_device;
+class mem_buf_desc_owner;
+class ib_ctx_handler;
 
 /**
  * A buffer pool which internally sorts the buffers.

--- a/src/vma/dev/cq_mgr.cpp
+++ b/src/vma/dev/cq_mgr.cpp
@@ -601,6 +601,7 @@ bool cq_mgr::compensate_qp_poll_success(mem_buf_desc_t* buff_cur)
 		if (m_rx_pool.size() || request_more_buffers()) {
 			do {
 				mem_buf_desc_t *buff_new = m_rx_pool.get_and_pop_front();
+				buff_new->reset_ref_count();
 				m_qp_rec.qp->post_recv(buff_new);
 			} while (--m_qp_rec.debth > 0 && m_rx_pool.size());
 			m_p_cq_stat->n_buffer_pool_len = m_rx_pool.size();
@@ -641,14 +642,8 @@ void cq_mgr::reclaim_recv_buffer_helper(mem_buf_desc_t* buff)
 				temp->rx.vma_polled = false;
 #endif // DEFINED_VMAPOLL
 				temp->rx.flow_tag_id = 0;
-				temp->rx.tcp.p_ip_h = NULL;
-				temp->rx.tcp.p_tcp_h = NULL;
-				temp->rx.udp.sw_timestamp.tv_nsec = 0;
-				temp->rx.udp.sw_timestamp.tv_sec = 0;
-				temp->rx.udp.hw_timestamp.tv_nsec = 0;
-				temp->rx.udp.hw_timestamp.tv_sec = 0;
-				temp->rx.hw_raw_timestamp = 0;
-				free_lwip_pbuf(&temp->lwip_pbuf);
+				temp->free_lwip_pbuf();
+
 				m_rx_pool.push_back(temp);
 			}
 			m_p_cq_stat->n_buffer_pool_len = m_rx_pool.size();
@@ -677,14 +672,8 @@ void cq_mgr::vma_poll_reclaim_recv_buffer_helper(mem_buf_desc_t* buff)
 				temp->rx.is_vma_thr = false;
 				temp->rx.vma_polled = false;
 				temp->rx.flow_tag_id = 0;
-				temp->rx.tcp.p_ip_h = NULL;
-				temp->rx.tcp.p_tcp_h = NULL;
-				temp->rx.udp.sw_timestamp.tv_nsec = 0;
-				temp->rx.udp.sw_timestamp.tv_sec = 0;
-				temp->rx.udp.hw_timestamp.tv_nsec = 0;
-				temp->rx.udp.hw_timestamp.tv_sec = 0;
-				temp->rx.hw_raw_timestamp = 0;
-				free_lwip_pbuf(&temp->lwip_pbuf);
+				temp->free_lwip_pbuf();
+
 				m_rx_pool.push_back(temp);
 			}
 			else {
@@ -711,14 +700,8 @@ int cq_mgr::vma_poll_reclaim_single_recv_buffer_helper(mem_buf_desc_t* buff)
 		buff->rx.is_vma_thr = false;
 		buff->rx.vma_polled = false;
 		buff->rx.flow_tag_id = 0;
-		buff->rx.tcp.p_ip_h = NULL;
-		buff->rx.tcp.p_tcp_h = NULL;
-		buff->rx.udp.sw_timestamp.tv_nsec = 0;
-		buff->rx.udp.sw_timestamp.tv_sec = 0;
-		buff->rx.udp.hw_timestamp.tv_nsec = 0;
-		buff->rx.udp.hw_timestamp.tv_sec = 0;
-		buff->rx.hw_raw_timestamp = 0;
-		free_lwip_pbuf(&buff->lwip_pbuf);
+		buff->free_lwip_pbuf();
+
 		m_rx_pool.push_back(buff);
 		m_p_cq_stat->n_buffer_pool_len = m_rx_pool.size();
 	}

--- a/src/vma/dev/cq_mgr.inl
+++ b/src/vma/dev/cq_mgr.inl
@@ -60,6 +60,7 @@ inline void cq_mgr::compensate_qp_poll_failed()
 		if (likely(m_rx_pool.size() || request_more_buffers())) {
 			do {
 				mem_buf_desc_t *buff_new = m_rx_pool.get_and_pop_front();
+				buff_new->reset_ref_count();
 				m_qp_rec.qp->post_recv(buff_new);
 			} while (--m_qp_rec.debth > 0 && m_rx_pool.size());
 			m_p_cq_stat->n_buffer_pool_len = m_rx_pool.size();

--- a/src/vma/dev/rfs_mc.cpp
+++ b/src/vma/dev/rfs_mc.cpp
@@ -157,7 +157,6 @@ bool rfs_mc::prepare_flow_spec()
 bool rfs_mc::rx_dispatch_packet(mem_buf_desc_t* p_rx_wc_buf_desc, void* pv_fd_ready_array)
 {
 	// Dispatching: Notify new packet to all registered receivers
-	p_rx_wc_buf_desc->reset_ref_count();
 	p_rx_wc_buf_desc->inc_ref_count();
 
 	for (uint32_t i=0; i < m_n_sinks_list_entries; ++i) {

--- a/src/vma/dev/rfs_uc.cpp
+++ b/src/vma/dev/rfs_uc.cpp
@@ -148,7 +148,6 @@ bool rfs_uc::prepare_flow_spec()
 bool rfs_uc::rx_dispatch_packet(mem_buf_desc_t* p_rx_wc_buf_desc, void* pv_fd_ready_array)
 {
 	// Dispatching: Notify new packet to the FIRST registered receiver ONLY
-	p_rx_wc_buf_desc->reset_ref_count();
 #ifdef DEFINED_VMAPOLL	
 #ifdef RDTSC_MEASURE_RX_DISPATCH_PACKET
 	RDTSC_TAKE_START(g_rdtsc_instr_info_arr[RDTSC_FLOW_RX_DISPATCH_PACKET]);

--- a/src/vma/dev/rfs_uc_tcp_gro.cpp
+++ b/src/vma/dev/rfs_uc_tcp_gro.cpp
@@ -113,8 +113,6 @@ void rfs_uc_tcp_gro::add_packet(mem_buf_desc_t* mem_buf_desc, struct iphdr* p_ip
 		m_gro_desc.tsecr = *(topt + 2);
 	}
 
-	mem_buf_desc->reset_ref_count();
-
 	mem_buf_desc->lwip_pbuf.pbuf.flags = PBUF_FLAG_IS_CUSTOM;
 	mem_buf_desc->lwip_pbuf.pbuf.len = mem_buf_desc->lwip_pbuf.pbuf.tot_len = mem_buf_desc->rx.sz_payload;
 	mem_buf_desc->lwip_pbuf.pbuf.ref = 1;

--- a/src/vma/dev/ring_simple.cpp
+++ b/src/vma/dev/ring_simple.cpp
@@ -1801,7 +1801,7 @@ int ring_simple::put_tx_buffers(mem_buf_desc_t* buff_list)
 			ring_logerr("ref count of %p is already zero, double free??", buff_list);
 
 		if (buff_list->lwip_pbuf.pbuf.ref == 0) {
-			free_lwip_pbuf(&buff_list->lwip_pbuf);
+			buff_list->free_lwip_pbuf();
 			m_tx_pool.push_back(buff_list);
 			freed++;
 		}
@@ -1834,7 +1834,7 @@ int ring_simple::put_tx_single_buffer(mem_buf_desc_t* buff)
 
 		if (buff->lwip_pbuf.pbuf.ref == 0) {
 			buff->p_next_desc = NULL;
-			free_lwip_pbuf(&buff->lwip_pbuf);
+			buff->free_lwip_pbuf();
 			m_tx_pool.push_back(buff);
 			count++;
 		}

--- a/src/vma/proto/mem_buf_desc.h
+++ b/src/vma/proto/mem_buf_desc.h
@@ -130,6 +130,8 @@ public:
 	inline int inc_ref_count() {return atomic_fetch_and_inc(&n_ref_count);}
 	inline int dec_ref_count() {return atomic_fetch_and_dec(&n_ref_count);}
 
+	inline void free_lwip_pbuf(void) { lwip_pbuf.pbuf.flags = 0; lwip_pbuf.pbuf.ref = 0; }
+
 	inline unsigned int lwip_pbuf_inc_ref_count() {return ++lwip_pbuf.pbuf.ref;}
 	inline unsigned int lwip_pbuf_dec_ref_count() {if (likely(lwip_pbuf.pbuf.ref)) --lwip_pbuf.pbuf.ref; return lwip_pbuf.pbuf.ref;}
 	inline unsigned int lwip_pbuf_get_ref_count() const {return lwip_pbuf.pbuf.ref;}


### PR DESCRIPTION
- Initializations of mem_buf_desc_t were changed in accordance with data
  mapping to improve cache locality
- Excluded reset of mem_buf_desc_t ref.counter from dispatch and check
  functions as it is performed in initial.


Signed-off-by: Oleg Kuporosov <olegk@mellanox.com>
