### PR TITLE
issue: 1004613 TX Post-Send PRM enabled for non-VMAPOLL

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -71,7 +71,16 @@ AC_CHECK_HEADERS([infiniband/verbs.h], ,
 AC_CHECK_HEADERS([rdma/rdma_cma.h], ,
                  [AC_MSG_ERROR([Unable to find the librdmacm-devel header files])])
 
-AC_CHECK_HEADERS([infiniband/mlx5_hw.h])
+#
+# Chech if infiniband/mlx5_hw.h can be used
+#
+AC_CHECK_HEADER([infiniband/mlx5_hw.h],
+	[AC_CHECK_MEMBERS([struct mlx5_qp.ctrl_seg, struct mlx5_qp.gen_data],
+		[AC_DEFINE([HAVE_INFINIBAND_MLX5_HW_H],1,[infiniband/mlx5_hw.h can be used])],
+		[ac_cv_header_infiniband_mlx5_hw_h="no"],
+		[[#include <infiniband/mlx5_hw.h>]] )],
+	[],[]
+)
 
 AC_MSG_CHECKING([md5 version of VMA statistics is])
 STATS_PROTOCOL_VER=`md5sum ${srcdir}/src/vma/util/vma_stats.h | awk '{ print $1}'`

--- a/src/vma/dev/cq_mgr.cpp
+++ b/src/vma/dev/cq_mgr.cpp
@@ -637,9 +637,7 @@ void cq_mgr::reclaim_recv_buffer_helper(mem_buf_desc_t* buff)
 				temp->reset_ref_count();
 				temp->rx.tcp.gro = 0;
 				temp->rx.is_vma_thr = false;
-#ifdef DEFINED_VMAPOLL
 				temp->rx.vma_polled = false;
-#endif // DEFINED_VMAPOL
 				temp->rx.flow_tag_id = 0;
 				temp->rx.tcp.p_ip_h = NULL;
 				temp->rx.tcp.p_tcp_h = NULL;
@@ -933,43 +931,6 @@ int cq_mgr::poll_and_process_element_tx(uint64_t* p_cq_poll_sn)
 	// Assume locked!!!
 	cq_logfuncall("");
 	
-#ifdef DEFINED_VMAPOLL
-	int ret = 0;
-	volatile mlx5_cqe64 *cqe_err = NULL;
-	volatile mlx5_cqe64 *cqe = mlx5_get_cqe64(&cqe_err);
-
-	if (likely(cqe)) {
-		m_qp->m_mlx5_hw_qp->sq.tail += NUM_TX_WRE_TO_SIGNAL_MAX;
-		uint16_t wqe_ctr = ntohs(cqe->wqe_counter);
-		int index = wqe_ctr & (m_qp->m_tx_num_wr - 1);
-		mem_buf_desc_t* buff = (mem_buf_desc_t*)(uintptr_t)m_qp->m_sq_wqe_idx_to_wrid[index];
-
-		// spoil the global sn if we have packets ready
-		union __attribute__((packed)) {
-			uint64_t global_sn;
-			struct {
-				uint32_t cq_id;
-				uint32_t cq_sn;
-			} bundle;
-		} next_sn;
-		next_sn.bundle.cq_sn = ++m_n_cq_poll_sn;
-		next_sn.bundle.cq_id = m_cq_id;
-
-		*p_cq_poll_sn = m_n_global_sn = next_sn.global_sn;
-
-		process_tx_buffer_list(buff);
-		ret = 1;
-	}
-	else if (cqe_err) {
-		ret = mlx5_poll_and_process_error_element_tx(cqe_err, p_cq_poll_sn);
-	}
-	else {
-		*p_cq_poll_sn = m_n_global_sn;
-	}
-
-	return ret;
-#else
-
 	/* coverity[stack_use_local_overflow] */
 	vma_ibv_wc wce[MCE_MAX_CQ_POLL_BATCH];
 	int ret = poll(wce, m_n_sysvar_cq_poll_batch_max, p_cq_poll_sn);
@@ -987,7 +948,6 @@ int cq_mgr::poll_and_process_element_tx(uint64_t* p_cq_poll_sn)
 	}
 
 	return ret;
-#endif // DEFINED_VMAPOLL
 }
 
 #ifdef DEFINED_VMAPOLL
@@ -1012,40 +972,6 @@ int cq_mgr::mlx5_poll_and_process_error_element_rx(volatile struct mlx5_cqe64 *c
 		}
 	}
 	m_rx_hot_buff = NULL;
-
-	return 1;
-}
-
-int cq_mgr::mlx5_poll_and_process_error_element_tx(volatile struct mlx5_cqe64 *cqe, uint64_t* p_cq_poll_sn)
-{
-	uint16_t wqe_ctr = ntohs(cqe->wqe_counter);
-	int index = wqe_ctr & (m_qp->m_tx_num_wr - 1);
-	mem_buf_desc_t* buff = NULL;
-	vma_ibv_wc wce;
-
-	m_qp->m_mlx5_hw_qp->sq.tail += NUM_TX_WRE_TO_SIGNAL_MAX;
-
-	// spoil the global sn if we have packets ready
-	union __attribute__((packed)) {
-		uint64_t global_sn;
-		struct {
-			uint32_t cq_id;
-			uint32_t cq_sn;
-		} bundle;
-	} next_sn;
-	next_sn.bundle.cq_sn = ++m_n_cq_poll_sn;
-	next_sn.bundle.cq_id = m_cq_id;
-
-	*p_cq_poll_sn = m_n_global_sn = next_sn.global_sn;
-
-	memset(&wce, 0, sizeof(wce));
-	wce.wr_id = m_qp->m_sq_wqe_idx_to_wrid[index];
-	mlx5_cqe64_to_vma_wc(cqe, &wce);
-
-	buff = process_cq_element_tx(&wce);
-	if (buff) {
-		process_tx_buffer_list(buff);
-	}
 
 	return 1;
 }

--- a/src/vma/dev/cq_mgr.h
+++ b/src/vma/dev/cq_mgr.h
@@ -42,7 +42,8 @@
 #include "vma/proto/mem_buf_desc.h"
 #include "vma/proto/vma_lwip.h"
 #include "vma/dev/ib_ctx_handler.h"
-#if defined(DEFINED_VMAPOLL) || defined(HAVE_INFINIBAND_MLX5_HW_H)
+
+#if defined(HAVE_INFINIBAND_MLX5_HW_H)
 #include <infiniband/mlx5_hw.h>
 /* Get struct mlx5_cq* from struct ibv_cq* */
 #define _to_mxxx(xxx, type)\
@@ -149,7 +150,7 @@ public:
 	inline void mlx5_cqe64_to_vma_wc(volatile struct mlx5_cqe64 *cqe, vma_ibv_wc *wce);
 	int mlx5_poll_and_process_error_element_rx(volatile struct mlx5_cqe64 *cqe, void* pv_fd_ready_array);
 	int mlx5_poll_and_process_error_element_tx(volatile struct mlx5_cqe64 *cqe, uint64_t* p_cq_poll_sn);
-#endif // DEFINED_VMAPOLL	
+#endif // DEFINED_VMAPOLL
 
 	/**
 	 * This will poll n_num_poll time on the cq or stop early if it gets
@@ -159,7 +160,7 @@ public:
 	 *         < 0 error
 	 */
 	virtual int	poll_and_process_element_rx(uint64_t* p_cq_poll_sn, void* pv_fd_ready_array = NULL);
-	int	poll_and_process_element_tx(uint64_t* p_cq_poll_sn);
+	virtual int	poll_and_process_element_tx(uint64_t* p_cq_poll_sn);
 
 	/**
 	 * This will check if the cq was drained, and if it wasn't it will drain it.
@@ -179,7 +180,7 @@ public:
 	virtual void	del_qp_rx(qp_mgr *qp);
 	virtual uint32_t	clean_cq();
 	
-	void 	add_qp_tx(qp_mgr* qp);
+	virtual void 	add_qp_tx(qp_mgr* qp);
 
 	bool	reclaim_recv_buffers(descq_t *rx_reuse);
 	bool	reclaim_recv_buffers_no_lock(descq_t *rx_reuse);
@@ -227,6 +228,8 @@ protected:
 	inline uint32_t process_recv_queue(void* pv_fd_ready_array = NULL);
 
 	virtual void	prep_ibv_cq(vma_ibv_cq_init_attr &attr) const;
+	//returns list of buffers to the owner.
+	void		process_tx_buffer_list(mem_buf_desc_t* p_mem_buf_desc);
 
 	struct ibv_cq*		m_p_ibv_cq;
 	bool			m_b_is_rx;
@@ -282,9 +285,6 @@ private:
 	int 		vma_poll_reclaim_single_recv_buffer_helper(mem_buf_desc_t* buff);
 	void		vma_poll_reclaim_recv_buffer_helper(mem_buf_desc_t* buff);
 #endif // DEFINED_VMAPOLL
-
-	//returns list of buffers to the owner.
-	void		process_tx_buffer_list(mem_buf_desc_t* p_mem_buf_desc);
 
 	// requests safe_mce_sys().qp_compensation_level buffers from global pool
 	bool 		request_more_buffers() __attribute__((noinline));

--- a/src/vma/dev/cq_mgr.h
+++ b/src/vma/dev/cq_mgr.h
@@ -149,7 +149,6 @@ public:
 	volatile struct mlx5_cqe64 *mlx5_check_error_completion(volatile struct mlx5_cqe64 *cqe, volatile uint16_t *ci, uint8_t op_own);
 	inline void mlx5_cqe64_to_vma_wc(volatile struct mlx5_cqe64 *cqe, vma_ibv_wc *wce);
 	int mlx5_poll_and_process_error_element_rx(volatile struct mlx5_cqe64 *cqe, void* pv_fd_ready_array);
-	int mlx5_poll_and_process_error_element_tx(volatile struct mlx5_cqe64 *cqe, uint64_t* p_cq_poll_sn);
 #endif // DEFINED_VMAPOLL
 
 	/**

--- a/src/vma/dev/cq_mgr_mlx5.cpp
+++ b/src/vma/dev/cq_mgr_mlx5.cpp
@@ -39,6 +39,7 @@
 #include "cq_mgr.inl"
 #include "cq_mgr_mlx5.inl"
 #include "qp_mgr.h"
+#include "qp_mgr_eth_mlx5.h"
 #include "ring_simple.h"
 
 #define MODULE_NAME "cqm_mlx5"
@@ -60,6 +61,7 @@ cq_mgr_mlx5::cq_mgr_mlx5(ring_simple* p_ring, ib_ctx_handler* p_ib_ctx_handler,
 	,m_cq_dbell(NULL)
 	,m_rx_hot_buffer(NULL)
 	,m_p_rq_wqe_idx_to_wrid(NULL)
+	,m_qp(NULL)
 {
 	cq_logfunc("");
 }
@@ -419,6 +421,151 @@ int cq_mgr_mlx5::poll_and_process_element_rx(uint64_t* p_cq_poll_sn, void* pv_fd
 	return ret_rx_processed;
 }
 
+inline void cq_mgr_mlx5::cqe64_to_vma_wc(volatile struct mlx5_cqe64 *cqe, vma_ibv_wc *wc)
+{
+	struct mlx5_err_cqe* ecqe = (struct mlx5_err_cqe *)cqe;
+
+	switch (cqe->op_own >> 4) {
+	case MLX5_CQE_RESP_WR_IMM:
+		cq_logerr("IBV_WC_RECV_RDMA_WITH_IMM is not supported");
+		break;
+	case MLX5_CQE_RESP_SEND:
+	case MLX5_CQE_RESP_SEND_IMM:
+	case MLX5_CQE_RESP_SEND_INV:
+		vma_wc_opcode(*wc) = VMA_IBV_WC_RECV;
+		wc->byte_len = ntohl(cqe->byte_cnt);
+		wc->status = IBV_WC_SUCCESS;
+		return;
+	case MLX5_CQE_REQ:
+		wc->status = IBV_WC_SUCCESS;
+		return;
+	default:
+		break;
+	}
+
+	/* Only IBV_WC_WR_FLUSH_ERR is used in code */
+	if (MLX5_CQE_SYNDROME_WR_FLUSH_ERR == ecqe->syndrome) {
+		wc->status = IBV_WC_WR_FLUSH_ERR;
+	} else {
+		wc->status = IBV_WC_GENERAL_ERR;
+	}
+
+	wc->vendor_err = ecqe->vendor_err_synd;
+}
+
+int cq_mgr_mlx5::poll_and_process_error_element_tx(volatile struct mlx5_cqe64 *cqe, uint64_t* p_cq_poll_sn)
+{
+	uint16_t wqe_ctr = ntohs(cqe->wqe_counter);
+	int index = wqe_ctr & (m_qp->m_tx_num_wr - 1);
+	mem_buf_desc_t* buff = NULL;
+	vma_ibv_wc wce;
+
+	m_qp->m_hw_qp->sq.tail += NUM_TX_WRE_TO_SIGNAL_MAX;
+
+	// spoil the global sn if we have packets ready
+	union __attribute__((packed)) {
+		uint64_t global_sn;
+		struct {
+			uint32_t cq_id;
+			uint32_t cq_sn;
+		} bundle;
+	} next_sn;
+	next_sn.bundle.cq_sn = ++m_n_cq_poll_sn;
+	next_sn.bundle.cq_id = m_cq_id;
+
+	*p_cq_poll_sn = m_n_global_sn = next_sn.global_sn;
+
+	memset(&wce, 0, sizeof(wce));
+	wce.wr_id = m_qp->m_sq_wqe_idx_to_wrid[index];
+
+	cqe64_to_vma_wc(cqe, &wce);
+
+	buff = cq_mgr::process_cq_element_tx(&wce);
+	if (buff) {
+		cq_mgr::process_tx_buffer_list(buff);
+	}
+
+	return 1;
+}
+
+inline volatile struct mlx5_cqe64* cq_mgr_mlx5::check_error_completion(volatile struct mlx5_cqe64 *cqe,
+								 volatile uint32_t *ci, uint8_t op_own)
+{
+	switch (op_own >> 4) {
+	case MLX5_CQE_REQ_ERR:
+	case MLX5_CQE_RESP_ERR:
+		++(*ci);
+		wmb();
+		*m_cq_dbell = htonl(m_cq_cons_index);
+		return cqe;
+
+	case MLX5_CQE_INVALID:
+	default:
+		return NULL; /* No CQE */
+	}
+}
+
+inline volatile struct mlx5_cqe64 *cq_mgr_mlx5::get_cqe64(volatile struct mlx5_cqe64 **cqe_err)
+{
+
+	volatile struct mlx5_cqe64 *cqe= &(*m_cqes)[m_cq_cons_index & (m_cq_size - 1)];
+	uint8_t op_own = cqe->op_own;
+
+	*cqe_err = NULL;
+	if (unlikely((op_own & MLX5_CQE_OWNER_MASK) == !(m_cq_cons_index & m_cq_size))) {
+		return NULL;
+	} else if (unlikely(op_own & 0x80)) {
+		*cqe_err = check_error_completion(cqe, &m_cq_cons_index, op_own);
+		return NULL;
+	}
+
+	++m_cq_cons_index;
+	wmb();
+	*m_cq_dbell = htonl(m_cq_cons_index);
+
+	return cqe;
+}
+
+int cq_mgr_mlx5::poll_and_process_element_tx(uint64_t* p_cq_poll_sn)
+{
+	// Assume locked!!!
+	cq_logfuncall("");
+
+	int ret = 0;
+	volatile mlx5_cqe64 *cqe_err = NULL;
+	volatile mlx5_cqe64 *cqe = get_cqe64(&cqe_err);
+
+	if (likely(cqe)) {
+		m_qp->m_hw_qp->sq.tail += NUM_TX_WRE_TO_SIGNAL_MAX;
+		uint16_t wqe_ctr = ntohs(cqe->wqe_counter);
+		int index = wqe_ctr & (m_qp->m_tx_num_wr - 1);
+		mem_buf_desc_t* buff = (mem_buf_desc_t*)(uintptr_t)m_qp->m_sq_wqe_idx_to_wrid[index];
+
+		// spoil the global sn if we have packets ready
+		union __attribute__((packed)) {
+			uint64_t global_sn;
+			struct {
+				uint32_t cq_id;
+				uint32_t cq_sn;
+			} bundle;
+		} next_sn;
+		next_sn.bundle.cq_sn = ++m_n_cq_poll_sn;
+		next_sn.bundle.cq_id = m_cq_id;
+
+		*p_cq_poll_sn = m_n_global_sn = next_sn.global_sn;
+
+		cq_mgr::process_tx_buffer_list(buff);
+		ret = 1;
+	}
+	else if (cqe_err) {
+		ret = poll_and_process_error_element_tx(cqe_err, p_cq_poll_sn);
+	}
+	else {
+		*p_cq_poll_sn = m_n_global_sn;
+	}
+
+	return ret;
+}
 
 void cq_mgr_mlx5::set_qp_rq(qp_mgr* qp)
 {
@@ -437,6 +584,7 @@ void cq_mgr_mlx5::set_qp_rq(qp_mgr* qp)
 
 void cq_mgr_mlx5::add_qp_rx(qp_mgr* qp)
 {
+	cq_logfunc("");
 	set_qp_rq(qp);
 	cq_mgr::add_qp_rx(qp);
 }
@@ -465,6 +613,18 @@ int cq_mgr_mlx5::wait_for_notification_and_process_element(uint64_t* p_cq_poll_s
 {
 	update_consumer_index();
 	return cq_mgr::wait_for_notification_and_process_element(p_cq_poll_sn, pv_fd_ready_array);
+}
+
+void cq_mgr_mlx5::add_qp_tx(qp_mgr* qp)
+{
+	//Assume locked!
+	cq_mgr::add_qp_tx(qp);
+	struct ibv_cq *ibcq = m_p_ibv_cq; // ibcp is used in next macro: _to_mxxx
+	struct mlx5_cq *mlx5_cq = _to_mxxx(cq, cq);
+	m_qp = static_cast<qp_mgr_eth_mlx5*> (qp);
+	m_cq_dbell = mlx5_cq->dbrec;
+	m_cqes = (struct mlx5_cqe64 (*)[])(uintptr_t)mlx5_cq->active_buf->buf;
+	cq_logfunc("qp_mgr=%p m_cq_dbell=%p m_cqes=%p", m_qp, m_cq_dbell, m_cqes);
 }
 
 #endif//HAVE_INFINIBAND_MLX5_HW_H

--- a/src/vma/dev/cq_mgr_mlx5.h
+++ b/src/vma/dev/cq_mgr_mlx5.h
@@ -35,8 +35,10 @@
 #define CQ_MGR_MLX5_H
 
 #include "cq_mgr.h"
+#include "qp_mgr_eth_mlx5.h"
 
 #ifdef HAVE_INFINIBAND_MLX5_HW_H
+class qp_mgr_eth_mlx5;
 
 /* Get CQE opcode. */
 #define MLX5_CQE_OPCODE(op_own) ((op_own) >> 4)
@@ -56,21 +58,24 @@ public:
 	virtual ~cq_mgr_mlx5();
 
 	virtual mem_buf_desc_t*     poll(enum buff_status_e& status);
+
 	inline volatile struct mlx5_cqe64* check_cqe(void);
+	inline volatile struct mlx5_cqe64* get_cqe64(volatile struct mlx5_cqe64 **cqe_err);
+
 	inline void                 cqe64_to_mem_buff_desc(volatile struct mlx5_cqe64 *cqe, mem_buf_desc_t* p_rx_wc_buf_desc, enum buff_status_e& status);
 	virtual int                 drain_and_proccess(uintptr_t* p_recycle_buffers_last_wr_id = NULL);
 	virtual int                 poll_and_process_element_rx(uint64_t* p_cq_poll_sn, void* pv_fd_ready_array = NULL);
+	virtual int		    poll_and_process_element_tx(uint64_t* p_cq_poll_sn);
+	int			    poll_and_process_error_element_tx(volatile struct mlx5_cqe64 *cqe, uint64_t* p_cq_poll_sn);
+
 	virtual mem_buf_desc_t*     process_cq_element_rx(mem_buf_desc_t* p_mem_buf_desc, enum buff_status_e status);
 	virtual void                add_qp_rx(qp_mgr* qp);
 	virtual void                del_qp_rx(qp_mgr* qp);
-	void                        set_qp_rq(qp_mgr* qp);
+	void			    set_qp_rq(qp_mgr* qp);
+	virtual	void		    add_qp_tx(qp_mgr* qp);
 	virtual uint32_t            clean_cq();
 	virtual int                 request_notification(uint64_t poll_sn);
 	virtual int                 wait_for_notification_and_process_element(uint64_t* p_cq_poll_sn, void* pv_fd_ready_array = NULL);
-
-private:
-	void                        update_consumer_index();
-	inline void                 update_global_sn(uint64_t& cq_poll_sn, uint32_t rettotal);
 
 protected:
 	uint32_t                    m_cq_size;
@@ -79,9 +84,15 @@ protected:
 	struct mlx5_wq              *m_rq;
 
 private:
-	volatile uint32_t           *m_cq_dbell;
+	volatile uint32_t*	    m_cq_dbell;
 	mem_buf_desc_t              *m_rx_hot_buffer;
 	uint64_t                    *m_p_rq_wqe_idx_to_wrid;
+	qp_mgr_eth_mlx5*            m_qp; //for tx
+
+	void cqe64_to_vma_wc(volatile struct mlx5_cqe64 *cqe, vma_ibv_wc *wc);
+	inline volatile struct mlx5_cqe64* check_error_completion(volatile struct mlx5_cqe64 *cqe,volatile uint32_t *ci, uint8_t op_own);
+	void                        update_consumer_index();
+	inline void                 update_global_sn(uint64_t& cq_poll_sn, uint32_t rettotal);
 };
 
 #endif //HAVE_INFINIBAND_MLX5_HW_H

--- a/src/vma/dev/ib_ctx_handler.cpp
+++ b/src/vma/dev/ib_ctx_handler.cpp
@@ -167,9 +167,10 @@ void ib_ctx_handler::set_dev_configuration()
 	m_conf_attr_rx_num_wre                  = safe_mce_sys().rx_num_wr;
 	m_conf_attr_tx_max_inline               = safe_mce_sys().tx_max_inline;
 	m_conf_attr_tx_num_wre                  = safe_mce_sys().tx_num_wr;
-#ifdef DEFINED_VMAPOLL
+//TODO: TX PSPRM  use only from tx_num_wr_to_signal after dynamic signaling
+// would be done for TX PostSend PRM!#ifdef DEFINED_VMAPOLL
 	m_conf_attr_tx_num_to_signal = NUM_TX_WRE_TO_SIGNAL_MAX;
-#else
+#if 0 //!else
 	m_conf_attr_tx_num_to_signal = 	safe_mce_sys().tx_num_wr_to_signal;
 #endif // DEFINED_VMAPOLL
 

--- a/src/vma/dev/qp_mgr.cpp
+++ b/src/vma/dev/qp_mgr.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001-2016 Mellanox Technologies, Ltd. All rights reserved.
+ * Copyright (c) 2001-2017 Mellanox Technologies, Ltd. All rights reserved.
  *
  * This software is available to you under a choice of one of two
  * licenses.  You may choose to be licensed under the terms of the GNU
@@ -62,15 +62,21 @@
 
 qp_mgr::qp_mgr(const ring_simple* p_ring, const ib_ctx_handler* p_context,
 		const uint8_t port_num, const uint32_t tx_num_wr):
-	m_rq_wqe_counter(0), m_rq_wqe_idx_to_wrid(NULL),
-	#ifdef DEFINED_VMAPOLL
-	m_mlx5_hw_qp(NULL),
-	#endif
-	m_qp(NULL), m_p_ring((ring_simple*)p_ring), m_port_num((uint8_t)port_num), m_p_ib_ctx_handler((ib_ctx_handler*)p_context),
+	 m_rq_wqe_counter(0)
+	,m_rq_wqe_idx_to_wrid(NULL)
+#ifdef DEFINED_VMAPOLL
+	,m_mlx5_hw_qp(NULL)
+#endif
+	,m_qp(NULL)
+	,m_p_ring((ring_simple*)p_ring)
+	,m_port_num((uint8_t)port_num)
+	,m_p_ib_ctx_handler((ib_ctx_handler*)p_context),
 	m_p_ahc_head(NULL), m_p_ahc_tail(NULL), m_max_inline_data(0), m_max_qp_wr(0), m_p_cq_mgr_rx(NULL), m_p_cq_mgr_tx(NULL),
 	m_rx_num_wr(safe_mce_sys().rx_num_wr), m_tx_num_wr(tx_num_wr), m_hw_dummy_send_support(false),
 	m_n_sysvar_rx_num_wr_to_post_recv(safe_mce_sys().rx_num_wr_to_post_recv),
-	m_n_sysvar_tx_num_wr_to_signal(safe_mce_sys().tx_num_wr_to_signal),
+	m_n_sysvar_tx_num_wr_to_signal(NUM_TX_WRE_TO_SIGNAL_MAX),
+//TODO:replace previous by this when dynamic signaling to be implemented for TX PostSend PRM
+//	m_n_sysvar_tx_num_wr_to_signal(safe_mce_sys().tx_num_wr_to_signal),
 	m_n_sysvar_rx_prefetch_bytes_before_poll(safe_mce_sys().rx_prefetch_bytes_before_poll),
 	m_curr_rx_wr(0),
 	m_last_posted_rx_wr_id(0), m_n_unsignaled_count(0),
@@ -105,6 +111,7 @@ qp_mgr::qp_mgr(const ring_simple* p_ring, const ib_ctx_handler* p_context,
 	m_sq_bf_buf_size = 0;
 	m_qp_num = 0;
 #endif // DEFINED_VMAPOLL
+	qp_logfunc("");
 }
 
 qp_mgr::~qp_mgr()
@@ -137,8 +144,18 @@ qp_mgr::~qp_mgr()
 	delete[] m_ibv_rx_wr_array;
 
 #ifdef DEFINED_VMAPOLL
-	munmap(m_rq_wqe_idx_to_wrid, m_rx_num_wr * sizeof(*m_rq_wqe_idx_to_wrid));
-	munmap(m_sq_wqe_idx_to_wrid, m_tx_num_wr * sizeof(*m_sq_wqe_idx_to_wrid));
+        if (m_rq_wqe_idx_to_wrid) {
+		if (0 != munmap(m_rq_wqe_idx_to_wrid, m_rx_num_wr * sizeof(*m_rq_wqe_idx_to_wrid))) {
+			qp_logerr("Failed deallocating memory with munmap m_rq_wqe_idx_to_wrid (errno=%d %m)", errno);
+		}
+		m_rq_wqe_idx_to_wrid = NULL;
+	}
+	if (m_sq_wqe_idx_to_wrid) {
+		if (0 != munmap(m_sq_wqe_idx_to_wrid, m_tx_num_wr * sizeof(*m_sq_wqe_idx_to_wrid))) {
+			qp_logerr("Failed deallocating memory with munmap m_sq_wqe_idx_to_wrid (errno=%d %m)", errno);
+		}
+		m_sq_wqe_idx_to_wrid = NULL;
+	}
 #endif // DEFINED_VMAPOLL
 
 	qp_logdbg("Rx buffer poll: %d free global buffers available", g_buffer_pool_rx->get_free_count());
@@ -147,11 +164,13 @@ qp_mgr::~qp_mgr()
 
 cq_mgr* qp_mgr::init_rx_cq_mgr(struct ibv_comp_channel* p_rx_comp_event_channel)
 {
+	qp_logfunc("");
 	return new cq_mgr(m_p_ring, m_p_ib_ctx_handler, m_rx_num_wr, p_rx_comp_event_channel, true);
 }
 
 cq_mgr* qp_mgr::init_tx_cq_mgr()
 {
+	qp_logfunc("");
 	return new cq_mgr(m_p_ring, m_p_ib_ctx_handler, m_tx_num_wr, m_p_ring->get_tx_comp_event_channel(), false);
 }
 
@@ -222,17 +241,17 @@ int qp_mgr::configure(struct ibv_comp_channel* p_rx_comp_event_channel)
 		return -1;
 	}
 
-#ifdef DEFINED_VMAPOLL
-	struct verbs_qp *vqp = (struct verbs_qp *)m_qp;
-	m_mlx5_hw_qp = (struct mlx5_qp*)container_of(vqp, struct mlx5_qp, verbs_qp);
-	m_qp_num = m_mlx5_hw_qp->ctrl_seg.qp_num;
-	m_mlx5_sq_wqes = (volatile struct mlx5_wqe64 (*)[])(uintptr_t)m_mlx5_hw_qp->gen_data.sqstart;
-	m_sq_db = &m_mlx5_hw_qp->gen_data.db[MLX5_SND_DBR];
-	m_sq_bf_reg = m_mlx5_hw_qp->gen_data.bf->reg;
-	m_sq_bf_offset = m_mlx5_hw_qp->gen_data.bf->offset;
-	m_sq_bf_buf_size = m_mlx5_hw_qp->gen_data.bf->buf_size;
-	mlx5_init_sq();
-#endif // DEFINED_VMAPOLL
+	int attr_mask = IBV_QP_CAP;
+	struct ibv_qp_attr tmp_ibv_qp_attr;
+	struct ibv_qp_init_attr tmp_ibv_qp_init_attr;
+	IF_VERBS_FAILURE(ibv_query_qp(m_qp, &tmp_ibv_qp_attr, (enum ibv_qp_attr_mask)attr_mask, &tmp_ibv_qp_init_attr)) {
+		qp_logerr("ibv_query_qp failed (errno=%d %m)", errno);
+		return -1;
+	} ENDIF_VERBS_FAILURE;
+
+	m_max_inline_data = min(tmp_ibv_qp_init_attr.cap.max_inline_data, tx_max_inline);
+	qp_logdbg("requested max inline = %d QP, actual max inline = %d, VMA max inline set to %d, max_send_wr=%d, max_recv_wr=%d, max_recv_sge=%d, max_send_sge=%d",
+		tx_max_inline, tmp_ibv_qp_init_attr.cap.max_inline_data, m_max_inline_data, qp_init_attr.cap.max_send_wr, qp_init_attr.cap.max_recv_wr, qp_init_attr.cap.max_recv_sge, qp_init_attr.cap.max_send_sge);
 
 	// All buffers will be allocated from this qp_mgr buffer pool so we can already set the Rx & Tx lkeys
 	for (uint32_t wr_idx = 0; wr_idx < m_n_sysvar_rx_num_wr_to_post_recv; wr_idx++) {
@@ -246,7 +265,10 @@ int qp_mgr::configure(struct ibv_comp_channel* p_rx_comp_event_channel)
 
 	m_p_ahc_head = NULL;
 	m_p_ahc_tail = NULL;
-	
+
+#ifdef DEFINED_VMAPOLL
+	init_sq();
+#endif //DEFINED_VMAPOLL
 	if (m_p_cq_mgr_tx) {
 		m_p_cq_mgr_tx->add_qp_tx(this);
 	}
@@ -356,7 +378,7 @@ void qp_mgr::set_signal_in_next_send_wqe()
 
 void qp_mgr::trigger_completion_for_all_sent_packets()
 {
-	vma_ibv_send_wr send_wr, *bad_wr = NULL;
+	vma_ibv_send_wr send_wr;
 	ibv_sge sge[1];
 
 	// Handle releasing of Tx buffers
@@ -437,19 +459,9 @@ void qp_mgr::trigger_completion_for_all_sent_packets()
 		m_p_ring->m_tx_num_wr_free--;
 
 #ifdef DEFINED_VMAPOLL
-		NOT_IN_USE(bad_wr);
 		set_signal_in_next_send_wqe();
-		mlx5_send(&send_wr);
-#else
-		IF_VERBS_FAILURE(vma_ibv_post_send(m_qp, &send_wr, &bad_wr)) {
-			qp_logerr("failed post_send%s (errno=%d %m)", ((vma_send_wr_send_flags(send_wr) & VMA_IBV_SEND_INLINE)?"(+inline)":""), errno);
-			if (bad_wr) {
-				qp_logerr("bad_wr info: wr_id=%#x, send_flags=%#x, addr=%#x, length=%d, lkey=%#x, max_inline_data=%d",
-				  bad_wr->wr_id, vma_send_wr_send_flags(*bad_wr), bad_wr->sg_list[0].addr, bad_wr->sg_list[0].length, bad_wr->sg_list[0].lkey, m_max_inline_data);
-			}
-		} ENDIF_VERBS_FAILURE;
 #endif // DEFINED_VMAPOLL
-
+		send_to_wire(&send_wr);
 		if (p_ah) {
 			IF_VERBS_FAILURE(ibv_destroy_ah(p_ah))
 			{
@@ -558,12 +570,47 @@ int qp_mgr::post_recv(mem_buf_desc_t* p_mem_buf_desc)
 }
 
 #ifdef DEFINED_VMAPOLL
+void qp_mgr::init_sq()
+{
+	unsigned int i;
+	unsigned int comp = NUM_TX_WRE_TO_SIGNAL_MAX;
+	struct verbs_qp *vqp = (struct verbs_qp *)m_qp;
+	m_mlx5_hw_qp = (struct mlx5_qp*)container_of(vqp, struct mlx5_qp, verbs_qp);
+	m_qp_num = m_mlx5_hw_qp->ctrl_seg.qp_num;
+	m_mlx5_sq_wqes = (volatile struct mlx5_wqe64 (*)[])(uintptr_t)m_mlx5_hw_qp->gen_data.sqstart;
+	m_sq_db = &m_mlx5_hw_qp->gen_data.db[MLX5_SND_DBR];
+	m_sq_bf_reg = m_mlx5_hw_qp->gen_data.bf->reg;
+	m_sq_bf_offset = m_mlx5_hw_qp->gen_data.bf->offset;
+	m_sq_bf_buf_size = m_mlx5_hw_qp->gen_data.bf->buf_size;
+
+	for (i = 0; (i != m_tx_num_wr); ++i) {
+		volatile struct mlx5_wqe64 *wqe = &(*m_mlx5_sq_wqes)[i];
+
+		memset((void *)(uintptr_t)wqe, 0, sizeof(struct mlx5_wqe64));
+		wqe->eseg.inline_hdr_sz = htons(MLX5_ETH_INLINE_HEADER_SIZE);
+		wqe->eseg.cs_flags = MLX5_ETH_WQE_L3_CSUM | MLX5_ETH_WQE_L4_CSUM;
+		wqe->ctrl.data[1] = htonl((m_qp_num << 8) | 4);
+		//wqe->dseg.lkey = (m_p_ring->get_lkey());
+		/* Store the completion request in the WQE. */
+		if (--comp == 0) {
+			wqe->ctrl.data[2] = htonl(8);
+			comp = NUM_TX_WRE_TO_SIGNAL_MAX;
+		}
+		else
+			wqe->ctrl.data[2] = 0;
+	}
+	m_sq_hot_wqe = &(*m_mlx5_sq_wqes)[0];
+	m_sq_hot_wqe->ctrl.data[0] = htonl(MLX5_OPCODE_SEND);
+	m_sq_hot_wqe_index = 0;
+	qp_logdbg("%p: allocated and configured %u WRs", this, m_tx_num_wr);
+}
+
 static inline void mlx5_bf_copy(volatile uintptr_t *dst, volatile uintptr_t *src)
 {
 	COPY_64B_NT(dst, src);
 }
 
-void qp_mgr::mlx5_send(vma_ibv_send_wr *p_send_wqe)
+inline int qp_mgr::send_to_wire(vma_ibv_send_wr *p_send_wqe)
 {
 	uintptr_t addr = 0;
 	uint32_t length = 0;
@@ -621,35 +668,22 @@ void qp_mgr::mlx5_send(vma_ibv_send_wr *p_send_wqe)
 	 * Other fields are already initialised in mlx5_init_sq. */
 	m_sq_hot_wqe->ctrl.data[0] = htonl((m_sq_wqe_counter << 8) | MLX5_OPCODE_SEND);
 	m_sq_hot_wqe_index = m_sq_wqe_counter & (m_tx_num_wr - 1);
+	return 0;
 }
-#endif // DEFINED_VMAPOLL
-
-#ifdef DEFINED_VMAPOLL
-void qp_mgr::mlx5_init_sq()
+#else //DEFINED_VMAPOLL
+inline int qp_mgr::send_to_wire(vma_ibv_send_wr* p_send_wqe)
 {
-	unsigned int i;
-	unsigned int comp = NUM_TX_WRE_TO_SIGNAL_MAX;
+	vma_ibv_send_wr *bad_wr = NULL;
 
-	for (i = 0; (i != m_tx_num_wr); ++i) {
-		volatile struct mlx5_wqe64 *wqe = &(*m_mlx5_sq_wqes)[i];
-
-		memset((void *)(uintptr_t)wqe, 0, sizeof(struct mlx5_wqe64));
-		wqe->eseg.inline_hdr_sz = htons(MLX5_ETH_INLINE_HEADER_SIZE);
-		wqe->eseg.cs_flags = MLX5_ETH_WQE_L3_CSUM | MLX5_ETH_WQE_L4_CSUM;
-		wqe->ctrl.data[1] = htonl((m_qp_num << 8) | 4);
-		//wqe->dseg.lkey = (m_p_ring->get_lkey());
-		/* Store the completion request in the WQE. */
-		if (--comp == 0) {
-			wqe->ctrl.data[2] = htonl(8);
-			comp = NUM_TX_WRE_TO_SIGNAL_MAX;
+	IF_VERBS_FAILURE(vma_ibv_post_send(m_qp, p_send_wqe, &bad_wr)) {
+		qp_logerr("failed post_send%s (errno=%d %m)\n", ((vma_send_wr_send_flags(*p_send_wqe) & VMA_IBV_SEND_INLINE)?"(+inline)":""), errno);
+		if (bad_wr) {
+			qp_logerr("bad_wr info: wr_id=%#x, send_flags=%#x, addr=%#x, length=%d, lkey=%#x, max_inline_data=%d",
+			bad_wr->wr_id, vma_send_wr_send_flags(*bad_wr), bad_wr->sg_list[0].addr, bad_wr->sg_list[0].length, bad_wr->sg_list[0].lkey, m_max_inline_data);
 		}
-		else
-			wqe->ctrl.data[2] = 0;
-	}
-	m_sq_hot_wqe = &(*m_mlx5_sq_wqes)[0];
-	m_sq_hot_wqe->ctrl.data[0] = htonl(MLX5_OPCODE_SEND);
-	m_sq_hot_wqe_index = 0;
-	qp_logdbg("%p: allocated and configured %u WRs", this, m_tx_num_wr);
+		return -1;
+	} ENDIF_VERBS_FAILURE;
+	return 0;
 }
 #endif // DEFINED_VMAPOLL
 
@@ -657,6 +691,7 @@ int qp_mgr::send(vma_ibv_send_wr* p_send_wqe)
 {
 	mem_buf_desc_t* p_mem_buf_desc = (mem_buf_desc_t *)p_send_wqe->wr_id;
 
+	qp_logfunc("VERBS send, unsignaled_count: %d", m_n_unsignaled_count);
 #ifndef DEFINED_VMAPOLL// not defined
 	if (!m_n_unsignaled_count) {
 		vma_send_wr_send_flags(*p_send_wqe) = (vma_ibv_send_flags)(vma_send_wr_send_flags(*p_send_wqe) | VMA_IBV_SEND_SIGNALED);
@@ -667,11 +702,17 @@ int qp_mgr::send(vma_ibv_send_wr* p_send_wqe)
 	TAKE_T_TX_POST_SEND_START;
 #endif
 
-#ifdef DEFINED_VMAPOLL
 #ifdef RDTSC_MEASURE_TX_VERBS_POST_SEND
 	RDTSC_TAKE_START(g_rdtsc_instr_info_arr[RDTSC_FLOW_TX_VERBS_POST_SEND]);
 #endif //RDTSC_MEASURE_TX_SENDTO_TO_AFTER_POST_SEND
-	mlx5_send(p_send_wqe);
+
+	if (send_to_wire(p_send_wqe)) {
+#ifdef VMA_TIME_MEASURE
+		INC_ERR_TX_COUNT;
+#endif
+		return -1;
+	}
+
 #ifdef RDTSC_MEASURE_TX_VERBS_POST_SEND
 	RDTSC_TAKE_END(g_rdtsc_instr_info_arr[RDTSC_FLOW_TX_VERBS_POST_SEND]);
 #endif //RDTSC_MEASURE_TX_SENDTO_TO_AFTER_POST_SEND
@@ -679,25 +720,10 @@ int qp_mgr::send(vma_ibv_send_wr* p_send_wqe)
 #ifdef RDTSC_MEASURE_TX_SENDTO_TO_AFTER_POST_SEND
 	RDTSC_TAKE_END(g_rdtsc_instr_info_arr[RDTSC_FLOW_SENDTO_TO_AFTER_POST_SEND]);
 #endif //RDTSC_MEASURE_TX_SENDTO_TO_AFTER_POST_SEND
-#else // DEFINED_VMAPOLLL
-	vma_ibv_send_wr *bad_wr = NULL;
-	IF_VERBS_FAILURE(vma_ibv_post_send(m_qp, p_send_wqe, &bad_wr)) {
-#ifdef VMA_TIME_MEASURE
-		INC_ERR_TX_COUNT;
-#endif
-		qp_logerr("failed post_send%s (errno=%d %m)\n", ((vma_send_wr_send_flags(*p_send_wqe) & VMA_IBV_SEND_INLINE)?"(+inline)":""), errno);
-		if (bad_wr) {
-			qp_logerr("bad_wr info: wr_id=%#x, send_flags=%#x, addr=%#x, length=%d, lkey=%#x, max_inline_data=%d",
-			    bad_wr->wr_id, vma_send_wr_send_flags(*bad_wr), bad_wr->sg_list[0].addr, bad_wr->sg_list[0].length, bad_wr->sg_list[0].lkey, m_max_inline_data);
-		}
-		return -1;
-	} ENDIF_VERBS_FAILURE;
-#endif // DEFINED_VMAPOLL
 
 #ifdef VMA_TIME_MEASURE
 	TAKE_T_TX_POST_SEND_END;
 #endif
-
 	// Link this new mem_buf_desc to the previous one sent
 	p_mem_buf_desc->p_next_desc = m_p_last_tx_mem_buf_desc;
 
@@ -735,14 +761,6 @@ int qp_mgr::send(vma_ibv_send_wr* p_send_wqe)
 	}
 
 	return 0;
-}
-
-inline void qp_mgr::set_unsignaled_count() {
-#ifdef DEFINED_VMAPOLL
-	m_n_unsignaled_count = NUM_TX_WRE_TO_SIGNAL_MAX - 1;
-#else
-	m_n_unsignaled_count = m_n_sysvar_tx_num_wr_to_signal - 1;
-#endif
 }
 
 void qp_mgr_eth::modify_qp_to_ready_state()

--- a/src/vma/dev/qp_mgr.h
+++ b/src/vma/dev/qp_mgr.h
@@ -144,20 +144,10 @@ public:
 	static inline bool  is_lib_mlx5(const char* device_name) {return strstr(device_name, "mlx5");}
 
 protected:
-	uint64_t                    m_rq_wqe_counter;
-	uint64_t*                   m_rq_wqe_idx_to_wrid;
+	uint64_t            m_rq_wqe_counter;
+	uint64_t*           m_rq_wqe_idx_to_wrid;
 #ifdef DEFINED_VMAPOLL
-	struct mlx5_qp*	            m_mlx5_hw_qp;
-	volatile struct mlx5_wqe64* m_sq_hot_wqe;
-	int                         m_sq_hot_wqe_index;
-	volatile struct mlx5_wqe64  (*m_mlx5_sq_wqes)[];
-	volatile uint32_t*          m_sq_db;
-	volatile void*              m_sq_bf_reg;
-	uint16_t                    m_sq_bf_offset;
-	uint16_t                    m_sq_bf_buf_size;
-	uint16_t                    m_sq_wqe_counter;
-	uint64_t*                   m_sq_wqe_idx_to_wrid;
-	unsigned int                m_qp_num;
+	struct mlx5_qp*	    m_mlx5_hw_qp;
 #endif // DEFINED_VMAPOLL
 	struct ibv_qp*      m_qp;
 
@@ -210,10 +200,6 @@ protected:
 
 	virtual int     post_qp_create(void) { return 0;};
 	virtual int     send_to_wire(vma_ibv_send_wr* p_send_wqe);
-#ifdef DEFINED_VMAPOLL
-	virtual void	set_signal_in_next_send_wqe();
-	virtual void	init_sq();
-#endif // DEFINED_VMAPOLL
 };
 
 class qp_mgr_eth : public qp_mgr

--- a/src/vma/dev/qp_mgr_eth_mlx5.cpp
+++ b/src/vma/dev/qp_mgr_eth_mlx5.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001-2016 Mellanox Technologies, Ltd. All rights reserved.
+ * Copyright (c) 2001-2017 Mellanox Technologies, Ltd. All rights reserved.
  *
  * This software is available to you under a choice of one of two
  * licenses.  You may choose to be licensed under the terms of the GNU
@@ -30,25 +30,99 @@
  * SOFTWARE.
  */
 
-#undef  MODULE_NAME
-#define MODULE_NAME 		"qpm_mlx5"
-
 #include "qp_mgr_eth_mlx5.h"
 
-#if !defined(DEFINED_VMAPOLL) && defined(HAVE_INFINIBAND_MLX5_HW_H)
+#if defined(HAVE_INFINIBAND_MLX5_HW_H)
 
 #include <sys/mman.h>
+#include "vma/hw/mlx5/wqe.h"
 #include "cq_mgr_mlx5.h"
 #include "vma/util/utils.h"
 #include "vlogger/vlogger.h"
-#define qp_logerr __log_info_err
+#include "ring_simple.h"
+
+#undef  MODULE_NAME
+#define MODULE_NAME 	"qpm_mlx5"
+#define qp_logpanic 	__log_info_panic
+#define qp_logerr	__log_info_err
+#define qp_logwarn	__log_info_warn
+#define qp_loginfo	__log_info_info
+#define qp_logdbg	__log_info_dbg
+#define qp_logfunc	__log_info_func
+#define qp_logfuncall	__log_info_funcall
+
+//
+void qp_mgr_eth_mlx5::init_sq()
+{
+	struct verbs_qp *vqp = (struct verbs_qp *)m_qp;
+	m_hw_qp = (struct mlx5_qp*)container_of(vqp, struct mlx5_qp, verbs_qp);
+	m_qp_num	 = m_hw_qp->ctrl_seg.qp_num;
+	m_sq_wqes	 = (volatile struct mlx5_wqe64 (*)[])(uintptr_t)m_hw_qp->gen_data.sqstart;
+	m_sq_wqe_hot	 = &(*m_sq_wqes)[0];
+	m_sq_wqes_end	 = (uint8_t*)m_hw_qp->gen_data.sqend;
+
+	m_sq_db		 = &m_hw_qp->gen_data.db[MLX5_SND_DBR];
+	m_sq_bf_reg	 = m_hw_qp->gen_data.bf->reg;
+	m_sq_bf_buf_size = m_hw_qp->gen_data.bf->buf_size;
+
+	m_sq_wqe_hot_index = 0;
+	m_sq_bf_offset	 = m_hw_qp->gen_data.bf->offset;
+/*
+ * Preliminary fill WQE for completetion request
+ * TODO: temporary - exclude for dynamic WQE
+ */
+	unsigned int comp = NUM_TX_WRE_TO_SIGNAL_MAX;
+
+	for (uint32_t i = 0; i < m_tx_num_wr; ++i) {
+		volatile struct mlx5_wqe64 *wqe = &(*m_sq_wqes)[i];
+
+		memset((void *)(uintptr_t)wqe, 0, sizeof(struct mlx5_wqe64));
+		wqe->eseg.inline_hdr_sz = htons(MLX5_ETH_INLINE_HEADER_SIZE);
+		wqe->eseg.cs_flags = MLX5_ETH_WQE_L3_CSUM | MLX5_ETH_WQE_L4_CSUM;
+		wqe->ctrl.data[1] = htonl((m_qp_num << 8) | 4);
+		//wqe->dseg.lkey = (m_p_ring->get_lkey());
+		/* Store the completion request in the WQE. */
+		if (--comp == 0) {
+			wqe->ctrl.data[2] = htonl(8);
+			comp = NUM_TX_WRE_TO_SIGNAL_MAX;
+		}
+		else
+			wqe->ctrl.data[2] = 0;
+	}
+	m_sq_wqe_hot->ctrl.data[0] = htonl(MLX5_OPCODE_SEND);
+
+	qp_logdbg("%p: %p allocated for %d QP and configured %u WRs BlueFlame buf_size: %d offset: %d",
+		  this, m_qp, m_qp_num, m_tx_num_wr, m_sq_bf_buf_size, m_sq_bf_offset);
+}
 
 qp_mgr_eth_mlx5::qp_mgr_eth_mlx5(const ring_simple* p_ring, const ib_ctx_handler* p_context, const uint8_t port_num,
 		struct ibv_comp_channel* p_rx_comp_event_channel, const uint32_t tx_num_wr, const uint16_t vlan) throw (vma_error):
-		qp_mgr_eth(p_ring, p_context, port_num, p_rx_comp_event_channel, tx_num_wr, vlan, false) {
+	qp_mgr_eth(p_ring, p_context, port_num, p_rx_comp_event_channel, tx_num_wr, vlan, false)
+	,m_hw_qp(NULL)
+	,m_sq_wqe_idx_to_wrid(NULL)
+	,m_sq_wqes(NULL)
+	,m_sq_wqe_hot(NULL)
+	,m_sq_wqes_end(NULL)
+	,m_sq_db(NULL)
+	,m_sq_bf_reg(NULL)
+	,m_qp_num(0)
+	,m_sq_wqe_hot_index(0)
+	,m_sq_bf_offset(0)
+	,m_sq_bf_buf_size(0)
+	,m_sq_wqe_cntr(0)
+{
 	if(configure(p_rx_comp_event_channel)) {
 		throw_vma_exception("failed creating qp_mgr_eth");
 	}
+
+	init_sq();
+
+	if (m_p_cq_mgr_tx) {
+		m_p_cq_mgr_tx->add_qp_tx(this);
+	}
+
+	qp_logfunc("cq_mgr_tx= %p", m_p_cq_mgr_tx);
+
 }
 
 qp_mgr_eth_mlx5::~qp_mgr_eth_mlx5()
@@ -59,6 +133,13 @@ qp_mgr_eth_mlx5::~qp_mgr_eth_mlx5()
 		}
 
 		m_rq_wqe_idx_to_wrid = NULL;
+	}
+	if (m_sq_wqe_idx_to_wrid) {
+		if (0 != munmap(m_sq_wqe_idx_to_wrid, m_tx_num_wr * sizeof(*m_sq_wqe_idx_to_wrid))) {
+			qp_logerr("Failed deallocating memory with munmap m_sq_wqe_idx_to_wrid (errno=%d %m)", errno);
+		}
+
+		m_sq_wqe_idx_to_wrid = NULL;
 	}
 }
 
@@ -74,4 +155,154 @@ cq_mgr* qp_mgr_eth_mlx5::init_rx_cq_mgr(struct ibv_comp_channel* p_rx_comp_event
 
 	return new cq_mgr_mlx5(m_p_ring, m_p_ib_ctx_handler, m_rx_num_wr, p_rx_comp_event_channel, true);
 }
+
+cq_mgr* qp_mgr_eth_mlx5::init_tx_cq_mgr()
+{
+	m_tx_num_wr = align32pow2(m_tx_num_wr);
+	if (m_sq_wqe_idx_to_wrid == NULL) {
+		m_sq_wqe_idx_to_wrid = (uint64_t*)mmap(NULL, m_tx_num_wr * sizeof(*m_sq_wqe_idx_to_wrid),
+			PROT_READ | PROT_WRITE, MAP_ANONYMOUS | MAP_PRIVATE, -1, 0);
+		if (m_sq_wqe_idx_to_wrid == MAP_FAILED) {
+			qp_logerr("Failed allocating m_sq_wqe_idx_to_wrid (errno=%d %m)", errno);
+			return NULL;
+		}
+	}
+	qp_logfunc("m_tx_num_wr=%d m_sq_wqe_idx_to_wrid=%p", m_tx_num_wr, m_sq_wqe_idx_to_wrid);
+
+	return new cq_mgr_mlx5(m_p_ring, m_p_ib_ctx_handler, m_tx_num_wr, m_p_ring->get_tx_comp_event_channel(), false);
+}
+
+inline void qp_mgr_eth_mlx5::set_signal_in_next_send_wqe()
+{
+	volatile struct mlx5_wqe64 *wqe = &(*m_sq_wqes)[m_sq_wqe_cntr & (m_tx_num_wr - 1)];
+	wqe->ctrl.data[2] = htonl(8);
+}
+
+static inline void mlx5_bf_copy(volatile uintptr_t *dst, volatile uintptr_t *src)
+{
+	COPY_64B_NT(dst, src);
+}
+
+int qp_mgr_eth_mlx5::send_to_wire(vma_ibv_send_wr *p_send_wqe)
+{
+	uintptr_t addr = 0;
+	uint32_t length = 0;
+	uint32_t lkey = 0;
+
+	addr = p_send_wqe->sg_list[0].addr;
+	length = p_send_wqe->sg_list[0].length;
+	lkey = p_send_wqe->sg_list[0].lkey;
+
+	/* Copy the first bytes into the inline header */
+	/* This suppress warning due to mlx5_wqe_eth_seg struct format as
+	 * uint8_t inline_hdr_start[2];
+	 * uint8_t inline_hdr[16];
+	 */
+	/* coverity[buffer_size] */
+	/* coverity[overrun-buffer-arg] */
+	memcpy((void *)m_sq_wqe_hot->eseg.inline_hdr_start,
+	       (void *)addr, MLX5_ETH_INLINE_HEADER_SIZE);
+
+	addr += MLX5_ETH_INLINE_HEADER_SIZE;
+	length -= MLX5_ETH_INLINE_HEADER_SIZE;
+
+	m_sq_wqe_hot->dseg.byte_count = htonl(length);
+	m_sq_wqe_hot->dseg.lkey = htonl(lkey);
+	m_sq_wqe_hot->dseg.addr = htonll(addr);
+
+	++m_sq_wqe_cntr;
+
+	/*
+	 * Make sure that descriptors are written before
+	 * updating doorbell record and ringing the doorbell
+	 */
+	wmb();
+	*m_sq_db = htonl(m_sq_wqe_cntr);
+
+	/* This wc_wmb ensures ordering between DB record and BF copy */
+	wc_wmb();
+
+	/*
+	 * Avoid using memcpy() to copy to BlueFlame page, since memcpy()
+	 * implementations may use move-string-buffer assembler instructions,
+	 * which do not guarantee order of copying.
+	 */
+	mlx5_bf_copy((volatile uintptr_t *)((uintptr_t)m_sq_bf_reg + m_sq_bf_offset),
+		(volatile uintptr_t *)m_sq_wqe_hot);
+
+	m_sq_bf_offset ^= m_sq_bf_buf_size;
+
+	m_sq_wqe_idx_to_wrid[m_sq_wqe_hot_index] = (uintptr_t)p_send_wqe->wr_id;
+
+	/*Set the next WQE and index*/
+	m_sq_wqe_hot = &(*m_sq_wqes)[m_sq_wqe_cntr & (m_tx_num_wr - 1)];
+	/* Write only data[0] which is the single element which changes.
+	 * Other fields are already initialised in mlx5_init_sq. */
+	m_sq_wqe_hot->ctrl.data[0] = htonl((m_sq_wqe_cntr << 8) | MLX5_OPCODE_SEND);
+	m_sq_wqe_hot_index = m_sq_wqe_cntr & (m_tx_num_wr - 1);
+	return 0;
+}
+
+// Handle releasing of Tx buffers
+// Single post send with SIGNAL of a dummy packet
+
+// NOTE: Since the QP is in ERROR state no packets will be sent on the wire!
+// So we can post_send anything we want :)
+void qp_mgr_eth_mlx5::trigger_completion_for_all_sent_packets()
+{
+	qp_logfunc("unsignaled count=%d, last=%p", m_n_unsignaled_count, m_p_last_tx_mem_buf_desc);
+
+	if (m_p_last_tx_mem_buf_desc) { // Meaning that there is at least one post_send in the QP mem_buf_desc that wasn't signaled for completion
+		qp_logdbg("Need to send closing tx wr...");
+		// Allocate new send buffer
+		mem_buf_desc_t* p_mem_buf_desc = m_p_ring->mem_buf_tx_get(0, true);
+		m_p_ring->m_missing_buf_ref_count--; // Align Tx buffer accounting since we will be bypassing the normal send calls
+		if (!p_mem_buf_desc) {
+			qp_logerr("no buffer in pool");
+			return;
+		}
+		p_mem_buf_desc->p_next_desc = m_p_last_tx_mem_buf_desc;
+
+		// Prepare dummy packet: zeroed payload ('0000').
+		// For ETH it replaces the MAC header!! (Nothing is going on the wire, QP in error state)
+		/* need to send at least eth+ip, since libmlx5 will drop just eth header */
+		ethhdr* p_buffer_ethhdr = (ethhdr *)p_mem_buf_desc->p_buffer;
+		memset(p_buffer_ethhdr, 0, sizeof(*p_buffer_ethhdr));
+		p_buffer_ethhdr->h_proto = htons(ETH_P_IP);
+		iphdr* p_buffer_iphdr = (iphdr *)(p_mem_buf_desc->p_buffer + sizeof(*p_buffer_ethhdr));
+		memset(p_buffer_iphdr, 0, sizeof(*p_buffer_iphdr));
+
+		ibv_sge sge[1];
+		sge[0].length = sizeof(ethhdr) + sizeof(iphdr);
+		sge[0].addr = (uintptr_t)(p_mem_buf_desc->p_buffer);
+		sge[0].lkey = m_p_ring->m_tx_lkey;
+
+		// Prepare send wr for (does not care if it is UD/IB or RAW/ETH)
+		// UD requires AH+qkey, RAW requires minimal payload instead of MAC header.
+		vma_ibv_send_wr send_wr;
+
+		memset(&send_wr, 0, sizeof(send_wr));
+		send_wr.wr_id = (uintptr_t)p_mem_buf_desc;
+		send_wr.wr.ud.ah = NULL;
+		send_wr.sg_list = sge;
+		send_wr.num_sge = 1;
+		send_wr.next = NULL;
+		vma_send_wr_opcode(send_wr) = VMA_IBV_WR_SEND;
+		vma_send_wr_send_flags(send_wr) = (vma_ibv_send_flags)(VMA_IBV_SEND_SIGNALED /*| VMA_IBV_SEND_INLINE*/); //todo inline only if inline is on
+
+		// Close the Tx unsignaled send list
+		set_unsignaled_count();
+		m_p_last_tx_mem_buf_desc = NULL;
+
+		if (!m_p_ring->m_tx_num_wr_free) {
+			qp_logdbg("failed to trigger completion for all packets due to no available wr");
+			return;
+		}
+		m_p_ring->m_tx_num_wr_free--;
+
+		set_signal_in_next_send_wqe();
+		send_to_wire(&send_wr);
+	}
+}
+
 #endif

--- a/src/vma/dev/qp_mgr_eth_mlx5.h
+++ b/src/vma/dev/qp_mgr_eth_mlx5.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001-2016 Mellanox Technologies, Ltd. All rights reserved.
+ * Copyright (c) 2001-2017 Mellanox Technologies, Ltd. All rights reserved.
  *
  * This software is available to you under a choice of one of two
  * licenses.  You may choose to be licensed under the terms of the GNU
@@ -36,19 +36,49 @@
 
 #include "qp_mgr.h"
 
-#if !defined(DEFINED_VMAPOLL) && defined(HAVE_INFINIBAND_MLX5_HW_H)
+#if defined(HAVE_INFINIBAND_MLX5_HW_H)
 
 #include <infiniband/mlx5_hw.h>
 
 class qp_mgr_eth_mlx5 : public qp_mgr_eth
 {
+friend class cq_mgr_mlx5;
 public:
 	qp_mgr_eth_mlx5(const ring_simple* p_ring, const ib_ctx_handler* p_context, const uint8_t port_num,
 			struct ibv_comp_channel* p_rx_comp_event_channel, const uint32_t tx_num_wr, const uint16_t vlan) throw (vma_error);
 	virtual ~qp_mgr_eth_mlx5();
 
+protected:
+	int			send_to_wire(vma_ibv_send_wr* p_send_wqe);
+	void			trigger_completion_for_all_sent_packets();
+	struct mlx5_qp*		m_hw_qp;
+	uint64_t*               m_sq_wqe_idx_to_wrid;
+
 private:
-	cq_mgr* init_rx_cq_mgr(struct ibv_comp_channel* p_rx_comp_event_channel);
+	cq_mgr*		init_rx_cq_mgr(struct ibv_comp_channel* p_rx_comp_event_channel);
+	virtual cq_mgr* init_tx_cq_mgr(void);
+
+	inline void	set_signal_in_next_send_wqe();
+
+//	int		fill_wqe(vma_ibv_send_wr* p_send_wqe);
+//	inline void	send_by_bf(volatile uintptr_t *addr, int size);
+//	inline void	send_by_bf_wrap_up(volatile uintptr_t *first_addr, int first_times, volatile uintptr_t *sec_addr, int sec_times);
+//	inline void	bf_copy(volatile uintptr_t *dst, volatile uintptr_t *src, int times);
+
+	void		init_sq();
+
+	volatile struct mlx5_wqe64	(*m_sq_wqes)[];
+	volatile struct mlx5_wqe64*	m_sq_wqe_hot;
+	uint8_t*			m_sq_wqes_end;
+
+	volatile uint32_t*	m_sq_db;
+	volatile void*		m_sq_bf_reg;
+
+	unsigned int        m_qp_num;
+	int                 m_sq_wqe_hot_index;
+	uint16_t            m_sq_bf_offset;
+	uint16_t            m_sq_bf_buf_size;
+	uint16_t            m_sq_wqe_cntr;
 };
 #endif //!defined(DEFINED_VMAPOLL) && defined(HAVE_INFINIBAND_MLX5_HW_H)
 #endif //QP_MGR_ETH_MLX5_H

--- a/src/vma/dev/qp_mgr_eth_mlx5.h
+++ b/src/vma/dev/qp_mgr_eth_mlx5.h
@@ -78,7 +78,7 @@ private:
 	int                 m_sq_wqe_hot_index;
 	uint16_t            m_sq_bf_offset;
 	uint16_t            m_sq_bf_buf_size;
-	uint16_t            m_sq_wqe_cntr;
+	uint16_t            m_sq_wqe_counter;
 };
-#endif //!defined(DEFINED_VMAPOLL) && defined(HAVE_INFINIBAND_MLX5_HW_H)
+#endif //defined(HAVE_INFINIBAND_MLX5_HW_H)
 #endif //QP_MGR_ETH_MLX5_H

--- a/src/vma/dev/ring_simple.cpp
+++ b/src/vma/dev/ring_simple.cpp
@@ -86,9 +86,11 @@ qp_mgr* ring_eth::create_qp_mgr(const ib_ctx_handler* ib_ctx, uint8_t port_num, 
 {
 #if !defined(DEFINED_VMAPOLL) && defined(HAVE_INFINIBAND_MLX5_HW_H)
 	if (qp_mgr::is_lib_mlx5(((ib_ctx_handler*)ib_ctx)->get_ibv_device()->name)) {
+		ring_logfunc("Using %s QPmanager",((ib_ctx_handler*)ib_ctx)->get_ibv_device()->name);
 		return new qp_mgr_eth_mlx5(this, ib_ctx, port_num, p_rx_comp_event_channel, get_tx_num_wr(), get_partition());
 	}
 #endif
+	ring_logfunc("Using DEFAULT QPmanager, device: %s",((ib_ctx_handler*)ib_ctx)->get_ibv_device()->name);
 	return new qp_mgr_eth(this, ib_ctx, port_num, p_rx_comp_event_channel, get_tx_num_wr(), get_partition());
 }
 

--- a/src/vma/dev/ring_simple.cpp
+++ b/src/vma/dev/ring_simple.cpp
@@ -49,7 +49,7 @@
 #include "vma/dev/rfs_uc.h"
 #include "vma/dev/rfs_uc_tcp_gro.h"
 #include "vma/dev/cq_mgr.h"
-#if !defined(DEFINED_VMAPOLL) && defined(HAVE_INFINIBAND_MLX5_HW_H)
+#if defined(HAVE_INFINIBAND_MLX5_HW_H)
 #include "qp_mgr_eth_mlx5.h"
 #endif
 
@@ -84,7 +84,7 @@ inline void ring_simple::send_status_handler(int ret, vma_ibv_send_wr* p_send_wq
 
 qp_mgr* ring_eth::create_qp_mgr(const ib_ctx_handler* ib_ctx, uint8_t port_num, struct ibv_comp_channel* p_rx_comp_event_channel) throw (vma_error)
 {
-#if !defined(DEFINED_VMAPOLL) && defined(HAVE_INFINIBAND_MLX5_HW_H)
+#if defined(HAVE_INFINIBAND_MLX5_HW_H)
 	if (qp_mgr::is_lib_mlx5(((ib_ctx_handler*)ib_ctx)->get_ibv_device()->name)) {
 		ring_logfunc("Using %s QPmanager",((ib_ctx_handler*)ib_ctx)->get_ibv_device()->name);
 		return new qp_mgr_eth_mlx5(this, ib_ctx, port_num, p_rx_comp_event_channel, get_tx_num_wr(), get_partition());

--- a/src/vma/dev/ring_simple.h
+++ b/src/vma/dev/ring_simple.h
@@ -89,6 +89,7 @@ public:
 	friend class cq_mgr;
 	friend class cq_mgr_mlx5;
 	friend class qp_mgr;
+	friend class qp_mgr_eth_mlx5;
 	friend class rfs;
 	friend class rfs_uc;
 	friend class rfs_uc_tcp_gro;
@@ -112,9 +113,7 @@ protected:
 	bool			request_more_tx_buffers(uint32_t count);
 	uint32_t		get_tx_num_wr() { return m_tx_num_wr; }
 	uint16_t		get_partition() { return m_partition; }
-#ifdef DEFINED_VMAPOLL		
 	uint16_t		get_lkey() { return m_tx_lkey; }
-#endif // DEFINED_VMAPOLL		
 
 	qp_mgr*			m_p_qp_mgr;
 	struct cq_moderation_info m_cq_moderation_info;

--- a/src/vma/hw/mlx5/wqe.h
+++ b/src/vma/hw/mlx5/wqe.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001-2016 Mellanox Technologies, Ltd. All rights reserved.
+ * Copyright (c) 2001-2017 Mellanox Technologies, Ltd. All rights reserved.
  *
  * This software is available to you under a choice of one of two
  * licenses.  You may choose to be licensed under the terms of the GNU
@@ -34,6 +34,8 @@
 #define WQE_H
 
 #define MLX5_ETH_INLINE_HEADER_SIZE 16
+#define OCTOWORD	16
+#define WQEBB		64
 
 #ifndef DEFINED_MLX5_HW_ETH_WQE_HEADER
 enum {

--- a/src/vma/proto/mem_buf_desc.h
+++ b/src/vma/proto/mem_buf_desc.h
@@ -103,12 +103,7 @@ public:
 		int8_t		n_frags;	//number of fragments
 		bool 		is_vma_thr; 	// specify whether packet drained from VMA internal thread or from user app thread
 		bool		is_sw_csum_need; // specify if software checksum is need for this packet
-
-#ifdef DEFINED_VMAPOLL
 		bool 		vma_polled;
-#else
-		bool		pad[1];
-#endif // DEFINED_VMAPOLL
 	} rx;
 
 private:
@@ -130,11 +125,9 @@ public:
 	inline int inc_ref_count() {return atomic_fetch_and_inc(&n_ref_count);}
 	inline int dec_ref_count() {return atomic_fetch_and_dec(&n_ref_count);}
 
-#ifdef DEFINED_VMAPOLL
 	inline unsigned int lwip_pbuf_inc_ref_count() {return ++lwip_pbuf.pbuf.ref;}
 	inline unsigned int lwip_pbuf_dec_ref_count() {if (likely(lwip_pbuf.pbuf.ref)) --lwip_pbuf.pbuf.ref; return lwip_pbuf.pbuf.ref;}
 	inline unsigned int lwip_pbuf_get_ref_count() const {return lwip_pbuf.pbuf.ref;}
-#endif // DEFINED_VMAPOLL
 };
 
 typedef vma_list_t<mem_buf_desc_t, mem_buf_desc_t::buffer_node_offset> descq_t;

--- a/src/vma/util/sys_vars.h
+++ b/src/vma/util/sys_vars.h
@@ -545,15 +545,11 @@ extern mce_sys_var & safe_mce_sys();
 #define MCE_DEFAULT_TCP_MAX_SYN_RATE                	(0)
 #define MCE_DEFAULT_TX_NUM_SEGS_TCP			(1000000)
 #define MCE_DEFAULT_TX_NUM_BUFS				(200000)
-#ifdef DEFINED_VMAPOLL
-#define MCE_DEFAULT_TX_NUM_WRE				(1024)
-#else
-#define MCE_DEFAULT_TX_NUM_WRE				(3000)
-#endif // DEFINED_VMAPOLL
+#define MCE_DEFAULT_TX_NUM_WRE				(2048)
 #define MCE_DEFAULT_TX_NUM_WRE_TO_SIGNAL		(64)
-#ifdef DEFINED_VMAPOLL
+//TODO: exclude when enable in-lining !#ifdef DEFINED_VMAPOLL
 #define MCE_DEFAULT_TX_MAX_INLINE			(0) //220
-#else
+#if 0 //!else
 #define MCE_DEFAULT_TX_MAX_INLINE			(220) //224
 #endif // DEFINED_VMAPOLL
 #define MCE_DEFAULT_TX_BUILD_IP_CHKSUM			(true)

--- a/tests/gtest/Makefile.am
+++ b/tests/gtest/Makefile.am
@@ -7,6 +7,7 @@ gtest_CPPFLAGS = \
 	-I$(top_srcdir)/src/vma \
 	-I$(top_srcdir)/tests/gtest
 
+CXXFLAGS      := $(filter-out -Wundef, $(CXXFLAGS))
 gtest_LDFLAGS  = $(GTEST_LDFLAGS) -no-install
 gtest_CXXFLAGS = $(GTEST_CXXFLAGS) -g -O3 -fno-tree-vectorize
 


### PR DESCRIPTION
TX Post Send PRM from VMAPOLL was implemented  with new class _mlx5
derived classes for QP/CP managers. New low level send_to_wire(),
init_sw() were implemented to be virtual and replace mlx5_send(),
mlx5_sq_init().
Rebased to 8.3.5

Signed-off-by: Oleg Kuporosov <olegk@mellanox.com>