### PR TITLE
issue: 1032039 Set max_send_sge as 1 for vmapoll

### DIFF
--- a/src/vma/dev/qp_mgr.cpp
+++ b/src/vma/dev/qp_mgr.cpp
@@ -197,7 +197,7 @@ int qp_mgr::configure(struct ibv_comp_channel* p_rx_comp_event_channel)
 	// Check device capabilities for max SG elements
 	uint32_t tx_max_inline = safe_mce_sys().tx_max_inline;
 	uint32_t rx_num_sge = (IS_VMAPOLL) ? 1 : MCE_DEFAULT_RX_NUM_SGE;
-	uint32_t tx_num_sge = MCE_DEFAULT_TX_NUM_SGE;
+	uint32_t tx_num_sge = (IS_VMAPOLL) ? 1 : MCE_DEFAULT_TX_NUM_SGE;
 
 	qp_init_attr.cap.max_send_wr = m_tx_num_wr;
 	qp_init_attr.cap.max_recv_wr = m_rx_num_wr;


### PR DESCRIPTION
Current implementation vmapoll does not support more then single
scatter gather element.

Signed-off-by: Igor Ivanov <igor.ivanov.va@gmail.com>