### PR TITLE
issue: 996086  Do not set cpp flag -DNDEBUG

### DIFF
--- a/config/m4/opt.m4
+++ b/config/m4/opt.m4
@@ -26,11 +26,9 @@ case "$enableval" in
         ;;
     yes | medium)
         enable_opt_log=6
-        CPPFLAGS="$CPPFLAGS -DNDEBUG"
         ;;
     high)
         enable_opt_log=5
-        CPPFLAGS="$CPPFLAGS -DNDEBUG"
         ;;
     *)
         AC_MSG_ERROR([Unrecognized --enable-opt-log parameter as $enableval])


### PR DESCRIPTION
Do not set cpp flags -DNDEBUG as part of --enable-opt-log configuration
handling. -DNDEBUG flag disables assertion handling and it should not be
set as part of log level optimization

Signed-off-by: Ophir Munk <ophirmu@mellanox.com>