### PR TITLE
issue: 1049758 Support ioctl() with FIONREAD flag

### DIFF
--- a/src/vma/sock/sockinfo.cpp
+++ b/src/vma/sock/sockinfo.cpp
@@ -201,6 +201,18 @@ int sockinfo::ioctl(unsigned long int __request, unsigned long int __arg) throw 
 		}
 		break;
 
+	case FIONREAD:
+		{
+			si_logdbg("request=FIONREAD, arg=%d", *p_arg);
+			int ret = rx_verify_available_data();
+			if (ret != -1) {
+				*p_arg = ret;
+				return 0;
+			}
+			return ret;
+		}
+		break;
+
 	default:
 		char buf[128];
 		snprintf(buf, sizeof(buf), "unimplemented ioctl request=%#x, flags=%#x", (unsigned)__request, (unsigned)__arg);

--- a/src/vma/sock/sockinfo.cpp
+++ b/src/vma/sock/sockinfo.cpp
@@ -203,9 +203,9 @@ int sockinfo::ioctl(unsigned long int __request, unsigned long int __arg) throw 
 
 	case FIONREAD:
 		{
-			si_logdbg("request=FIONREAD, arg=%d", *p_arg);
+			si_logfunc("request=FIONREAD, arg=%d", *p_arg);
 			int ret = rx_verify_available_data();
-			if (ret != -1) {
+			if (ret >= 0) {
 				*p_arg = ret;
 				return 0;
 			}

--- a/src/vma/sock/sockinfo.h
+++ b/src/vma/sock/sockinfo.h
@@ -235,6 +235,7 @@ protected:
 	void 			save_stats_tx_os(int bytes);
 	void 			save_stats_rx_offload(int nbytes);
 
+	virtual int             rx_verify_available_data() = 0;
 	virtual mem_buf_desc_t *get_next_desc (mem_buf_desc_t *p_desc) = 0;
 	virtual	mem_buf_desc_t* get_next_desc_peek(mem_buf_desc_t *p_desc, int& rx_pkt_ready_list_idx) = 0;
 	

--- a/src/vma/sock/sockinfo_tcp.cpp
+++ b/src/vma/sock/sockinfo_tcp.cpp
@@ -2416,7 +2416,7 @@ int sockinfo_tcp::rx_verify_available_data()
 	int poll_count = 0;
 	int ret = rx_wait_helper(poll_count, false);
 
-	return ret == -1 ? ret : m_p_socket_stats->n_rx_ready_byte_count;
+	return (ret == -1 ? ret : m_p_socket_stats->n_rx_ready_byte_count);
 }
 
 int sockinfo_tcp::accept_helper(struct sockaddr *__addr, socklen_t *__addrlen, int __flags /* = 0 */)

--- a/src/vma/sock/sockinfo_tcp.cpp
+++ b/src/vma/sock/sockinfo_tcp.cpp
@@ -2411,6 +2411,14 @@ int sockinfo_tcp::listen(int backlog)
 
 }
 
+int sockinfo_tcp::rx_verify_available_data()
+{
+	int poll_count = 0;
+	int ret = rx_wait_helper(poll_count, false);
+
+	return ret == -1 ? ret : m_p_socket_stats->n_rx_ready_byte_count;
+}
+
 int sockinfo_tcp::accept_helper(struct sockaddr *__addr, socklen_t *__addrlen, int __flags /* = 0 */)
 {
 	sockinfo_tcp *ns;

--- a/src/vma/sock/sockinfo_tcp.h
+++ b/src/vma/sock/sockinfo_tcp.h
@@ -394,6 +394,7 @@ private:
 
 	//lock_spin_recursive m_rx_cq_lck;
 	/* pick all cqs that match given address */
+	virtual int	rx_verify_available_data();
 	inline int 	rx_wait(int & poll_count, bool is_blocking);
 	inline int 	rx_wait_lockless(int & poll_count, bool is_blocking);
 	int 		rx_wait_helper(int & poll_count, bool is_blocking);

--- a/src/vma/sock/sockinfo_udp.cpp
+++ b/src/vma/sock/sockinfo_udp.cpp
@@ -1933,7 +1933,7 @@ int sockinfo_udp::rx_verify_available_data()
 
 	if (ret == 0) {
 		// Got 0, means we might have a ready packet
-		auto_unlocker lock(m_lock_rcv);
+		auto_unlocker locker(m_lock_rcv);
 		if (!m_rx_pkt_ready_list.empty()) {
 			ret = m_rx_pkt_ready_list.front()->rx.sz_payload;
 		}

--- a/src/vma/sock/sockinfo_udp.cpp
+++ b/src/vma/sock/sockinfo_udp.cpp
@@ -1942,7 +1942,7 @@ int sockinfo_udp::rx_verify_available_data()
 		// Got 1, means we have a ready packet in OS
 		uint64_t pending_data = 0;
 		ret = orig_os_api.ioctl(m_fd, FIONREAD, &pending_data);
-		if (ret != -1) {
+		if (ret >= 0) {
 			// This will cause the next non-blocked read to check the OS again.
 			// We do this only after a successful read.
 			m_rx_udp_poll_os_ratio_counter = m_n_sysvar_rx_udp_poll_os_ratio;

--- a/src/vma/sock/sockinfo_udp.h
+++ b/src/vma/sock/sockinfo_udp.h
@@ -156,6 +156,7 @@ public:
 	bool tx_check_if_would_not_block();
 	void rx_add_ring_cb(flow_tuple_with_local_if& flow_key, ring* p_ring, bool is_migration = false);
 	void rx_del_ring_cb(flow_tuple_with_local_if& flow_key, ring* p_ring, bool is_migration = false);
+	virtual int rx_verify_available_data();
 
 	// This callback will handle ready rx packet notification from any ib_conn_mgr
 	/**


### PR DESCRIPTION
ioctl() with FIONREAD flag is used to get the number of bytes that are
immediately available for reading.

Signed-off-by: Liran Oz <lirano@mellanox.com>