### PR TITLE
issue: 996086 Use log levels definitions instead of enumeration

### DIFF
--- a/config/m4/opt.m4
+++ b/config/m4/opt.m4
@@ -7,11 +7,20 @@
 ##########################
 # Logging control
 #
-# VMA_OPTIMIZE_LOG values:
-# 5 - VMA_DEBUG and up
-# 6 - VMA_FINE and up
-# 10 - invalid value (no logging optimization)
+# VMA defined log levels
 #
+AC_DEFINE(DEFINED_VLOG_INIT,		-2,	VMA Log Init Definition)
+AC_DEFINE(DEFINED_VLOG_NONE,		-1,	VMA Log None Definition)
+AC_DEFINE(DEFINED_VLOG_PANIC,		0,	VMA Log Panic Definition)
+AC_DEFINE(DEFINED_VLOG_ERROR,		1,	VMA Log Error Definition)
+AC_DEFINE(DEFINED_VLOG_WARNING,		2,	VMA Log Warning Definition)
+AC_DEFINE(DEFINED_VLOG_INFO,		3,	VMA Log Info Definition)
+AC_DEFINE(DEFINED_VLOG_DETAILS,		4,	VMA Log Details Definition)
+AC_DEFINE(DEFINED_VLOG_DEBUG,		5,	VMA Log Debug Definition)
+AC_DEFINE(DEFINED_VLOG_FINE,		6,	VMA Log Fine Definition) 
+AC_DEFINE(DEFINED_VLOG_FINER,		7,	VMA Log Finer Definition)
+AC_DEFINE(DEFINED_VLOG_ALL,		8,	VMA Log All Definition)
+
 AC_ARG_ENABLE(
     [opt-log],
     AC_HELP_STRING(
@@ -20,22 +29,22 @@ AC_ARG_ENABLE(
     enableval=medium)
 AC_MSG_CHECKING(
     [checking for logging optimization])
-enable_opt_log=10
+enable_opt_log=DEFINED_VLOG_ALL
 case "$enableval" in
     no | none)
         ;;
     yes | medium)
-        enable_opt_log=6
+        enable_opt_log=DEFINED_VLOG_DEBUG
         CPPFLAGS="$CPPFLAGS -DNDEBUG"
         ;;
     high)
-        enable_opt_log=5
+        enable_opt_log=DEFINED_VLOG_DETAILS
         CPPFLAGS="$CPPFLAGS -DNDEBUG"
         ;;
     *)
         AC_MSG_ERROR([Unrecognized --enable-opt-log parameter as $enableval])
         ;;
 esac
-AC_DEFINE_UNQUOTED([VMA_OPTIMIZE_LOG], [$enable_opt_log], [Log optimization level])
+AC_DEFINE_UNQUOTED([VMA_MAX_DEFINED_LOG_LEVEL], [$enable_opt_log], [Log optimization level])
 AC_MSG_RESULT([$enableval])
 

--- a/src/vlogger/vlogger.cpp
+++ b/src/vlogger/vlogger.cpp
@@ -105,13 +105,11 @@ namespace log_level
 					/* Set maximum accessible logging level in case
 					 * a user requests level that is reduced during compilation
 					 * or requested one if the level is in valid range
-					 * VMA_OPTIMIZE_LOG is defined in any configuration and
-					 * accepts values as VLOG_DEBUG, VLOG_FINE
 					 */
-					if (levels[i].level < VMA_OPTIMIZE_LOG) {
+					if (levels[i].level <= VMA_MAX_DEFINED_LOG_LEVEL) {
 						return levels[i].level;
 					}
-					def_value = (vlog_levels_t)(VMA_OPTIMIZE_LOG - 1);
+					def_value = (vlog_levels_t)(VMA_MAX_DEFINED_LOG_LEVEL);
 					vlog_printf(VLOG_WARNING, "VMA trace level set to max level %s\n", to_str(def_value));
 					return def_value;
 				}

--- a/src/vlogger/vlogger.h
+++ b/src/vlogger/vlogger.h
@@ -84,94 +84,94 @@
 #define __log_warn(log_fmt, log_args...)         do { VLOG_PRINTF(VLOG_WARNING, log_fmt, ##log_args); } while (0)
 #define __log_info(log_fmt, log_args...)         do { VLOG_PRINTF(VLOG_INFO, log_fmt, ##log_args); } while (0)
 
-#if (VMA_OPTIMIZE_LOG <= 4)
+#if (VMA_MAX_DEFINED_LOG_LEVEL < DEFINED_VLOG_DETAIL)
 #define __log_details(log_fmt, log_args...)      ((void)0)
 #else
 #define __log_details(log_fmt, log_args...)      do { if (g_vlogger_level >= VLOG_DETAILS) 	VLOG_PRINTF(VLOG_DETAILS, log_fmt, ##log_args); } while (0)
 #endif
 
-#if (VMA_OPTIMIZE_LOG <= 5)
+#if (VMA_MAX_DEFINED_LOG_LEVEL < DEFINED_VLOG_DEBUG)
 #define __log_dbg(log_fmt, log_args...)          ((void)0)
 #else
 #define __log_dbg(log_fmt, log_args...)          do { if (g_vlogger_level >= VLOG_DEBUG) 	VLOG_PRINTF(VLOG_DEBUG, log_fmt, ##log_args); } while (0)
 #endif
 
-#if (VMA_OPTIMIZE_LOG <= 6)
+#if (VMA_MAX_DEFINED_LOG_LEVEL < DEFINED_VLOG_FINE)
 #define __log_fine(log_fmt, log_args...)         ((void)0)
 #else
 #define __log_fine(log_fmt, log_args...)         do { if (g_vlogger_level >= VLOG_FINE) 		VLOG_PRINTF(VLOG_FINE, log_fmt, ##log_args); } while (0)
 #endif
 
-#if (VMA_OPTIMIZE_LOG <= 7)
+#if (VMA_MAX_DEFINED_LOG_LEVEL < DEFINED_VLOG_FINER)
 #define __log_finer(log_fmt, log_args...)        ((void)0)
 #else
 #define __log_finer(log_fmt, log_args...)        do { if (g_vlogger_level >= VLOG_FINER) 	VLOG_PRINTF(VLOG_FINER, log_fmt, ##log_args); } while (0)
-#endif /* VMA_OPTIMIZE_LOG */
+#endif /* VMA_MAX_DEFINED_LOG_LEVEL */
 
 #define __log_info_panic(log_fmt, log_args...)   do { VLOG_PRINTF_INFO(VLOG_PANIC, log_fmt, ##log_args); throw; } while (0)
 #define __log_info_err(log_fmt, log_args...)     do { VLOG_PRINTF_INFO(VLOG_ERROR, log_fmt, ##log_args); } while (0)
 #define __log_info_warn(log_fmt, log_args...)    do { VLOG_PRINTF_INFO(VLOG_WARNING, log_fmt, ##log_args); } while (0)
 #define __log_info_info(log_fmt, log_args...)    do { VLOG_PRINTF_INFO(VLOG_INFO, log_fmt, ##log_args); } while (0)
 
-#if (VMA_OPTIMIZE_LOG <= 4)
+#if (VMA_MAX_DEFINED_LOG_LEVEL < DEFINED_VLOG_DETAILS)
 #define __log_info_details(log_fmt, log_args...) ((void)0)
 #else
 #define __log_info_details(log_fmt, log_args...) do { if (g_vlogger_level >= VLOG_DETAILS) 	VLOG_PRINTF_INFO(VLOG_DETAILS, log_fmt, ##log_args); } while (0)
 #endif
 
-#if (VMA_OPTIMIZE_LOG <= 5)
+#if (VMA_MAX_DEFINED_LOG_LEVEL < DEFINED_VLOG_DEBUG)
 #define __log_info_dbg(log_fmt, log_args...)     ((void)0)
 #else
 #define __log_info_dbg(log_fmt, log_args...)     do { if (g_vlogger_level >= VLOG_DEBUG) 	VLOG_PRINTF_INFO(VLOG_DEBUG, log_fmt, ##log_args); } while (0)
 #endif
 
-#if (VMA_OPTIMIZE_LOG <= 6)
+#if (VMA_MAX_DEFINED_LOG_LEVEL < DEFINED_VLOG_FINE)
 #define __log_info_fine(log_fmt, log_args...)    ((void)0)
 #else
-#define __log_info_fine(log_fmt, log_args...)    do { if (g_vlogger_level >= VLOG_FINE) 		VLOG_PRINTF_INFO(VLOG_FINE, log_fmt, ##log_args); } while (0)
+#define __log_info_fine(log_fmt, log_args...)    do { if (g_vlogger_level >= VLOG_FINE) 	VLOG_PRINTF_INFO(VLOG_FINE, log_fmt, ##log_args); } while (0)
 #endif
 
-#if (VMA_OPTIMIZE_LOG <= 7)
+#if (VMA_MAX_DEFINED_LOG_LEVEL < DEFINED_VLOG_FINER)
 #define __log_info_finer(log_fmt, log_args...)   ((void)0)
 #else
 #define __log_info_finer(log_fmt, log_args...)   do { if (g_vlogger_level >= VLOG_FINER) 	VLOG_PRINTF_INFO(VLOG_FINER, log_fmt, ##log_args); } while (0)
-#endif /* VMA_OPTIMIZE_LOG */
+#endif /* VMA_MAX_DEFINED_LOG_LEVEL */
 
-#if (VMA_OPTIMIZE_LOG <= 5)
+#if (VMA_MAX_DEFINED_LOG_LEVEL < DEFINED_VLOG_DEBUG)
 #define __log_entry_dbg(log_fmt, log_args...)    ((void)0)
 #else
 #define __log_entry_dbg(log_fmt, log_args...)    do { if (g_vlogger_level >= VLOG_DEBUG) 	VLOG_PRINTF_ENTRY(VLOG_DEBUG, log_fmt, ##log_args); } while (0)
 #endif
 
-#if (VMA_OPTIMIZE_LOG <= 6)
+#if (VMA_MAX_DEFINED_LOG_LEVEL < DEFINED_VLOG_FINE)
 #define __log_entry_fine(log_fmt, log_args...)   ((void)0)
 #else
 #define __log_entry_fine(log_fmt, log_args...)   do { if (g_vlogger_level >= VLOG_FINE)		VLOG_PRINTF_ENTRY(VLOG_FINE, log_fmt, ##log_args); } while (0)
 #endif
 
-#if (VMA_OPTIMIZE_LOG <= 7)
+#if (VMA_MAX_DEFINED_LOG_LEVEL < DEFINED_VLOG_FINER)
 #define __log_entry_finer(log_fmt, log_args...)  ((void)0)
 #else
 #define __log_entry_finer(log_fmt, log_args...)  do { if (g_vlogger_level >= VLOG_FINER) 	VLOG_PRINTF_ENTRY(VLOG_FINER, log_fmt, ##log_args); } while (0)
 #endif
 
-#if (VMA_OPTIMIZE_LOG <= 5)
+#if (VMA_MAX_DEFINED_LOG_LEVEL < DEFINED_VLOG_DEBUG)
 #define __log_exit_dbg(log_fmt, log_args...)     ((void)0)
 #else
 #define __log_exit_dbg(log_fmt, log_args...)     do { if (g_vlogger_level >= VLOG_DEBUG) 	VLOG_PRINTF_EXIT(VLOG_DEBUG, log_fmt, ##log_args); } while (0)
 #endif
 
-#if (VMA_OPTIMIZE_LOG <= 6)
+#if (VMA_MAX_DEFINED_LOG_LEVEL < DEFINED_VLOG_FINE)
 #define __log_exit_fine(log_fmt, log_args...)    ((void)0)
 #else
 #define __log_exit_fine(log_fmt, log_args...)    do { if (g_vlogger_level >= VLOG_FINE)		VLOG_PRINTF_EXIT(VLOG_FINE, log_fmt, ##log_args); } while (0)
 #endif
 
-#if (VMA_OPTIMIZE_LOG <= 7)
+#if (VMA_MAX_DEFINED_LOG_LEVEL < DEFINED_VLOG_FINER)
 #define __log_exit_finer(log_fmt, log_args...)   ((void)0)
 #else
 #define __log_exit_finer(log_fmt, log_args...)   do { if (g_vlogger_level >= VLOG_FINER) 	VLOG_PRINTF_EXIT(VLOG_FINER, log_fmt, ##log_args); } while (0)
-#endif /* VMA_OPTIMIZE_LOG */
+#endif /* VMA_MAX_DEFINED_LOG_LEVEL */
 
 // deprecated functions - only exist for Backward Compatibility.  Please avoid using them!
 #define __log_func(...)          __log_fine(__VA_ARGS__)
@@ -188,17 +188,17 @@ extern "C" {
 #endif //__cplusplus
 
 typedef enum {
-	VLOG_INIT = -2,
-	VLOG_NONE = -1,
-	VLOG_PANIC = 0,
-	VLOG_ERROR,
-	VLOG_WARNING,
-	VLOG_INFO, VLOG_DEFAULT = VLOG_INFO,
-	VLOG_DETAILS,
-	VLOG_DEBUG,
-	VLOG_FINE, VLOG_FUNC = VLOG_FINE,
-	VLOG_FINER, VLOG_FUNC_ALL = VLOG_FINER,
-	VLOG_ALL /* last element */
+	VLOG_INIT	= DEFINED_VLOG_INIT,
+	VLOG_NONE	= DEFINED_VLOG_NONE,
+	VLOG_PANIC	= DEFINED_VLOG_PANIC,
+	VLOG_ERROR	= DEFINED_VLOG_ERROR,
+	VLOG_WARNING	= DEFINED_VLOG_WARNING,
+	VLOG_INFO	= DEFINED_VLOG_INFO, VLOG_DEFAULT = VLOG_INFO,
+	VLOG_DETAILS	= DEFINED_VLOG_DETAILS,
+	VLOG_DEBUG	= DEFINED_VLOG_DEBUG,
+	VLOG_FINE	= DEFINED_VLOG_FINE, VLOG_FUNC = VLOG_FINE,
+	VLOG_FINER	= DEFINED_VLOG_FINER, VLOG_FUNC_ALL = VLOG_FINER,
+	VLOG_ALL	= DEFINED_VLOG_ALL /* last element */
 } vlog_levels_t;
 
 namespace log_level {

--- a/src/vma/dev/ring_simple.cpp
+++ b/src/vma/dev/ring_simple.cpp
@@ -1413,7 +1413,7 @@ bool ring_simple::rx_process_buffer(mem_buf_desc_t* p_rx_wc_buf_desc, transport_
 	case IPPROTO_IGMP:
 	{
 		struct igmp* p_igmp_h= (struct igmp*)((uint8_t*)p_ip_h + ip_hdr_len);
-		NOT_IN_USE(p_igmp_h); /* to supress warning in case VMA_OPTIMIZE_LOG */
+		NOT_IN_USE(p_igmp_h); /* to supress warning in case VMA_MAX_DEFINED_LOG_LEVEL */
 		ring_logdbg("Rx IGMP packet info: type=%s (%d), group=%d.%d.%d.%d, code=%d",
 				priv_igmp_type_tostr(p_igmp_h->igmp_type), p_igmp_h->igmp_type,
 				NIPQUAD(p_igmp_h->igmp_group.s_addr), p_igmp_h->igmp_code);

--- a/src/vma/event/event_handler_manager.cpp
+++ b/src/vma/event/event_handler_manager.cpp
@@ -59,17 +59,17 @@
 #undef  VLOG_PRINTF_ENTRY
 #define VLOG_PRINTF_ENTRY(log_level, log_fmt, log_args...) 	vlog_printf(log_level, MODULE_NAME "%d:%s(" log_fmt ")\n", __LINE__, __FUNCTION__, ##log_args)
 
-#if (VMA_OPTIMIZE_LOG <= 5)
+#if (VMA_MAX_DEFINED_LOG_LEVEL < DEFINED_VLOG_DEBUG)
 #define evh_logdbg_entry(log_fmt, log_args...)                  ((void)0)
 #else
 #define evh_logdbg_entry(log_fmt, log_args...)                  do { if (g_vlogger_level >= VLOG_DEBUG) VLOG_PRINTF_ENTRY(VLOG_DEBUG, log_fmt, ##log_args); } while (0)
 #endif
 
-#if (VMA_OPTIMIZE_LOG <= 6)
+#if (VMA_MAX_DEFINED_LOG_LEVEL < DEFINED_VLOG_FUNC)
 #define evh_logfunc_entry(log_fmt, log_args...)                 ((void)0)
 #else
 #define evh_logfunc_entry(log_fmt, log_args...)			do { if (g_vlogger_level >= VLOG_FUNC)	VLOG_PRINTF_ENTRY(VLOG_FUNC, log_fmt, ##log_args); } while (0)
-#endif /* VMA_OPTIMIZE_LOG */
+#endif /* VMA_MAX_DEFINED_LOG_LEVEL */
 
 
 #define INITIAL_EVENTS_NUM      64

--- a/src/vma/proto/neighbour.cpp
+++ b/src/vma/proto/neighbour.cpp
@@ -568,7 +568,7 @@ bool neigh_entry::post_send_tcp(iovec *iov, header *h)
 	m_p_ring->send_ring_buffer(m_id, &m_send_wqe, false);
 #ifndef __COVERITY__
 	struct tcphdr* p_tcp_h = (struct tcphdr*)(((uint8_t*)(&(p_pkt->hdr.m_ip_hdr))+sizeof(p_pkt->hdr.m_ip_hdr)));
-	NOT_IN_USE(p_tcp_h); /* to supress warning in case VMA_OPTIMIZE_LOG */
+	NOT_IN_USE(p_tcp_h); /* to supress warning in case VMA_MAX_DEFINED_LOG_LEVEL */
 	neigh_logdbg("Tx TCP segment info: src_port=%d, dst_port=%d, flags='%s%s%s%s%s%s' seq=%u, ack=%u, win=%u, payload_sz=%u",
 			ntohs(p_tcp_h->source), ntohs(p_tcp_h->dest),
 			p_tcp_h->urg?"U":"", p_tcp_h->ack?"A":"", p_tcp_h->psh?"P":"",
@@ -937,7 +937,7 @@ void neigh_entry::dofunc_enter_ready(const sm_info_t& func_info)
 
 void neigh_entry::priv_general_st_entry(const sm_info_t& func_info)
 {
-	NOT_IN_USE(func_info); /* to supress warning in case VMA_OPTIMIZE_LOG */
+	NOT_IN_USE(func_info); /* to supress warning in case VMA_MAX_DEFINED_LOG_LEVEL */
 	neigh_logdbg("State change: %s (%d) => %s (%d) with event %s (%d)",
 		state_to_str((state_t) func_info.old_state), func_info.old_state,
 		state_to_str((state_t) func_info.new_state), func_info.new_state,
@@ -951,8 +951,8 @@ void neigh_entry::priv_general_st_leave(const sm_info_t& func_info)
 
 void neigh_entry::priv_print_event_info(state_t state, event_t event)
 {
-	NOT_IN_USE(state); /* to supress warning in case VMA_OPTIMIZE_LOG */
-	NOT_IN_USE(event); /* to supress warning in case VMA_OPTIMIZE_LOG */
+	NOT_IN_USE(state); /* to supress warning in case VMA_MAX_DEFINED_LOG_LEVEL */
+	NOT_IN_USE(event); /* to supress warning in case VMA_MAX_DEFINED_LOG_LEVEL */
 	neigh_logdbg("Got event '%s' (%d) in state '%s' (%d)",
 		event_to_str(event), event, state_to_str(state), state);
 }

--- a/src/vma/proto/vma_lwip.cpp
+++ b/src/vma/proto/vma_lwip.cpp
@@ -120,7 +120,7 @@ vma_lwip::vma_lwip() : lock_spin_recursive("vma_lwip")
 {
 	m_run_timers = false;
 
-#if (VMA_OPTIMIZE_LOG <= 5)
+#if (VMA_MAX_DEFINED_LOG_LEVEL < DEFINED_VLOG_DEBUG)
 	if (*g_p_vlogger_level >= VLOG_DEBUG)
 		__vma_print_conf_file(__instance_list);
 #endif

--- a/src/vma/sock/fd_collection.h
+++ b/src/vma/sock/fd_collection.h
@@ -50,11 +50,11 @@ typedef vma_list_t<epfd_info, epfd_info::epfd_info_node_offset> epfd_info_list_t
 
 typedef std::tr1::unordered_map<pthread_t, int> offload_thread_rule_t;
 
-#if (VMA_OPTIMIZE_LOG <= 7)
+#if (VMA_MAX_DEFINED_LOG_LEVEL < DEFINED_VLOG_FINER)
 #define fdcoll_logfuncall(log_fmt, log_args...)         ((void)0)
 #else
 #define fdcoll_logfuncall(log_fmt, log_args...)		do { if (g_vlogger_level >= VLOG_FUNC_ALL) vlog_printf(VLOG_FUNC_ALL, "fdc:%d:%s() " log_fmt "\n", __LINE__, __FUNCTION__, ##log_args); } while (0)
-#endif /* VMA_OPTIMIZE_LOG */
+#endif /* VMA_MAX_DEFINED_LOG_LEVEL */
 
 class cq_channel_info: public cleanable_obj
 {

--- a/src/vma/sock/pipeinfo.cpp
+++ b/src/vma/sock/pipeinfo.cpp
@@ -50,7 +50,7 @@
 #define pi_logwarn(log_fmt, log_args...) 							VLOG_PRINTF(VLOG_WARNING, log_fmt, ##log_args)
 #define pi_loginfo(log_fmt, log_args...) 							VLOG_PRINTF(VLOG_INFO, log_fmt, ##log_args)
 
-#if (VMA_OPTIMIZE_LOG <= 5)
+#if (VMA_MAX_DEFINED_LOG_LEVEL < DEFINED_VLOG_DEBUG)
 #define pi_logdbg_no_funcname(log_fmt, log_args...)    ((void)0)
 #define pi_logdbg(log_fmt, log_args...)                ((void)0)
 #define si_logdbg_no_funcname(log_fmt, log_args...)    ((void)0)
@@ -60,17 +60,17 @@
 #define si_logdbg_no_funcname(log_fmt, log_args...)	do { if (g_vlogger_level >= VLOG_DEBUG) 	vlog_printf(VLOG_DEBUG, MODULE_NAME "[fd=%d]:%d: " log_fmt "\n", m_fd, __LINE__, ##log_args); } while (0)
 #endif
 
-#if (VMA_OPTIMIZE_LOG <= 6)
+#if (VMA_MAX_DEFINED_LOG_LEVEL < DEFINED_VLOG_FINE)
 #define pi_logfunc(log_fmt, log_args...)               ((void)0)
 #else
 #define pi_logfunc(log_fmt, log_args...)                if (g_vlogger_level >= VLOG_FUNC)       VLOG_PRINTF_DETAILS(VLOG_FUNC, log_fmt, ##log_args)
 #endif
 
-#if (VMA_OPTIMIZE_LOG <= 7)
+#if (VMA_MAX_DEFINED_LOG_LEVEL < DEFINED_VLOG_FINER)
 #define pi_logfuncall(log_fmt, log_args...)            ((void)0)
 #else
 #define pi_logfuncall(log_fmt, log_args...) 		if (g_vlogger_level >= VLOG_FUNC_ALL) 	VLOG_PRINTF_DETAILS(VLOG_FUNC_ALL, log_fmt, ##log_args)
-#endif /* VMA_OPTIMIZE_LOG */
+#endif /* VMA_MAX_DEFINED_LOG_LEVEL */
 
 pipeinfo::pipeinfo(int fd) : socket_fd_api(fd),
     m_lock("pipeinfo::m_lock"),

--- a/src/vma/sock/sock-redirect.cpp
+++ b/src/vma/sock/sock-redirect.cpp
@@ -525,10 +525,8 @@ int vma_add_conf_rule(char *config_line)
 
 	int ret = __vma_parse_config_line(config_line);
 
-#if (VMA_OPTIMIZE_LOG <= 5)
 	if (*g_p_vlogger_level >= VLOG_DEBUG)
 		__vma_print_conf_file(__instance_list);
-#endif
 
 	return ret;
 }
@@ -738,7 +736,7 @@ int bind(int __fd, const struct sockaddr *__addr, socklen_t __addrlen)
 	BULLSEYE_EXCLUDE_BLOCK_END
 
 	char buf[256];
-	NOT_IN_USE(buf); /* to suppress warning in case VMA_OPTIMIZE_LOG */
+	NOT_IN_USE(buf); /* to suppress warning in case VMA_MAX_DEFINED_LOG_LEVEL */
 	srdr_logdbg_entry("fd=%d, %s", __fd, sprintf_sockaddr(buf, 256, __addr, __addrlen));
 
 	int ret = 0;
@@ -779,7 +777,7 @@ int connect(int __fd, const struct sockaddr *__to, socklen_t __tolen)
 	BULLSEYE_EXCLUDE_BLOCK_END
 
 	char buf[256];
-	NOT_IN_USE(buf); /* to suppress warning in case VMA_OPTIMIZE_LOG */
+	NOT_IN_USE(buf); /* to suppress warning in case VMA_MAX_DEFINED_LOG_LEVEL */
 	srdr_logdbg_entry("fd=%d, %s", __fd, sprintf_sockaddr(buf, 256, __to, __tolen));
 
 	int ret = 0;
@@ -1624,9 +1622,9 @@ int select_helper(int __nfds,
 	if (g_vlogger_level >= VLOG_FUNC) {
 		const int tmpbufsize = 256;
 		char tmpbuf[tmpbufsize], tmpbuf2[tmpbufsize];
-		NOT_IN_USE(tmpbufsize); /* to suppress warning in case VMA_OPTIMIZE_LOG */
-		NOT_IN_USE(tmpbuf); /* to suppress warning in case VMA_OPTIMIZE_LOG */
-		NOT_IN_USE(tmpbuf2); /* to suppress warning in case VMA_OPTIMIZE_LOG */
+		NOT_IN_USE(tmpbufsize); /* to suppress warning in case VMA_MAX_DEFINED_LOG_LEVEL */
+		NOT_IN_USE(tmpbuf); /* to suppress warning in case VMA_MAX_DEFINED_LOG_LEVEL */
+		NOT_IN_USE(tmpbuf2); /* to suppress warning in case VMA_MAX_DEFINED_LOG_LEVEL */
 		srdr_logfunc("readfds: %s, writefds: %s",
 			   sprintf_fdset(tmpbuf, tmpbufsize, __nfds, __readfds), 
 			   sprintf_fdset(tmpbuf2, tmpbufsize, __nfds, __writefds));
@@ -1640,9 +1638,9 @@ int select_helper(int __nfds,
 		if (g_vlogger_level >= VLOG_FUNC) {
 			const int tmpbufsize = 256;
 			char tmpbuf[tmpbufsize], tmpbuf2[tmpbufsize];
-			NOT_IN_USE(tmpbufsize); /* to suppress warning in case VMA_OPTIMIZE_LOG */
-			NOT_IN_USE(tmpbuf); /* to suppress warning in case VMA_OPTIMIZE_LOG */
-			NOT_IN_USE(tmpbuf2); /* to suppress warning in case VMA_OPTIMIZE_LOG */
+			NOT_IN_USE(tmpbufsize); /* to suppress warning in case VMA_MAX_DEFINED_LOG_LEVEL */
+			NOT_IN_USE(tmpbuf); /* to suppress warning in case VMA_MAX_DEFINED_LOG_LEVEL */
+			NOT_IN_USE(tmpbuf2); /* to suppress warning in case VMA_MAX_DEFINED_LOG_LEVEL */
 			srdr_logfunc_exit("readfds: %s, writefds: %s",
 				   sprintf_fdset(tmpbuf, tmpbufsize, __nfds, __readfds),
 				   sprintf_fdset(tmpbuf2, tmpbufsize, __nfds, __writefds));
@@ -1843,7 +1841,7 @@ int epoll_ctl(int __epfd, int __op, int __fd, struct epoll_event *__event)
 	     "DEL",
 	     "MOD"
 	};
-	NOT_IN_USE(op_names); /* to suppress warning in case VMA_OPTIMIZE_LOG */
+	NOT_IN_USE(op_names); /* to suppress warning in case VMA_MAX_DEFINED_LOG_LEVEL */
 	if (__event) {
 		srdr_logfunc_entry("epfd=%d, op=%s, fd=%d, events=%#x, data=%x", 
 			__epfd, op_names[__op], __fd, __event->events, __event->data.u64);

--- a/src/vma/sock/sockinfo_tcp.cpp
+++ b/src/vma/sock/sockinfo_tcp.cpp
@@ -1357,7 +1357,7 @@ err_t sockinfo_tcp::ack_recvd_lwip_cb(void *arg, struct tcp_pcb *tpcb, u16_t ack
 {
 	sockinfo_tcp *conn = (sockinfo_tcp *)arg;
 
-	NOT_IN_USE(tpcb); /* to suppress warning in case VMA_OPTIMIZE_LOG */
+	NOT_IN_USE(tpcb); /* to suppress warning in case VMA_MAX_DEFINED_LOG_LEVEL */
 	assert((uintptr_t)tpcb->my_container == (uintptr_t)arg);
 
 	vlog_func_enter();


### PR DESCRIPTION
Log levels are used in both C source files and config/m4/opt.m4
(shell script like). Use #define in order to have the same log levels
naming in all files types.

Signed-off-by: Ophir Munk <ophirmu@mellanox.com>