### PR TITLE
issue: 1025949 Improve Jenkins readability of failures

### DIFF
--- a/contrib/jenkins_tests/compiler.sh
+++ b/contrib/jenkins_tests/compiler.sh
@@ -2,14 +2,9 @@
 
 source $(dirname $0)/globals.sh
 
-check_filter "Checking for compiler ..." "on"
+do_check_filter "Checking for compiler ..." "on"
 
-# This unit requires module so check for existence
-if [ $(command -v module >/dev/null 2>&1 || echo $?) ]; then
-	echo "[SKIP] module tool does not exist"
-	exit 0
-fi
-module load intel/ics-15.0.1
+do_module "intel/ics-15.0.1"
 
 cd $WORKSPACE
 
@@ -27,13 +22,14 @@ for compiler in $compiler_list; do
     IFS=':' read cc cxx <<< "$compiler"
     mkdir -p ${compiler_dir}/${test_id}
     cd ${compiler_dir}/${test_id}
-    test_id=$((test_id+1))
     test_exec='${WORKSPACE}/configure --prefix=$compiler_dir-$cc CC=$cc CXX=$cxx $jenkins_test_custom_configure && make $make_opt all'
-    check_result "$test_exec" "$test_id" "$compiler" "$compiler_tap"
+    do_check_result "$test_exec" "$test_id" "$compiler" "$compiler_tap" "${compiler_dir}/compiler-${test_id}"
     cd ${compiler_dir}
+    test_id=$((test_id+1))
 done
 
 module unload intel/ics-15.0.1
+
 
 echo "[${0##*/}]..................exit code = $rc"
 exit $rc

--- a/contrib/jenkins_tests/cov.sh
+++ b/contrib/jenkins_tests/cov.sh
@@ -2,14 +2,9 @@
 
 source $(dirname $0)/globals.sh
 
-check_filter "Checking for coverity ..." "on"
+do_check_filter "Checking for coverity ..." "on"
 
-# This unit requires module so check for existence
-if [ $(command -v module >/dev/null 2>&1 || echo $?) ]; then
-	echo "[SKIP] module tool does not exist"
-	exit 0
-fi
-module load tools/cov
+do_module "tools/cov"
 
 cd $WORKSPACE
 
@@ -54,6 +49,7 @@ coverity_tap=${WORKSPACE}/${prefix}/coverity.tap
 echo 1..1 > $coverity_tap
 if [ $rc -gt 0 ]; then
     echo "not ok 1 Coverity Detected $nerrors failures # $cov_url" >> $coverity_tap
+    do_err "coverity" "${cov_build}/output/summary.txt"
     info="Coverity found $nerrors errors"
     status="error"
 else
@@ -71,6 +67,8 @@ echo Coverity report: $cov_url
 printf "%s\t%s\n" Coverity $cov_url >> jenkins_sidelinks.txt
 
 module unload tools/cov
+
+do_archive "${cov_build}"
 
 echo "[${0##*/}]..................exit code = $rc"
 exit $rc

--- a/contrib/jenkins_tests/cppcheck.sh
+++ b/contrib/jenkins_tests/cppcheck.sh
@@ -2,9 +2,9 @@
 
 source $(dirname $0)/globals.sh
 
-check_filter "Checking for cppcheck ..." "on"
+do_check_filter "Checking for cppcheck ..." "on"
 
-# This unit requires module so check for existence
+# This unit requires cppcheck so check for existence
 if [ $(command -v cppcheck >/dev/null 2>&1 || echo $?) ]; then
 	echo "[SKIP] cppcheck tool does not exist"
 	exit 0
@@ -33,14 +33,17 @@ cppcheck_tap=${WORKSPACE}/${prefix}/cppcheck.tap
 echo 1..1 > $cppcheck_tap
 if [ $rc -gt 0 ]; then
     echo "not ok 1 cppcheck Detected $nerrors failures # ${cppcheck_dir}/cppcheck.err" >> $cppcheck_tap
+    do_err "cppcheck" "${cppcheck_dir}/cppcheck.err"
     info="cppcheck found $nerrors errors"
     status="error"
+    do_err "$1" "${5}.err"
 else
     echo ok 1 cppcheck found no issues >> $cppcheck_tap
     info="cppcheck found no issues"
     status="success"
 fi
 
+do_archive "${cppcheck_dir}/cppcheck.err" "${cppcheck_dir}/cppcheck.log"
 
 echo "[${0##*/}]..................exit code = $rc"
 exit $rc

--- a/contrib/jenkins_tests/csbuild.sh
+++ b/contrib/jenkins_tests/csbuild.sh
@@ -2,9 +2,9 @@
 
 source $(dirname $0)/globals.sh
 
-check_filter "Checking for csbuild ..." "on"
+do_check_filter "Checking for csbuild ..." "on"
 
-# This unit requires module so check for existence
+# This unit requires csbuild so check for existence
 if [ $(command -v csbuild >/dev/null 2>&1 || echo $?) ]; then
 	echo "[SKIP] csbuild tool does not exist"
 	exit 0
@@ -24,10 +24,10 @@ cd $csbuild_dir
 
 set +eE
 
-${WORKSPACE}/configure --prefix=${csbuild_dir}/install $jenkins_test_custom_configure
+${WORKSPACE}/configure --prefix=${csbuild_dir}/install $jenkins_test_custom_configure > "${csbuild_dir}/csbuild.log" 2>&1
 make clean
 
-eval "csbuild --no-clean -c \"make $make_opt \" > ${csbuild_dir}/csbuild.log 2>&1"
+eval "csbuild --no-clean -c \"make $make_opt \" > \"${csbuild_dir}/csbuild.log\" 2>&1"
 rc=$(($rc+$?))
 
 set -eE
@@ -53,6 +53,7 @@ csbuild_tap=${WORKSPACE}/${prefix}/csbuild.tap
 echo 1..1 > $csbuild_tap
 if [ $rc -gt 0 ]; then
     echo "not ok 1 csbuild Detected $nerrors failures # ${csbuild_dir}/csbuild.err" >> $csbuild_tap
+    do_err "csbuild" "${csbuild_dir}/csbuild.err"
     info="csbuild found $nerrors errors"
     status="error"
 else
@@ -61,6 +62,7 @@ else
     status="success"
 fi
 
+do_archive "${csbuild_dir}/csbuild.err" "${csbuild_dir}/csbuild.log"
 
 echo "[${0##*/}]..................exit code = $rc"
 exit $rc

--- a/contrib/jenkins_tests/globals.sh
+++ b/contrib/jenkins_tests/globals.sh
@@ -11,14 +11,26 @@ else
     WS_URL=$JOB_URL/ws
 fi
 
+TARGET=${TARGET:=all}
+i=0
+if [ "$TARGET" == "all" -o "$TARGET" == "default" ]; then
+	target_list[$i]="default: "
+	i=$((i+1))
+fi
+if [ "$TARGET" == "all" -o "$TARGET" == "vmapoll" ]; then
+	target_list[$i]="vmapoll:--enable-vmapoll"
+	i=$((i+1))
+fi
+
+
 # exit code
 rc=0
 
 jenkins_test_custom_configure=${jenkins_test_custom_configure:=""}
 jenkins_test_custom_prefix=${jenkins_test_custom_prefix:="jenkins"}
 
-prefix=${jenkins_test_custom_prefix}
-build_dir=${WORKSPACE}/${prefix}/build
+prefix=${jenkins_test_custom_prefix}/${jenkins_target}
+build_dir=${WORKSPACE}/${prefix}/build/
 install_dir=${WORKSPACE}/${prefix}/install
 compiler_dir=${WORKSPACE}/${prefix}/compiler
 test_dir=${WORKSPACE}/${prefix}/test
@@ -40,7 +52,7 @@ fi
 
 trap "on_exit" INT TERM ILL KILL FPE SEGV ALRM
 
-function on_exit
+function on_exit()
 {
     rc=$((rc + $?))
     echo "[${0##*/}]..................exit code = $rc"
@@ -67,6 +79,14 @@ function do_export()
     export MANPATH="$1/share/man:${MANPATH}"
 }
 
+function do_archive()
+{
+    cmd="tar -rvf ${jenkins_test_artifacts}.tar $*"
+    set +e
+    eval $cmd >> /dev/null 2>&1
+    set -e
+}
+
 function do_github_status()
 {
     echo "Calling: github $1"
@@ -91,7 +111,63 @@ function do_github_status()
     "https://api.github.com/repos/$repo/statuses/${sha1}?access_token=$token"
 }
 
-function check_env()
+# Test if an environment module exists and load it if yes.
+# Otherwise, return error code.
+# $1 - module name
+#
+function do_module()
+{
+    echo "Checking module $1"
+    if [ $(command -v module >/dev/null 2>&1 || echo $?) ]; then
+	    echo "[SKIP] module tool does not exist"
+	    exit 0
+	else
+        module load "$1"
+    fi
+}
+
+# format text
+#
+function do_format()
+{
+    set +x
+    local is_format=true
+    if [[ $is_format == true ]] ; then
+        res=""
+        for ((i=2; i<=$#; i++)) ; do
+            case "${!i}" in
+                "bold" ) res="$res\e[1m" ;;
+                "underline" ) res="$res\e[4m" ;;
+                "reverse" ) res="$res\e[7m" ;;
+                "red" ) res="$res\e[91m" ;;
+                "green" ) res="$res\e[92m" ;;
+                "yellow" ) res="$res\e[93m" ;;
+            esac
+        done
+        echo -e "$res$1\e[0m"
+    else
+        echo "$1"
+    fi
+    set -x
+}
+
+# print error message
+#
+function do_err()
+{
+    set +x
+    echo -e $(do_format "FAILURE: $1" "red" "bold") 2>&1
+    if [ -n "$2" ]; then
+        echo ">>>"
+        cat $2
+        echo ">>>"
+    fi
+    set -x
+}
+
+# Verify if current environment is suitable.
+#
+function do_check_env()
 {
     echo "Checking system configuration"
     if [ $(command -v pkill >/dev/null 2>&1 || echo $?) ]; then
@@ -114,9 +190,11 @@ function check_env()
     echo "environment [OK]"
 }
 
+# Check if the unit should be proccesed
 # $1 - output message
 # $2 - [on|off] if on - skip this case if JENKINS_RUN_TESTS variable is OFF
-function check_filter()
+#
+function do_check_filter()
 {
     local msg=$1
     local filter=$2
@@ -131,33 +209,52 @@ function check_filter()
     echo "$msg [OK]"
 }
 
+# Launch command and detect result of execution
 # $1 - test command
 # $2 - test id
 # $3 - test name
 # $4 - test tap file
-function check_result()
+# $5 - files for stdout/stderr
+#
+function do_check_result()
 {
     set +e
-    eval $timeout_exe $1
-    ret=$?
+    if [ -z "$5" ]; then
+        eval $timeout_exe $1
+        ret=$?
+    else
+        eval $timeout_exe $1 2>> "${5}.err" 1>> "${5}.log"
+        ret=$?
+        do_archive "${5}.err" "${5}.log"
+    fi
     set -e
     if [ $ret -gt 0 ]; then
         echo "not ok $2 $3" >> $4
+        if [ -z "$5" ]; then
+            do_err "$1"
+        else
+            do_err "$1" "${5}.err"
+        fi
     else
         echo "ok $2 $3" >> $4
     fi
     rc=$((rc + $ret))
 }
 
+# Detect interface ip
 # $1 - [ib|eth] to select link type or empty to select the first found
-function get_ip()
+#
+function do_get_ip()
 {
     for ip in $(ibdev2netdev | grep Up | cut -f 5 -d ' '); do
         if [ -n "$1" -a "$1" == "ib" -a -n "$(ip link show $ip | grep 'link/inf')" ]; then
             found_ip=$(ip -4 address show $ip | grep 'inet' | sed 's/.*inet \([0-9\.]\+\).*/\1/')
             if [ -n "$(ibdev2netdev | grep $ip | grep mlx5)" ]; then
-                echo "$ip is CX4 device that does not support IPoIB"
-                unset found_ip
+                local ofed_v=$(ofed_info -s | grep OFED | sed 's/.*[l|X]-\([0-9\.]\+\).*/\1/')
+                if [ $(echo $ofed_v | grep 4.[1-9] >/dev/null 2>&1 || echo $?) ]; then
+                    echo "$ip is CX4 device that does not support IPoIB in OFED: $ofed_v"
+                    unset found_ip
+                fi
             fi
         elif [ -n "$1" -a "$1" == "eth" -a -n "$(ip link show $ip | grep 'link/eth')" ]; then
             found_ip=$(ip -4 address show $ip | grep 'inet' | sed 's/.*inet \([0-9\.]\+\).*/\1/')

--- a/contrib/jenkins_tests/gtest.sh
+++ b/contrib/jenkins_tests/gtest.sh
@@ -2,7 +2,8 @@
 
 source $(dirname $0)/globals.sh
 
-check_filter "Checking for gtest ..." "on"
+do_check_filter "Checking for gtest ..." "on"
+
 if [ $(command -v ibdev2netdev >/dev/null 2>&1 || echo $?) ]; then
 	echo "[SKIP] ibdev2netdev tool does not exist"
 	exit 0
@@ -18,11 +19,11 @@ gtest_app="$PWD/tests/gtest/gtest"
 gtest_lib=$install_dir/lib/libvma.so
 
 gtest_ip_list=""
-if [ ! -z $(get_ip 'eth') ]; then
-	gtest_ip_list="$(get_ip 'eth')"
+if [ ! -z $(do_get_ip 'eth') ]; then
+	gtest_ip_list="$(do_get_ip 'eth')"
 fi
-if [ ! -z $(get_ip 'eth' $gtest_ip_list) ]; then
-	gtest_ip_list="${gtest_ip_list}:$(get_ip 'eth' $gtest_ip_list)"
+if [ ! -z $(do_get_ip 'eth' $gtest_ip_list) ]; then
+	gtest_ip_list="${gtest_ip_list}:$(do_get_ip 'eth' $gtest_ip_list)"
 else
 	echo "[SKIP] two eth interfaces are required. found: ${gtest_ip_list}"
 	exit 0

--- a/contrib/jenkins_tests/rpm.sh
+++ b/contrib/jenkins_tests/rpm.sh
@@ -2,7 +2,7 @@
 
 source $(dirname $0)/globals.sh
 
-check_filter "Checking for rpm ..." "off"
+do_check_filter "Checking for rpm ..." "off"
 
 cd $WORKSPACE
 
@@ -10,16 +10,16 @@ rm -rf $rpm_dir
 mkdir -p $rpm_dir
 cd $rpm_dir
 
-#${WORKSPACE}/configure --prefix=$install_dir $jenkins_test_custom_configure
-cd $build_dir
-
 rpm_tap=${WORKSPACE}/${prefix}/rpm.tap
+
+cd ${build_dir}/0
 
 if [ -x /usr/bin/dpkg-buildpackage ]; then
     echo "Build on debian"
     set +e
-    ${WORKSPACE}/build/build_deb.sh
+    ${WORKSPACE}/build/build_deb.sh 2> "${rpm_dir}/rpm-deb.err" 1> "${rpm_dir}/rpm-deb.log"
     rc=$((rc + $?))
+    do_archive "${rpm_dir}/*.err" "${rpm_dir}/*.log"
     set -e
 	echo "1..1" > $rpm_tap
 	if [ $rc -gt 0 ]; then
@@ -29,7 +29,7 @@ if [ -x /usr/bin/dpkg-buildpackage ]; then
 	fi
 else
     echo "Build rpms"
-    rpmspec=${build_dir}/build/libvma.spec
+    rpmspec=${build_dir}/0/build/libvma.spec
     rpmmacros="--define='_rpmdir ${rpm_dir}/rpm-dist' --define='_srcrpmdir ${rpm_dir}/rpm-dist' --define='_sourcedir ${rpm_dir}' --define='_specdir ${rpm_dir}' --define='_builddir ${rpm_dir}'"
     rpmopts="--nodeps --buildroot='${rpm_dir}/_rpm'"
 
@@ -44,7 +44,6 @@ else
 
     test_id=0
     if [ $opt_tarball -eq 1 ]; then
-        test_id=$((test_id+1))
         # Automake 1.10.1 has a bug https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=456632
         if [ -n "$(automake --version | grep 'automake (GNU automake) 1.10.1')" ]; then
             test_exec='make dist'
@@ -52,22 +51,24 @@ else
             test_exec='make dist && make distcheck'
         fi
 
-        check_result "$test_exec" "$test_id" "tarball" "$rpm_tap"
+        do_check_result "$test_exec" "$test_id" "tarball" "$rpm_tap" "${rpm_dir}/rpm-${test_id}"
         eval $timeout_exe cp libvma*.tar.gz ${rpm_dir}
+        test_id=$((test_id+1))
     fi
 	
     if [ $opt_srcrpm -eq 1 ]; then
-        test_id=$((test_id+1))
         test_exec="rpmbuild -bs $rpmmacros $rpmopts $rpmspec"
-        check_result "$test_exec" "$test_id" "srcrpm" "$rpm_tap"
+        do_check_result "$test_exec" "$test_id" "srcrpm" "$rpm_tap" "${rpm_dir}/rpm-${test_id}"
+        test_id=$((test_id+1))
     fi
 
     if [ $opt_binrpm -eq 1 ]; then
-        test_id=$((test_id+1))
         test_exec="rpmbuild -bb $rpmmacros $rpmopts $rpmspec"
-        check_result "$test_exec" "$test_id" "binrpm" "$rpm_tap"
+        do_check_result "$test_exec" "$test_id" "binrpm" "$rpm_tap" "${rpm_dir}/rpm-${test_id}"
+        test_id=$((test_id+1))
     fi
 fi
+
 
 echo "[${0##*/}]..................exit code = $rc"
 exit $rc

--- a/contrib/jenkins_tests/style.sh
+++ b/contrib/jenkins_tests/style.sh
@@ -2,7 +2,7 @@
 
 source $(dirname $0)/globals.sh
 
-check_filter "Checking for codying style ..." "on"
+do_check_filter "Checking for codying style ..." "on"
 
 cd $WORKSPACE
 

--- a/contrib/jenkins_tests/test.sh
+++ b/contrib/jenkins_tests/test.sh
@@ -2,7 +2,8 @@
 
 source $(dirname $0)/globals.sh
 
-check_filter "Checking for test ..." "on"
+do_check_filter "Checking for test ..." "on"
+
 if [ $(command -v ibdev2netdev >/dev/null 2>&1 || echo $?) ]; then
 	echo "[SKIP] ibdev2netdev tool does not exist"
 	exit 0
@@ -28,11 +29,11 @@ if [ $(command -v $test_app >/dev/null 2>&1 || echo $?) ]; then
 fi
 
 test_ip_list=""
-if [ ! -z $(get_ip 'ib') ]; then
-	test_ip_list="${test_ip_list} ib:$(get_ip 'ib')"
+if [ ! -z $(do_get_ip 'ib') ]; then
+	test_ip_list="${test_ip_list} ib:$(do_get_ip 'ib')"
 fi
-if [ ! -z $(get_ip 'eth') ]; then
-    test_ip_list="${test_ip_list} eth:$(get_ip 'eth')"
+if [ ! -z $(do_get_ip 'eth') ]; then
+    test_ip_list="${test_ip_list} eth:$(do_get_ip 'eth')"
 fi
 
 test_list="tcp-pp tcp-tp tcp-ul"
@@ -53,6 +54,8 @@ for test_link in $test_ip_list; do
 
 		cp $PWD/${test_name}.dump ${test_dir}/${test_name}.dump
 		grep -e 'PASS' -e 'FAIL' ${test_dir}/${test_name}.dump > ${test_dir}/${test_name}.tmp
+
+        do_archive "${test_dir}/${test_name}.dump" "${test_dir}/${test_name}.log"
 
 		echo "1..$(wc -l < ${test_dir}/${test_name}.tmp)" > $test_tap
 

--- a/contrib/jenkins_tests/tool.sh
+++ b/contrib/jenkins_tests/tool.sh
@@ -2,7 +2,7 @@
 
 source $(dirname $0)/globals.sh
 
-check_filter "Checking for tool ..." "off"
+do_check_filter "Checking for tool ..." "off"
 
 cd $WORKSPACE
 
@@ -51,7 +51,7 @@ for tool in $tool_list; do
     cd ${tool_dir}/${tool}
     test_id=$((test_id+1))
     test_exec="[ 0 = $(check_daemon "${tool_dir}/${tool}/output.log") ]"
-    check_result "$test_exec" "$test_id" "$tool" "$tool_tap"
+    do_check_result "$test_exec" "$test_id" "$tool" "$tool_tap" "${tool_dir}/tool-${test_id}"
     cd ${tool_dir}
 done
 


### PR DESCRIPTION
Most command outputs are redirected to log and err files
specific for test a unit. But in case failure detection
err file is printed to console.

Signed-off-by: Igor Ivanov <igor.ivanov.va@gmail.com>