### PR TITLE
issue: 969414 revert "Set log severity to ERROR (was DEBUG) in case of

### DIFF
--- a/src/vma/dev/buffer_pool.cpp
+++ b/src/vma/dev/buffer_pool.cpp
@@ -349,10 +349,10 @@ mem_buf_desc_t *buffer_pool::get_buffers(size_t count, uint32_t lkey)
 	__log_info_funcall("requested %lu, present %lu, created %lu", count, m_n_buffers, m_n_buffers_created);
 
 	if (unlikely(m_n_buffers < count)) {
-		static vlog_levels_t log_severity = VLOG_ERROR; // ERROR severity will be used only once - at the 1st time
+		static vlog_levels_t log_severity = VLOG_DEBUG; // DEBUG severity will be used only once - at the 1st time
 
-		VLOG_PRINTF_INFO(log_severity, "not enough buffers in the pool (requested: %lu, have: %lu, created: %lu isRx=%d isTx=%d)",
-				count, m_n_buffers, m_n_buffers_created, (int)(this==g_buffer_pool_rx), (int)(this==g_buffer_pool_tx));
+		VLOG_PRINTF_INFO(log_severity, "ERROR! not enough buffers in the pool (requested: %lu, have: %lu, created: %lu, Buffer pool type: %s)",
+				count, m_n_buffers, m_n_buffers_created, m_p_bpool_stat->is_rx ? "Rx" : "Tx");
 
 		log_severity = VLOG_FUNC; // for all times but the 1st one
 

--- a/src/vma/dev/buffer_pool.h
+++ b/src/vma/dev/buffer_pool.h
@@ -141,6 +141,7 @@ private:
 	/**
 	 * Get buffers from the pool - no thread safe
 	 * @param count Number of buffers required.
+	 * @param lkey the registered memory lkey.
 	 * @return List of buffers, or NULL if don't have enough buffers.
 	 */
 	mem_buf_desc_t *get_buffers(size_t count, uint32_t lkey);

--- a/src/vma/dev/cq_mgr.cpp
+++ b/src/vma/dev/cq_mgr.cpp
@@ -251,8 +251,10 @@ void cq_mgr::add_qp_rx(qp_mgr* qp)
 			n_num_mem_bufs = qp_rx_wr_num;
 		p_temp_desc_list = g_buffer_pool_rx->get_buffers_thread_safe(n_num_mem_bufs, m_p_ib_ctx_handler);
 		if (p_temp_desc_list == NULL) {
-			cq_logdbg("WARNING Out of mem_buf_desc from Rx buffer pool for qp_mgr qp_mgr initialization (qp=%p)", qp);
-			cq_logdbg("WARNING This might happen due to wrong setting of VMA_RX_BUFS and VMA_RX_WRE. Please refer to README.txt for more info");
+			static vlog_levels_t log_severity = VLOG_WARNING; // WARNING severity will be used only once - at the 1st time
+			VLOG_PRINTF_INFO(log_severity, "WARNING Out of mem_buf_desc from Rx buffer pool for qp_mgr qp_mgr initialization (qp=%p)", qp);
+			VLOG_PRINTF_INFO(log_severity, "WARNING This might happen due to wrong setting of VMA_RX_BUFS and VMA_RX_WRE. Please refer to README.txt for more info");
+			log_severity = VLOG_DEBUG; // for all times but the 1st one
 			break;
 		}
 


### PR DESCRIPTION
insufficient buffers in pool"

- This reverts commit 3cf34e4.
- Warning message will be printed once only if there are not enough buffers
  during RX QP initialization.

Signed-off-by: Liran Oz <lirano@mellanox.com>