### PR TITLE
issue: 1025933 Add -Wundef flag to VMA compilation

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -521,7 +521,7 @@ if test "x${GCC}" = "xyes" ; then
         else
                 AC_MSG_RESULT([< 4])
         fi
-        SHARED_FLAGS="-Wall -Wextra -Werror -ffunction-sections -fdata-sections -Wsequence-point -pipe -Winit-self -Wmissing-include-dirs"
+        SHARED_FLAGS="-Wall -Wextra -Werror -Wundef -ffunction-sections -fdata-sections -Wsequence-point -pipe -Winit-self -Wmissing-include-dirs"
         CFLAGS="$SHARED_FLAGS $CFLAGS $WNO_FLAGS"
         CXXFLAGS="$SHARED_FLAGS -Wshadow $CXXFLAGS"
 fi

--- a/src/utils/atomic.h
+++ b/src/utils/atomic.h
@@ -35,6 +35,7 @@
 #define ATOMIC_H_
 
 #include "asm.h"
+#include "utils/bullseye.h"
 
 struct atomic_t {
 	__volatile__ int counter;

--- a/src/utils/lock_wrapper.h
+++ b/src/utils/lock_wrapper.h
@@ -40,6 +40,7 @@
 #include <stdio.h>
 #include <assert.h>
 #include "types.h"
+#include "utils/bullseye.h"
 #include "utils/rdtsc.h"
 
 //todo disable assert


### PR DESCRIPTION
Issue warning when using undefined parameter during VMA compilation

Signed-off-by: Ophir Munk <ophirmu@mellanox.com>