### PR TITLE
issue: 1057922 Optimize socket m_rx_ring_map_lock usage

### DIFF
--- a/src/vma/sock/sockinfo.cpp
+++ b/src/vma/sock/sockinfo.cpp
@@ -771,8 +771,8 @@ void sockinfo::consider_rings_migration()
 
 int sockinfo::add_epoll_context(epfd_info *epfd)
 {
-	rx_ring_map_t::const_iterator sock_ring_map_iter;
 	int ret;
+	rx_ring_map_t::const_iterator sock_ring_map_iter;
 
 	m_rx_ring_map_lock.lock();
 	lock_rx_q();
@@ -782,8 +782,10 @@ int sockinfo::add_epoll_context(epfd_info *epfd)
 		goto unlock_locks;
 	}
 
-	for  (sock_ring_map_iter = m_rx_ring_map.begin(); sock_ring_map_iter != m_rx_ring_map.end(); sock_ring_map_iter++) {
+	sock_ring_map_iter = m_rx_ring_map.begin();
+	while (sock_ring_map_iter != m_rx_ring_map.end()) {
 		notify_epoll_context_add_ring(sock_ring_map_iter->first);
+		sock_ring_map_iter++;
 	}
 
 unlock_locks:
@@ -805,8 +807,10 @@ void sockinfo::remove_epoll_context(epfd_info *epfd)
 		goto unlock_locks;
 	}
 
-	for (sock_ring_map_iter = m_rx_ring_map.begin(); sock_ring_map_iter != m_rx_ring_map.end() ; sock_ring_map_iter++) {
+	sock_ring_map_iter = m_rx_ring_map.begin();
+	while (sock_ring_map_iter != m_rx_ring_map.end()) {
 		notify_epoll_context_remove_ring(sock_ring_map_iter->first);
+		sock_ring_map_iter++;
 	}
 
 	socket_fd_api::remove_epoll_context(epfd);

--- a/src/vma/sock/sockinfo.h
+++ b/src/vma/sock/sockinfo.h
@@ -176,7 +176,7 @@ protected:
 	inline void		set_rx_reuse_pending(bool is_pending = true) {m_rx_reuse_buf_pending = is_pending;}
 
 	rx_ring_map_t		m_rx_ring_map; // CQ map
-	lock_mutex_recursive	m_rx_ring_map_lock;
+	lock_mutex		m_rx_ring_map_lock;
 	ring_allocation_logic_rx m_ring_alloc_logic;
 
 	loops_timer             m_loops_timer;

--- a/src/vma/sock/sockinfo_tcp.cpp
+++ b/src/vma/sock/sockinfo_tcp.cpp
@@ -3023,7 +3023,7 @@ bool sockinfo_tcp::is_readable(uint64_t *p_poll_sn, fd_array_t* p_fd_array)
 			return true;
 		}
 
-		return m_sock_state == TCP_SOCK_ACCEPT_SHUT ? true : false;
+		return (m_sock_state == TCP_SOCK_ACCEPT_SHUT ? true : false);
 	} 
 
 	if (m_sock_state == TCP_SOCK_ASYNC_CONNECT) {
@@ -3053,8 +3053,9 @@ bool sockinfo_tcp::is_readable(uint64_t *p_poll_sn, fd_array_t* p_fd_array)
 		while(!g_b_exit && is_rtr()) {
 			// likely scenario: rx socket bound to specific cq
 			ret = m_p_rx_ring->poll_and_process_element_rx(p_poll_sn, p_fd_array);
-			if (m_n_rx_pkt_ready_list_count)
+			if (m_n_rx_pkt_ready_list_count) {
 				return true;
+			}
 			if (ret <= 0) {
 				break;
 			}
@@ -3074,14 +3075,15 @@ bool sockinfo_tcp::is_readable(uint64_t *p_poll_sn, fd_array_t* p_fd_array)
 					m_rx_ring_map_lock.unlock();
 					return true;
 				}
-				if (ret <= 0)
+				if (ret <= 0) {
 					break;
+				}
 			}
 		}
 		m_rx_ring_map_lock.unlock();
 	}
 
-	return m_n_rx_pkt_ready_list_count ? true : false;
+	return (m_n_rx_pkt_ready_list_count ? true : false);
 }
 
 bool sockinfo_tcp::is_writeable()

--- a/src/vma/sock/sockinfo_tcp.cpp
+++ b/src/vma/sock/sockinfo_tcp.cpp
@@ -3018,20 +3018,15 @@ bool sockinfo_tcp::is_readable(uint64_t *p_poll_sn, fd_array_t* p_fd_array)
 	int ret;
 
 	if (is_server()) {
-		bool state;
-		//tcp_si_logwarn("select on accept()");
-		//m_conn_cond.lock();
-		state = m_ready_conn_cnt == 0 ? false : true; 
-		if (state) {
+		if (m_ready_conn_cnt) {
 			si_tcp_logdbg("accept ready");
-			goto noblock_nolock;
+			return true;
 		}
 
-		if (m_sock_state == TCP_SOCK_ACCEPT_SHUT) goto noblock_nolock;
-
-		return false;
+		return m_sock_state == TCP_SOCK_ACCEPT_SHUT ? true : false;
 	} 
-	else if (m_sock_state == TCP_SOCK_ASYNC_CONNECT) {
+
+	if (m_sock_state == TCP_SOCK_ASYNC_CONNECT) {
 		// socket is not ready to read in this state!!!
 		return false;
 	}
@@ -3040,29 +3035,33 @@ bool sockinfo_tcp::is_readable(uint64_t *p_poll_sn, fd_array_t* p_fd_array)
 		// unconnected tcp sock is always ready for read!
 		// return its fd as ready
 		si_tcp_logdbg("block check on unconnected socket");
-		goto noblock_nolock;
+		return true;
 	}
 
-	if (m_n_rx_pkt_ready_list_count)
-		goto noblock_nolock;
+	if (m_n_rx_pkt_ready_list_count) {
+		return true;
+	}
 
-	if (!p_poll_sn)
+	if (!p_poll_sn) {
 		return false;
+	}
 
 	consider_rings_migration();
 
-	m_rx_ring_map_lock.lock();
-	while(!g_b_exit && is_rtr()) {
-	   if (likely(m_p_rx_ring)) {
-		   // likely scenario: rx socket bound to specific cq
-		   ret = m_p_rx_ring->poll_and_process_element_rx(p_poll_sn, p_fd_array);
-		   if (m_n_rx_pkt_ready_list_count)
-			   goto noblock;
-		   if (ret <= 0) {
-			   break;
-		   }
+
+	if (likely(m_p_rx_ring)) {
+		while(!g_b_exit && is_rtr()) {
+			// likely scenario: rx socket bound to specific cq
+			ret = m_p_rx_ring->poll_and_process_element_rx(p_poll_sn, p_fd_array);
+			if (m_n_rx_pkt_ready_list_count)
+				return true;
+			if (ret <= 0) {
+				break;
+			}
 		}
-		else {
+	} else {
+		m_rx_ring_map_lock.lock();
+		while(!g_b_exit && is_rtr()) {
 			rx_ring_map_t::iterator rx_ring_iter;
 			for (rx_ring_iter = m_rx_ring_map.begin(); rx_ring_iter != m_rx_ring_map.end(); rx_ring_iter++) {
 				if (rx_ring_iter->second->refcnt <= 0) {
@@ -3071,21 +3070,18 @@ bool sockinfo_tcp::is_readable(uint64_t *p_poll_sn, fd_array_t* p_fd_array)
 				ring* p_ring =  rx_ring_iter->first;
 				//g_p_lwip->do_timers();
 				ret = p_ring->poll_and_process_element_rx(p_poll_sn, p_fd_array);
-				if (m_n_rx_pkt_ready_list_count)
-					goto noblock;
+				if (m_n_rx_pkt_ready_list_count) {
+					m_rx_ring_map_lock.unlock();
+					return true;
+				}
 				if (ret <= 0)
 					break;
 			}
 		}
-	}
-	if (!m_n_rx_pkt_ready_list_count) {
 		m_rx_ring_map_lock.unlock();
-		return false;
 	}
-noblock:
-	m_rx_ring_map_lock.unlock();
-noblock_nolock:
-	return true;
+
+	return m_n_rx_pkt_ready_list_count ? true : false;
 }
 
 bool sockinfo_tcp::is_writeable()
@@ -3853,11 +3849,11 @@ int sockinfo_tcp::rx_wait_helper(int &poll_count, bool is_blocking)
 	consider_rings_migration();
 
 	// There's only one CQ
-	m_rx_ring_map_lock.lock();
 	if (likely(m_p_rx_ring)) {
 		n =  m_p_rx_ring->poll_and_process_element_rx(&poll_sn);
 	}
 	else { //There's more than one CQ, go over each one
+		m_rx_ring_map_lock.lock();
 		for (rx_ring_iter = m_rx_ring_map.begin(); rx_ring_iter != m_rx_ring_map.end(); rx_ring_iter++) {
 			if (unlikely(rx_ring_iter->second->refcnt <= 0)) {
 				__log_err("Attempt to poll illegal cq");
@@ -3867,8 +3863,8 @@ int sockinfo_tcp::rx_wait_helper(int &poll_count, bool is_blocking)
 			//g_p_lwip->do_timers();
 			n += p_ring->poll_and_process_element_rx(&poll_sn);
 		}
+		m_rx_ring_map_lock.unlock();
 	}
-	m_rx_ring_map_lock.unlock();
 	if (likely(n > 0)) { // got completions from CQ
 #ifdef DEFINED_VMAPOLL
 		__log_entry_funcall("got %d elements sn=%llu", n, (unsigned long long)poll_sn);
@@ -3903,15 +3899,14 @@ int sockinfo_tcp::rx_wait_helper(int &poll_count, bool is_blocking)
 	}
 
 	//arming CQs
-	m_rx_ring_map_lock.lock();
 	if (likely(m_p_rx_ring)) {
 		ret = m_p_rx_ring->request_notification(CQT_RX, poll_sn);
 		if (ret !=  0) {
-			m_rx_ring_map_lock.unlock();
 			return 0;
 		}
 	}
 	else {
+		m_rx_ring_map_lock.lock();
 		for (rx_ring_iter = m_rx_ring_map.begin(); rx_ring_iter != m_rx_ring_map.end(); rx_ring_iter++) {
 			if (rx_ring_iter->second->refcnt <= 0) {
 				continue;
@@ -3925,8 +3920,8 @@ int sockinfo_tcp::rx_wait_helper(int &poll_count, bool is_blocking)
 				}
 			}
 		}
+		m_rx_ring_map_lock.unlock();
 	}
-	m_rx_ring_map_lock.unlock();
 
 	//Check if we have a packet in receive queue before we going to sleep and
 	//update is_sleeping flag under the same lock to synchronize between


### PR DESCRIPTION
- Convert m_rx_ring_map_lock type to lock_mutex.
- TCP: lock only when iterate the ring map.

Signed-off-by: Liran Oz <lirano@mellanox.com>