### PR TITLE
issue: 1030299 - Fix cqe request_notification bug in cq_mgr_mlx5 class

### DIFF
--- a/src/vma/dev/cq_mgr.h
+++ b/src/vma/dev/cq_mgr.h
@@ -127,7 +127,7 @@ public:
 	 *         ==1 cq not armed (cq poll_sn out of sync)
 	 *         < 0 on error
 	 */
-	int	request_notification(uint64_t poll_sn);
+	virtual int	request_notification(uint64_t poll_sn);
 
 	/**
 	 * Block on the CQ's notification channel for the next event and process
@@ -137,7 +137,7 @@ public:
 	 *         < 0 error or if channel not armed or channel would block
 	 *             (on non-blocked channel) (some other thread beat you to it)
 	 */
-	int	wait_for_notification_and_process_element(uint64_t* p_cq_poll_sn,
+	virtual int	wait_for_notification_and_process_element(uint64_t* p_cq_poll_sn,
 	   	                                          void* pv_fd_ready_array = NULL);
 #ifdef DEFINED_VMAPOLL
 	inline volatile struct mlx5_cqe64 *mlx5_get_cqe64(void);
@@ -292,7 +292,7 @@ private:
 	inline void	find_buff_dest_local_if(mem_buf_desc_t * buff);
 
 	//Finds and sets the vma if to which the buff is addressed (according to qpn).
-	inline void 	find_buff_dest_vma_if_ctx(mem_buf_desc_t * buff);
+	inline void	find_buff_dest_vma_if_ctx(mem_buf_desc_t * buff);
 
 	void		process_cq_element_log_helper(mem_buf_desc_t* p_mem_buf_desc, vma_ibv_wc* p_wce);
 };

--- a/src/vma/dev/cq_mgr_mlx5.cpp
+++ b/src/vma/dev/cq_mgr_mlx5.cpp
@@ -427,7 +427,7 @@ int cq_mgr_mlx5::poll_and_process_element_rx(uint64_t* p_cq_poll_sn, void* pv_fd
 	return ret_rx_processed;
 }
 
-void	cq_mgr_mlx5::add_qp_rx(qp_mgr* qp)
+void cq_mgr_mlx5::add_qp_rx(qp_mgr* qp)
 {
 	cq_mgr::add_qp_rx(qp);
 	struct verbs_qp *vqp = (struct verbs_qp *)qp->m_qp;
@@ -436,11 +436,30 @@ void	cq_mgr_mlx5::add_qp_rx(qp_mgr* qp)
 	m_p_rq_wqe_idx_to_wrid = qp->m_rq_wqe_idx_to_wrid;
 }
 
-void	cq_mgr_mlx5::del_qp_rx(qp_mgr *qp)
+void cq_mgr_mlx5::del_qp_rx(qp_mgr *qp)
 {
 	cq_mgr::del_qp_rx(qp);
 	m_rq = NULL;
 	m_p_rq_wqe_idx_to_wrid = NULL;
+}
+
+void cq_mgr_mlx5::update_consumer_index()
+{
+	struct mlx5_cq* mlx5_cq = _to_mxxx(cq, cq);
+	mlx5_cq->cons_index = m_cq_cons_index;
+	wmb();
+}
+
+int cq_mgr_mlx5::request_notification(uint64_t poll_sn)
+{
+	update_consumer_index();
+	return cq_mgr::request_notification(poll_sn);
+}
+
+int cq_mgr_mlx5::wait_for_notification_and_process_element(uint64_t* p_cq_poll_sn, void* pv_fd_ready_array/* = NULL*/)
+{
+	update_consumer_index();
+	return cq_mgr::wait_for_notification_and_process_element(p_cq_poll_sn, pv_fd_ready_array);
 }
 
 #endif//HAVE_INFINIBAND_MLX5_HW_H

--- a/src/vma/dev/cq_mgr_mlx5.h
+++ b/src/vma/dev/cq_mgr_mlx5.h
@@ -56,8 +56,12 @@ public:
 	virtual void                add_qp_rx(qp_mgr* qp);
 	virtual void                del_qp_rx(qp_mgr *qp);
 	virtual uint32_t            clean_cq();
+	virtual int                 request_notification(uint64_t poll_sn);
+	virtual int                 wait_for_notification_and_process_element(uint64_t* p_cq_poll_sn, void* pv_fd_ready_array = NULL);
 
 private:
+	void                        update_consumer_index();
+
 	uint32_t                    m_cq_size;
 	uint32_t                    m_cq_cons_index;
 	struct mlx5_cqe64           (*m_cqes)[];


### PR DESCRIPTION
Add verbs consumer index update before calling ibv_req_notify_cq function.

Signed-off-by: Daniel Libenson <danielli@mellanox.com>