### PR TITLE
issue: 1025933 Do not use CXXFLAGS for gtest

### DIFF
--- a/tests/gtest/Makefile.am
+++ b/tests/gtest/Makefile.am
@@ -1,5 +1,7 @@
 noinst_PROGRAMS = gtest
 
+CXXFLAGS = $(GTEST_CXXFLAGS)
+
 gtest_LDADD =
 
 gtest_CPPFLAGS = \
@@ -50,7 +52,6 @@ noinst_HEADERS = \
 
 
 all-local: gtest
-
 
 #
 # List variables


### PR DESCRIPTION
Currently VMA set CXXFLAGS/CFLAFS/LDFLAGS for all modules.
It should be changed to allow specific values for every module.
For example: -Wundef option does not allow to compile gtest.

@ilansmith please consider fast review and push to the master