### PR TITLE
issue: 1025129 Remove socket TCP lock from Rx path

### DIFF
--- a/src/vma/sock/sockinfo_tcp.h
+++ b/src/vma/sock/sockinfo_tcp.h
@@ -351,6 +351,8 @@ private:
 
 	void handle_socket_linger();
 
+	int handle_rx_error();
+
 	/** Function prototype for tcp error callback functions. Called when the pcb
 	 * receives a RST or is unexpectedly closed for any other reason.
 	 *
@@ -390,7 +392,8 @@ private:
 
 	//lock_spin_recursive m_rx_cq_lck;
 	/* pick all cqs that match given address */
-	int 		rx_wait(int & poll_count, bool is_blocking);
+	inline int 	rx_wait(int & poll_count, bool is_blocking);
+	inline int 	rx_wait_lockless(int & poll_count, bool is_blocking);
 	int 		rx_wait_helper(int & poll_count, bool is_blocking);
 	void 		fit_rcv_wnd(bool force_fit);
 	void 		fit_snd_bufs(unsigned int new_max);


### PR DESCRIPTION
Improved socket TCP lock availability in case of high **VMA_RX_POLL*** parameter
value at a multithreaded environment.

_VMA_RX_POLL - The number of times to unsuccessfully poll an Rx for VMA
packets before going to sleep._

Signed-off-by: Daniel Libenson <daneilli@mellanox.com>