### PR TITLE
issue: 1044574 Fix netlink failures

### DIFF
--- a/src/vma/netlink/netlink_wrapper.cpp
+++ b/src/vma/netlink/netlink_wrapper.cpp
@@ -251,10 +251,13 @@ int netlink_wrapper::open_channel()
 
 	if (nl_cache_mngr_compatible_add(m_mngr, "route/neigh", neigh_callback, NULL, &m_cache_neigh))
 		return -1;
+	usleep(500);
 	if (nl_cache_mngr_compatible_add(m_mngr, "route/link", link_callback, NULL, &m_cache_link))
 		return -1;
+	usleep(500);
 	if (nl_cache_mngr_compatible_add(m_mngr, "route/route", route_callback, NULL, &m_cache_route))
 		return -1;
+	usleep(500);
 
 	// set custom callback for every message to update message
 	nl_socket_modify_cb(m_socket_handle, NL_CB_MSG_IN, NL_CB_CUSTOM, nl_msg_rcv_cb ,NULL);


### PR DESCRIPTION
Occasionally when registering to netlink callbacks nl_cache_mngr_add()
three times in a raw for neigh, link and route updates events - a
failure occurs. If the process goes to sleep for 500usec between the
registration calls - no failures occur.
This commit is a work around for this issue

Signed-off-by: Ophir Munk <ophirmu@mellanox.com>