### PR TITLE
issue: 1037215 rdma_lib_reset not detected

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -818,7 +818,7 @@ AC_CHECK_LIB([rt], [clock_gettime])
 AC_CHECK_LIB([pthread], [pthread_create])
 
 TMP_LDFLAGS=$LDFLAGS
-AC_CHECK_LIB([rdmacm], [rdma_create_id],
+AC_SEARCH_LIBS([rdma_create_id],[rdmacm],
 		[LDFLAGS="$LDFLAGS -lrdmacm" VERBS_FLAGS="$VERBS_FLAGS -lrdmacm"],
 		[])
 AC_CHECK_FUNCS_ONCE([rdma_lib_reset])


### PR DESCRIPTION
On some gcc versions e.g. 5.4.0 (Ubuntu 16.04)
there is an issue with the order of arguments.
The -l must be used after the name of the source
file or the function won't be detected.
Replacing AC_CHECK_LIB with AC_SEARCH_LIBS adds -l
after the source file and by that autotools detects
rdma_lib_reset.

Signed-off-by: Rafi Wiener <rafiw@mellanox.com>