### PR TITLE
issue: 1048224 Use ioctl() to verify if non-offloaded data is available

### DIFF
--- a/src/vma/sock/sockinfo_tcp.cpp
+++ b/src/vma/sock/sockinfo_tcp.cpp
@@ -2443,18 +2443,16 @@ int sockinfo_tcp::accept_helper(struct sockaddr *__addr, socklen_t *__addrlen, i
 
 		// Poll OS socket for pending connection
 		// smart bit to switch between the two
-		pollfd os_fd[1];
-		os_fd[0].fd = m_fd;
-		os_fd[0].events = POLLIN;
-		ret = orig_os_api.poll(os_fd, 1, 0); // Zero timeout - just poll and return quickly
+		uint64_t pending_data = 0;
+		ret = orig_os_api.ioctl(m_fd, FIONREAD, &pending_data);
 		if (unlikely(ret == -1)) {
 			m_p_socket_stats->counters.n_rx_os_errors++;
-			si_tcp_logdbg("orig_os_api.poll returned with error (errno=%d %m)", errno);
+			si_tcp_logdbg("orig_os_api.ioctl returned with error (errno=%d %m)", errno);
 			unlock_tcp_con();
 			return -1;
 		}
-		if (ret == 1) {
-			si_tcp_logdbg("orig_os_api.poll returned with packet");
+		if (pending_data > 0) {
+			si_tcp_logdbg("orig_os_api.ioctl returned with packet");
 			unlock_tcp_con();
 			if (__flags)
 				return orig_os_api.accept4(m_fd, __addr, __addrlen, __flags);

--- a/src/vma/sock/sockinfo_udp.h
+++ b/src/vma/sock/sockinfo_udp.h
@@ -265,7 +265,7 @@ private:
 	int 		rx_wait_helper(int &poll_count, bool is_blocking);
 	
 	inline int 	rx_wait(bool blocking);
-	inline ssize_t	poll_os();
+	inline int 	poll_os();
 
 	virtual inline void			reuse_buffer(mem_buf_desc_t *buff);
 	virtual 	mem_buf_desc_t*	get_next_desc (mem_buf_desc_t *p_desc);


### PR DESCRIPTION
Insted of using os.poll() to verify if non-offloaded data is available,
We can use os.ioctl() using FIONREAD flag which takes less time.

Signed-off-by: Liran Oz <lirano@mellanox.com>