### PR TITLE
issue: 1011829 Fix VMA_TCP_NODELAY parameter (Nagle algorithm)

### DIFF
--- a/src/vma/sock/sockinfo_tcp.cpp
+++ b/src/vma/sock/sockinfo_tcp.cpp
@@ -267,8 +267,8 @@ sockinfo_tcp::sockinfo_tcp(int fd) throw (vma_exception) :
 
 	// Disable Nagle algorithm if VMA_TCP_NODELAY flag was set.
 	if (safe_mce_sys().tcp_nodelay) {
-		tcp_nagle_disable(&m_pcb);
-		fit_snd_bufs_to_nagle(true);
+		int tcp_nodelay = 1;
+		setsockopt(IPPROTO_TCP, TCP_NODELAY, &tcp_nodelay, sizeof(tcp_nodelay));
 	}
 
 	si_tcp_logdbg("TCP PCB FLAGS: 0x%x", m_pcb.flags);

--- a/src/vma/sock/sockinfo_tcp.cpp
+++ b/src/vma/sock/sockinfo_tcp.cpp
@@ -267,8 +267,12 @@ sockinfo_tcp::sockinfo_tcp(int fd) throw (vma_exception) :
 
 	// Disable Nagle algorithm if VMA_TCP_NODELAY flag was set.
 	if (safe_mce_sys().tcp_nodelay) {
-		int tcp_nodelay = 1;
-		setsockopt(IPPROTO_TCP, TCP_NODELAY, &tcp_nodelay, sizeof(tcp_nodelay));
+		try {
+			int tcp_nodelay = 1;
+			setsockopt(IPPROTO_TCP, TCP_NODELAY, &tcp_nodelay, sizeof(tcp_nodelay));
+		} catch (vma_error&) {
+			// We should not be here
+		}
 	}
 
 	si_tcp_logdbg("TCP PCB FLAGS: 0x%x", m_pcb.flags);


### PR DESCRIPTION
Enable TCP_NODELAY using setsockopt() .

Signed-off-by: Liran Oz <lirano@mellanox.com>