### PR TITLE
issue: 1029468 - Fix crash in cq_mgr_mlx5 destructor

### DIFF
--- a/src/vma/dev/cq_mgr_mlx5.cpp
+++ b/src/vma/dev/cq_mgr_mlx5.cpp
@@ -114,6 +114,7 @@ cq_mgr_mlx5::~cq_mgr_mlx5()
 	if (ret_total > 0) {
 		cq_logdbg("Drained %d wce", ret_total);
 	}
+	m_rq = NULL;
 	m_b_is_clean = true;
 }
 
@@ -439,7 +440,6 @@ void	cq_mgr_mlx5::add_qp_rx(qp_mgr* qp)
 void	cq_mgr_mlx5::del_qp_rx(qp_mgr *qp)
 {
 	cq_mgr::del_qp_rx(qp);
-	m_rq = NULL;
 	m_p_rq_wqe_idx_to_wrid = NULL;
 }
 


### PR DESCRIPTION
m_rq member of cq_mgr_mlx5 class was reset at cq_mgr_mlx5::del_qp_rx function instead of cq_mgr_mlx5:~cq_mgr_mlx5 destructor.

Signed-off-by: Daniel Libenson <danielli@mellanox.com>