### PR TITLE
issue: 1008712 Synchronize access to intermediate rx buffer for bonding

### DIFF
--- a/src/vma/dev/ring_bond.cpp
+++ b/src/vma/dev/ring_bond.cpp
@@ -53,8 +53,15 @@
 #undef  MODULE_HDR
 #define MODULE_HDR	 	MODULE_NAME "%d:%s() "
 
+/* Set limitation for number of rings for bonding device */
+#define MAX_NUM_RING_RESOURCES 10
+
+
 ring_bond::ring_bond(int count, net_device_val::bond_type type, net_device_val::bond_xmit_hash_policy bond_xmit_hash_policy, uint32_t mtu) :
 ring(count, mtu), m_lock_ring_rx("ring_bond:lock_rx"), m_lock_ring_tx("ring_bond:lock_tx") {
+	if (m_n_num_resources > MAX_NUM_RING_RESOURCES) {
+		ring_logpanic("Error creating bond ring with more than %d resource", MAX_NUM_RING_RESOURCES);
+	}
 	m_bond_rings = new ring_simple*[count];
 	for (int i = 0; i < count; i++)
 		m_bond_rings[i] = NULL;
@@ -393,8 +400,7 @@ bool ring_bond::reclaim_recv_buffers(descq_t *rx_reuse)
 	 * own array. Set hardcoded number to meet C++11
 	 * VLA is not an official part of C++11.
 	 */
-	descq_t buffer_per_ring[10];
-	assert(10 > m_n_num_resources);
+	descq_t buffer_per_ring[MAX_NUM_RING_RESOURCES];
 
 	devide_buffers_helper(rx_reuse, buffer_per_ring);
 	for (uint32_t i = 0; i < m_n_num_resources; i++) {

--- a/src/vma/dev/ring_bond.cpp
+++ b/src/vma/dev/ring_bond.cpp
@@ -394,6 +394,7 @@ bool ring_bond::reclaim_recv_buffers(descq_t *rx_reuse)
 {
 	devide_buffers_helper(rx_reuse, m_buffer_per_ring);
 	for (uint32_t i = 0; i < m_n_num_resources; i++) {
+		m_buffer_per_ring[i].clear_without_cleanup();
 		if (m_buffer_per_ring[i].size() > 0) {
 			if (!m_bond_rings[i]->reclaim_recv_buffers(&m_buffer_per_ring[i])) {
 				g_buffer_pool_rx->put_buffers_after_deref_thread_safe(&m_buffer_per_ring[i]);

--- a/src/vma/dev/ring_bond.cpp
+++ b/src/vma/dev/ring_bond.cpp
@@ -61,6 +61,7 @@ ring(count, mtu), m_lock_ring_rx("ring_bond:lock_rx"), m_lock_ring_tx("ring_bond
 	m_active_rings = new ring_simple*[count];
 	for (int i = 0; i < count; i++)
 		m_active_rings[i] = NULL;
+	m_buffer_per_ring = new descq_t[m_n_num_resources + 1];
 	m_parent = this;
 	m_type = type;
 	m_xmit_hash_policy = bond_xmit_hash_policy;
@@ -79,6 +80,9 @@ void ring_bond::free_ring_bond_resources()
 
 	delete [] m_active_rings;
 	m_active_rings = NULL;
+
+	delete [] m_buffer_per_ring;
+	m_buffer_per_ring = NULL;
 }
 
 ring_bond::~ring_bond()
@@ -99,11 +103,12 @@ bool ring_bond::attach_flow(flow_tuple& flow_spec_5t, pkt_rcvr_sink* sink) {
 
 bool ring_bond::detach_flow(flow_tuple& flow_spec_5t, pkt_rcvr_sink* sink) {
 	bool ret = true;
-	auto_unlocker lock(m_lock_ring_rx);
+	while (m_lock_ring_rx.trylock()) ;
 	for (uint32_t i = 0; i < m_n_num_resources; i++) {
 		bool step_ret = m_bond_rings[i]->detach_flow(flow_spec_5t, sink);
 		ret = ret && step_ret;
 	}
+	m_lock_ring_rx.unlock();
 	return ret;
 }
 
@@ -388,25 +393,21 @@ void ring_bond::inc_tx_retransmissions(ring_user_id_t id)
 
 bool ring_bond::reclaim_recv_buffers(descq_t *rx_reuse)
 {
-	/* use this local array to avoid locking mechanizm
-	 * for threads synchronization. So every thread should use
-	 * own array. Set hardcoded number to meet C++11
-	 * VLA is not an official part of C++11.
-	 */
-	descq_t buffer_per_ring[10];
-	assert(10 > m_n_num_resources);
+	while (m_lock_ring_rx.trylock()) ;
 
-	devide_buffers_helper(rx_reuse, buffer_per_ring);
+	devide_buffers_helper(rx_reuse, m_buffer_per_ring);
 	for (uint32_t i = 0; i < m_n_num_resources; i++) {
-		if (buffer_per_ring[i].size() > 0) {
-			if (!m_bond_rings[i]->reclaim_recv_buffers(&buffer_per_ring[i])) {
-				g_buffer_pool_rx->put_buffers_after_deref_thread_safe(&buffer_per_ring[i]);
+		if (m_buffer_per_ring[i].size() > 0) {
+			if (!m_bond_rings[i]->reclaim_recv_buffers(&m_buffer_per_ring[i])) {
+				g_buffer_pool_rx->put_buffers_after_deref_thread_safe(&m_buffer_per_ring[i]);
 			}
 		}
 	}
 
-	if (buffer_per_ring[m_n_num_resources].size() > 0)
-		g_buffer_pool_rx->put_buffers_after_deref_thread_safe(&buffer_per_ring[m_n_num_resources]);
+	if (m_buffer_per_ring[m_n_num_resources].size() > 0)
+		g_buffer_pool_rx->put_buffers_after_deref_thread_safe(&m_buffer_per_ring[m_n_num_resources]);
+
+	m_lock_ring_rx.unlock();
 
 	return true;
 }

--- a/src/vma/dev/ring_bond.cpp
+++ b/src/vma/dev/ring_bond.cpp
@@ -390,9 +390,11 @@ bool ring_bond::reclaim_recv_buffers(descq_t *rx_reuse)
 {
 	/* use this local array to avoid locking mechanizm
 	 * for threads synchronization. So every thread should use
-	 * own array.
+	 * own array. Set hardcoded number to meet C++11
+	 * VLA is not an official part of C++11.
 	 */
-	descq_t buffer_per_ring[m_n_num_resources + 1];
+	descq_t buffer_per_ring[10];
+	assert(10 > m_n_num_resources);
 
 	devide_buffers_helper(rx_reuse, buffer_per_ring);
 	for (uint32_t i = 0; i < m_n_num_resources; i++) {

--- a/src/vma/dev/ring_bond.h
+++ b/src/vma/dev/ring_bond.h
@@ -88,7 +88,6 @@ private:
 	net_device_val::bond_xmit_hash_policy m_xmit_hash_policy;
 	lock_mutex_recursive	m_lock_ring_rx;
 	lock_mutex_recursive	m_lock_ring_tx;
-	descq_t*		m_buffer_per_ring;
 };
 
 class ring_bond_eth : public ring_bond

--- a/src/vma/dev/ring_bond.h
+++ b/src/vma/dev/ring_bond.h
@@ -88,6 +88,7 @@ private:
 	net_device_val::bond_xmit_hash_policy m_xmit_hash_policy;
 	lock_mutex_recursive	m_lock_ring_rx;
 	lock_mutex_recursive	m_lock_ring_tx;
+	descq_t*		m_buffer_per_ring;
 };
 
 class ring_bond_eth : public ring_bond


### PR DESCRIPTION
m_buffer_per_ring is introduced to avoid buffer allocation
in fast path but it should be clean before usage.

Signed-off-by: Igor Ivanov <igor.ivanov.va@gmail.com>