### PR TITLE
issue: 1044955 Code cleanup in vma_list.h

### DIFF
--- a/src/vma/dev/buffer_pool.cpp
+++ b/src/vma/dev/buffer_pool.cpp
@@ -53,9 +53,9 @@ buffer_pool *g_buffer_pool_tx = NULL;
 // inlining a function only help in case it come before using it...
 inline void buffer_pool::put_buffer_helper(mem_buf_desc_t *buff)
 {
-#if _VMA_LIST_DEBUG
+#if VLIST_DEBUG
 	if (buff->buffer_node.is_list_member()) {
-		vlog_printf(VLOG_WARNING, "buffer_pool::put_buffer_helper - buff is already a member in a list (list id = %s)\n", buff->buffer_node.list_id());
+		__log_info_warn("Buffer is already a member in a list! id=[%s]", buff->buffer_node.list_id());
 	}
 #endif
 	buff->p_next_desc = m_p_head;

--- a/src/vma/dev/cq_mgr.cpp
+++ b/src/vma/dev/cq_mgr.cpp
@@ -604,9 +604,9 @@ void cq_mgr::reclaim_recv_buffer_helper(mem_buf_desc_t* buff)
 #endif // DEFINED_VMAPOLL
 			mem_buf_desc_t* temp = NULL;
 			while (buff) {
-			#if _VMA_LIST_DEBUG
+			#if VLIST_DEBUG
 				if (buff->buffer_node.is_list_member()) {
-					vlog_printf(VLOG_WARNING, "cq_mgr::reclaim_recv_buffer_helper - buff is already a member in a list , id = %s\n", buff->buffer_node.list_id());
+					cq_logwarn("Buffer is already a member in a list! id=[%s]", buff->node.list_id());
 				}
 			#endif
 				temp = buff;
@@ -645,9 +645,9 @@ void cq_mgr::vma_poll_reclaim_recv_buffer_helper(mem_buf_desc_t* buff)
 	if (buff->dec_ref_count() <= 1) {
 		mem_buf_desc_t* temp = NULL;
 		while (buff) {
-		#if _VMA_LIST_DEBUG
+		#if VLIST_DEBUG
 			if (buff->node.is_list_member()) {
-				vlog_printf(VLOG_WARNING, "cq_mgr::reclaim_recv_buffer_helper - buff is already a member in a list , id = %s\n", buff->node.list_id());
+				cq_logwarn("Buffer is already a member in a list! id=[%s]", buff->node.list_id());
 			}
 		#endif
 			if(buff->lwip_pbuf_dec_ref_count() <= 0) {
@@ -684,9 +684,9 @@ int cq_mgr::vma_poll_reclaim_single_recv_buffer_helper(mem_buf_desc_t* buff)
 {
 	int ref_cnt = buff->lwip_pbuf_dec_ref_count();
 	if (ref_cnt <= 0) {
-		#if _VMA_LIST_DEBUG
+		#if VLIST_DEBUG
 			if (buff->node.is_list_member()) {
-				vlog_printf(VLOG_WARNING, "cq_mgr::reclaim_recv_buffer_helper - buff is already a member in a list , id = %s\n", buff->node.list_id());
+				cq_logwarn("Buffer is already a member in a list! id=[%s]", buff->node.list_id());
 			}
 		#endif
 

--- a/src/vma/util/chunk_list.h
+++ b/src/vma/util/chunk_list.h
@@ -146,7 +146,7 @@ public:
 		return m_size;
 	}
 
-	inline T front() {
+	inline T front() const {
 		// Check if the list is empty.
 		if (unlikely(empty()))
 				return NULL;

--- a/src/vma/util/vma_list.h
+++ b/src/vma/util/vma_list.h
@@ -171,11 +171,11 @@ private:
 
 	T*	m_ptr;
 
-	void increment_ptr() {
+	inline void increment_ptr() {
 		m_ptr = ((list_node<T, offset> *)GET_NODE(m_ptr, T, offset)->head.next)->obj_ptr;
 	}
 
-	void decrement_ptr() {
+	inline void decrement_ptr() {
 		m_ptr = ((list_node<T, offset> *)GET_NODE(m_ptr, T, offset)->head.prev)->obj_ptr;
 	}
 

--- a/src/vma/util/vma_list.h
+++ b/src/vma/util/vma_list.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001-2016 Mellanox Technologies, Ltd. All rights reserved.
+ * Copyright (c) 2001-2017 Mellanox Technologies, Ltd. All rights reserved.
  *
  * This software is available to you under a choice of one of two
  * licenses.  You may choose to be licensed under the terms of the GNU
@@ -30,24 +30,34 @@
  * SOFTWARE.
  */
 
-#ifndef VMA_LIST
-#define VMA_LIST
+#ifndef VMA_LIST_H
+#define VMA_LIST_H
 
 #include "vma/util/list.h"
 #include "vlogger/vlogger.h"
 
-#define _VMA_LIST_DEBUG 0
-#define ID_MAX_SIZE 200
+#define VLIST_DEBUG        0
+#define VLIST_ID_SIZE      200
 
-#if _VMA_LIST_DEBUG
+#if VLIST_DEBUG
 template <class T, size_t offset(void)>
 class vma_list_t;
 #endif
 
 #define NODE_OFFSET(_obj_type, _node_name) \
-	((size_t)(&(char &)(((_obj_type *) 1)->_node_name)) - 1)
+		((size_t)(&(char &)(((_obj_type *) 1)->_node_name)) - 1)
 #define GET_NODE(_obj, _obj_type, _offset_func) \
-	((list_node<_obj_type, _offset_func> *) ((size_t)(_obj) + (size_t)(_offset_func())))
+		((list_node<_obj_type, _offset_func> *) ((size_t)(_obj) + (size_t)(_offset_func())))
+
+// debugging macros
+#undef  MODULE_HDR_INFO
+#undef  __INFO__
+
+#define MODULE_HDR_INFO    "vlist[%p]:%d:%s() "
+#define __INFO__           this
+
+#define vlist_logwarn      __log_info_warn
+#define vlist_logerr       __log_info_err
 
 template <class T, size_t offset(void)>
 class list_node {
@@ -57,27 +67,26 @@ public :
 	struct list_head head;
 	T *obj_ptr;
 
-#if _VMA_LIST_DEBUG
+#if VLIST_DEBUG
 	vma_list_t<T, offset> * parent;
 
-	char* list_id(){
+	char* list_id() {
 		return this->parent->list_id();
 	}
 
 #endif
 
-	list_node() {
+	list_node() : obj_ptr(NULL) {
 		this->head.next = &this->head;
 		this->head.prev = &this->head;
-		this->obj_ptr = NULL;
 
-	#if _VMA_LIST_DEBUG
+	#if VLIST_DEBUG
 		this->parent = NULL;
 	#endif
 	}
 
 	/* is_list_member - check if the node is already a member in a list. */
-	bool is_list_member(){
+	bool is_list_member() {
 		return this->head.next != &this->head || this->head.prev != &this->head;
 	}
 
@@ -88,63 +97,87 @@ class list_iterator_t : public std::iterator<std::random_access_iterator_tag, T,
 {
 public:
 
-    list_iterator_t(T* ptr = NULL){m_ptr = ptr;}
-    list_iterator_t(const list_iterator_t<T, offset>& __iterator){m_ptr = __iterator.m_ptr;}
-    ~list_iterator_t(){}
+	list_iterator_t(T* ptr = NULL) : m_ptr(ptr) {}
 
-    list_iterator_t<T, offset>&          operator=(T* ptr){m_ptr = ptr;return (*this);}
-    list_iterator_t<T, offset>&          operator=(const list_iterator_t<T, offset>& __iterator){m_ptr = __iterator.m_ptr;return (*this);}
+	list_iterator_t(const list_iterator_t<T, offset>& iter) : m_ptr(iter.m_ptr) {}
 
-    operator	bool()const {
-        if(m_ptr)
-            return true;
-        else
-            return false;
-    }
+	~list_iterator_t() {}
 
-    bool	operator==(const list_iterator_t<T, offset>& __iterator)const{return (m_ptr == __iterator.getConstPtr());}
-    bool	operator!=(const list_iterator_t<T, offset>& __iterator)const{return (m_ptr != __iterator.getConstPtr());}
+	list_iterator_t<T, offset>& operator=(T* ptr) {
+		m_ptr = ptr;
+		return (*this);
+	}
 
-    list_iterator_t<T, offset> operator++(int){
-    	list_iterator_t<T, offset> tmp(*this);
-    	increment_ptr();
-    	return tmp;
-    }
+	list_iterator_t<T, offset>& operator=(const list_iterator_t<T, offset>& iter) {
+		m_ptr = iter.m_ptr;
+		return (*this);
+	}
 
-    list_iterator_t<T, offset>& operator++(){
-    	increment_ptr();
-    	return *this;
-    }
+	operator bool() const {
+		return m_ptr ? true : false;
+	}
 
-    list_iterator_t<T, offset> operator--(int){
-     	list_iterator_t<T, offset> tmp(*this);
-     	decrement_ptr();
-     	return tmp;
-     }
+	bool operator==(const list_iterator_t<T, offset>& iter) const {
+		return m_ptr == iter.getConstPtr();
+	}
 
-    list_iterator_t<T, offset>& operator--(){
-    	decrement_ptr();
-    	return *this;
-    }
+	bool operator!=(const list_iterator_t<T, offset>& iter) const {
+		return m_ptr != iter.getConstPtr();
+	}
 
-    T*	operator*(){return m_ptr;}
-    const T*	operator*()const{return m_ptr;}
-    T*	operator->(){return m_ptr;}
+	list_iterator_t<T, offset> operator++(int) {
+		list_iterator_t<T, offset> iter(*this);
+		increment_ptr();
+		return iter;
+	}
 
-    T*	getPtr()const{return m_ptr;}
-    const T*	getConstPtr()const{return m_ptr;}
+	list_iterator_t<T, offset>& operator++() {
+		increment_ptr();
+		return *this;
+	}
+
+	list_iterator_t<T, offset> operator--(int) {
+		list_iterator_t<T, offset> iter(*this);
+		decrement_ptr();
+		return iter;
+	}
+
+	list_iterator_t<T, offset>& operator--() {
+		decrement_ptr();
+		return *this;
+	}
+
+	T* operator*() {
+		return m_ptr;
+	}
+
+	const T* operator*() const {
+		return m_ptr;
+	}
+
+	T* operator->() {
+		return m_ptr;
+	}
+
+	T* getPtr() const {
+		return m_ptr;
+	}
+
+	const T* getConstPtr() const {
+		return m_ptr;
+	}
 
 private:
 
-    T*	m_ptr;
+	T*	m_ptr;
 
-    void increment_ptr() {
-    	m_ptr =  ((list_node<T, offset> *)GET_NODE(m_ptr, T, offset)->head.next)->obj_ptr;
-    }
+	void increment_ptr() {
+		m_ptr = ((list_node<T, offset> *)GET_NODE(m_ptr, T, offset)->head.next)->obj_ptr;
+	}
 
-    void decrement_ptr(){
-    	m_ptr = ((list_node<T, offset> *)GET_NODE(m_ptr, T, offset)->head.prev)->obj_ptr;
-    }
+	void decrement_ptr() {
+		m_ptr = ((list_node<T, offset> *)GET_NODE(m_ptr, T, offset)->head.prev)->obj_ptr;
+	}
 
 };
 
@@ -157,9 +190,9 @@ public:
 		init_list();
 	}
 
-	void set_id(const char *format, ...){
+	void set_id(const char *format, ...) {
 		if (format) {
-	#if _VMA_LIST_DEBUG
+	#if VLIST_DEBUG
 			va_list arg;
 			va_start (arg, format);
 			vsnprintf (id, sizeof(id) ,format, arg);
@@ -169,27 +202,27 @@ public:
 	}
 
 	~vma_list_t() {
-		if (! empty()) {
-			vlog_printf(VLOG_WARNING,"vma_list_t destructor is not supported for non-empty list (list_counter=%d).\n", (int)m_size);
+		if (!empty()) {
+			vlist_logwarn("Destructor is not supported for non-empty list! size=%zu", m_size);
 		}
 	}
 
-	vma_list_t<T, offset> (const vma_list_t<T, offset> & other) {
+	vma_list_t<T, offset> (const vma_list_t<T, offset>& other) {
 		if (!other.empty())
-			vlog_printf(VLOG_WARNING,"vma_list_t copy constructor is not supported for non-empty list (other.list_counter=%d).\n", (int)other.m_size);
+			vlist_logwarn("Copy constructor is not supported for non-empty list! other.size=%zu", other.m_size);
 		init_list();
 	}
 
-	vma_list_t<T, offset> & operator=(const vma_list_t<T, offset> & other) {
+	vma_list_t<T, offset>& operator=(const vma_list_t<T, offset>& other) {
 		if (!empty() || !other.empty())
-			vlog_printf(VLOG_WARNING,"vma_list_t operator= is not supported for non-empty list (list_counter=%d, other.list_counter=%d).\n", (int)m_size, (int)other.m_size);
+			vlist_logwarn("Operator= is not supported for non-empty list! size=%zu, other.size=%zu", m_size, other.m_size);
 		if (this != &other) {
 			init_list();
 		}
 		return *this;
 	}
 
-	T* operator[](size_t idx) {
+	T* operator[](size_t idx) const {
 		return get(idx);
 	}
 
@@ -197,27 +230,27 @@ public:
 		return m_size == 0;
 	}
 
-	inline size_t size(){
+	inline size_t size() const {
 		return m_size;
 	}
 
-	inline T* front() {
+	inline T* front() const {
 		if (unlikely(empty()))
 			return NULL;
 		return ((list_node<T, offset> *)m_list.head.next)->obj_ptr;
 	}
 
-	inline T* back() {
+	inline T* back() const {
 		if (unlikely(empty()))
 			return NULL;
 		return ((list_node<T, offset> *)m_list.head.prev)->obj_ptr;
 	}
 
-	inline void pop_front(){
+	inline void pop_front() {
 		erase(front());
 	}
 
-	inline void pop_back(){
+	inline void pop_back() {
 		erase(back());
 	}
 
@@ -233,12 +266,12 @@ public:
 		return list_back;
 	}
 
-	void erase(T* obj){
+	void erase(T* obj) {
 		if (unlikely(!obj)) {
-			vlog_printf(VLOG_WARNING,"vma_list_t.erase() got NULL object - ignoring.\n");
+			vlist_logwarn("Got NULL object - ignoring");
 			return;
 		}
-	#if _VMA_LIST_DEBUG
+	#if VLIST_DEBUG
 		GET_NODE(obj, T, offset)->parent = NULL;
 	#endif
 		list_del_init(&GET_NODE(obj, T, offset)->head);
@@ -255,53 +288,24 @@ public:
 		init_list();
 	}
 
-	void push_back(T* obj){
-		if (unlikely(!obj)) {
-			vlog_printf(VLOG_WARNING,"vma_list_t.push_back() got NULL object - ignoring.\n");
-			return;
+	void push_back(T* obj) {
+		if (likely(handle_push(obj))) {
+			list_add_tail(&GET_NODE(obj, T, offset)->head, &m_list.head);
 		}
-		if (unlikely(GET_NODE(obj, T, offset)->is_list_member())) {
-		#if _VMA_LIST_DEBUG
-			vlog_printf(VLOG_ERROR,"vma_list_t.push_back() - buff is already a member in a list (list id = %s), (this.id = %s)\n", GET_NODE(obj, T, offset)->list_id(), this->list_id());
-		#else
-			vlog_printf(VLOG_ERROR,"vma_list_t.push_back() - buff is already a member in a list.\n");
-		#endif
-		}
-	#if _VMA_LIST_DEBUG
-		GET_NODE(obj, T, offset)->parent = this;
-	#endif
-		GET_NODE(obj, T, offset)->obj_ptr = obj;
-		list_add_tail(&GET_NODE(obj, T, offset)->head, &m_list.head);
-		m_size++;
 	}
 
-	void push_front(T* obj){
-		if (unlikely(!obj)) {
-			vlog_printf(VLOG_WARNING,"vma_list_t.push_front() got NULL object - ignoring.\n");
-			return;
+	void push_front(T* obj) {
+		if (likely(handle_push(obj))) {
+			list_add(&GET_NODE(obj, T, offset)->head, &m_list.head);
 		}
-		if (unlikely(GET_NODE(obj, T, offset)->is_list_member())) {
-		#if _VMA_LIST_DEBUG
-			vlog_printf(VLOG_ERROR,"vma_list_t.push_front() - buff is already a member in a list (list id = %s), (this.id = %s)\n", GET_NODE(obj, T, offset)->list_id(), this->list_id());
-		#else
-			vlog_printf(VLOG_ERROR,"vma_list_t.push_front() - buff is already a member in a list.\n");
-		#endif
-		}
-
-	#if _VMA_LIST_DEBUG
-		GET_NODE(obj, T, offset)->parent = this;
-	#endif
-		GET_NODE(obj, T, offset)->obj_ptr = obj;
-		list_add(&GET_NODE(obj, T, offset)->head, &m_list.head);
-		m_size++;
 	}
 
-	T* get(size_t index) {
+	T* get(size_t index) const {
 		if (m_size <= index) {
 			return NULL;
 		} else {
 			list_head* ans = m_list.head.next;
-			for (size_t i = 0 ; i < index ; i++){
+			for (size_t i = 0 ; i < index ; i++) {
 				ans = ans->next;
 			}
 			return ((list_node<T, offset> *)ans)->obj_ptr;
@@ -309,20 +313,20 @@ public:
 	}
 
 	// concatenate 'from' at the head of this list
-	void splice_head(vma_list_t<T, offset> & from) {
+	void splice_head(vma_list_t<T, offset>& from) {
 
 		this->m_size += from.m_size;
 		list_splice(&from.m_list.head, &this->m_list.head);
 		from.init_list();
-		// TODO: in case _VMA_LIST_DEBUG, this invalidates parent list of all nodes in the list
+		// TODO: in case VLIST_DEBUG, this invalidates parent list of all nodes in the list
 	}
 
 	// concatenate 'from' at the tail of this list
-	void splice_tail(vma_list_t<T, offset> & from) {
+	void splice_tail(vma_list_t<T, offset>& from) {
 		this->m_size += from.m_size;
 		list_splice_tail(&from.m_list.head, &this->m_list.head);
 		from.init_list();
-		// TODO: in case _VMA_LIST_DEBUG, this invalidates parent list of all nodes in the list
+		// TODO: in case VLIST_DEBUG, this invalidates parent list of all nodes in the list
 	}
 
 	/**
@@ -332,24 +336,23 @@ public:
 	 * After the call to this member function, the elements in this container are those which were in x before the call, and
 	 * the elements of x are those which were in this. All iterators, references and pointers remain valid for the swapped objects.
 	 */
-	void swap (vma_list_t<T, offset> & x) {
-
+	void swap (vma_list_t<T, offset>& x) {
 		vma_list_t<T, offset> temp_list;
 		this->move_to_empty(temp_list);
 		x.move_to_empty(*this);
 		temp_list.move_to_empty(x);
 	}
 
-	list_iterator_t<T, offset> begin(){
+	list_iterator_t<T, offset> begin() {
 		return list_iterator_t<T, offset>(front());
 	}
 
-	list_iterator_t<T,offset> end(){
+	list_iterator_t<T,offset> end() {
 		return list_iterator_t<T, offset>(NULL);
 	}
 
-#if _VMA_LIST_DEBUG
-	char* list_id(){
+#if VLIST_DEBUG
+	char* list_id() {
 		return (char*)&id;
 	}
 #endif
@@ -359,24 +362,46 @@ private:
 	list_node<T, offset> m_list;
 	size_t m_size;
 
-#if _VMA_LIST_DEBUG
-	char id[ID_MAX_SIZE];
+#if VLIST_DEBUG
+	char id[VLIST_ID_SIZE];
 #endif
 
-	void move_to_empty(vma_list_t<T, offset> & to) {
+	void move_to_empty(vma_list_t<T, offset>& to) {
 		assert(to.empty());
 		to.m_size   = this->m_size;
 		list_splice_tail(&this->m_list.head, &to.m_list.head);
 		this->init_list();
-		// TODO: in case _VMA_LIST_DEBUG, this invalidates parent list of all nodes in the list
+		// TODO: in case VLIST_DEBUG, this invalidates parent list of all nodes in the list
 	}
-	void init_list(){
+
+	inline bool handle_push(T* obj) {
+		if (unlikely(!obj)) {
+			vlist_logwarn("Got NULL object - ignoring");
+			return false;
+		}
+		if (unlikely(GET_NODE(obj, T, offset)->is_list_member())) {
+		#if VLIST_DEBUG
+			vlist_logerr("Buff is already a member in a list! parent.id=[%s], this.id=[%s]", GET_NODE(obj, T, offset)->list_id(), this->list_id());
+		#else
+			vlist_logerr("Buff is already a member in a list!");
+		#endif
+		}
+
+	#if VLIST_DEBUG
+		GET_NODE(obj, T, offset)->parent = this;
+	#endif
+		GET_NODE(obj, T, offset)->obj_ptr = obj;
+		m_size++;
+		return true;
+	}
+
+	void init_list() {
 		m_size = 0;
 		INIT_LIST_HEAD(&m_list.head);
-	#if _VMA_LIST_DEBUG
+	#if VLIST_DEBUG
 		id[0] = '\0';
 	#endif
 	}
 };
 
-#endif /* VMA_LIST */
+#endif /* VMA_LIST_H */


### PR DESCRIPTION
- Use debug macros instead of vlog_printf calls.
- Declare several functions as const functions.
- Fix indentation.
- Use private function to avoid code duplication in push_back() and
  push_front().

Signed-off-by: Liran Oz <lirano@mellanox.com>