### PR TITLE
issue: 1055917 TX Post-Send PRM

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -71,7 +71,16 @@ AC_CHECK_HEADERS([infiniband/verbs.h], ,
 AC_CHECK_HEADERS([rdma/rdma_cma.h], ,
                  [AC_MSG_ERROR([Unable to find the librdmacm-devel header files])])
 
-AC_CHECK_HEADERS([infiniband/mlx5_hw.h])
+#
+# Chech if infiniband/mlx5_hw.h can be used
+#
+AC_CHECK_HEADER([infiniband/mlx5_hw.h],
+	[AC_CHECK_MEMBERS([struct mlx5_qp.ctrl_seg, struct mlx5_qp.gen_data],
+		[AC_DEFINE([HAVE_INFINIBAND_MLX5_HW_H],1,[infiniband/mlx5_hw.h can be used])],
+		[ac_cv_header_infiniband_mlx5_hw_h="no"],
+		[[#include <infiniband/mlx5_hw.h>]] )],
+	[],[]
+)
 
 AC_MSG_CHECKING([md5 version of VMA statistics is])
 STATS_PROTOCOL_VER=`md5sum ${srcdir}/src/vma/util/vma_stats.h | awk '{ print $1}'`

--- a/src/vma/Makefile.am
+++ b/src/vma/Makefile.am
@@ -273,12 +273,14 @@ libvma_la_SOURCES := \
 	sock/sockinfo_udp.h \
 	sock/sock-redirect.h \
 	\
+	util/chunk_list.h \
 	util/hash_map.h \
 	util/if.h \
 	util/instrumentation.h \
 	util/libvma.h \
 	util/linked_unordered_map.h \
 	util/list.h \
+	util/sg_array.h \
 	util/sock_addr.h \
 	util/sysctl_reader.h \
 	util/sys_vars.h \
@@ -287,7 +289,6 @@ libvma_la_SOURCES := \
 	util/valgrind.h \
 	util/verbs_extra.h \
 	util/vma_list.h \
-	util/chunk_list.h \
 	util/vma_stats.h \
 	util/vtypes.h \
 	util/wakeup.h \

--- a/src/vma/dev/cq_mgr.h
+++ b/src/vma/dev/cq_mgr.h
@@ -42,7 +42,8 @@
 #include "vma/proto/mem_buf_desc.h"
 #include "vma/proto/vma_lwip.h"
 #include "vma/dev/ib_ctx_handler.h"
-#if defined(DEFINED_VMAPOLL) || defined(HAVE_INFINIBAND_MLX5_HW_H)
+
+#if defined(HAVE_INFINIBAND_MLX5_HW_H)
 #include <infiniband/mlx5_hw.h>
 /* Get struct mlx5_cq* from struct ibv_cq* */
 #define _to_mxxx(xxx, type)\
@@ -149,7 +150,7 @@ public:
 	inline void mlx5_cqe64_to_vma_wc(volatile struct mlx5_cqe64 *cqe, vma_ibv_wc *wce);
 	int mlx5_poll_and_process_error_element_rx(volatile struct mlx5_cqe64 *cqe, void* pv_fd_ready_array);
 	int mlx5_poll_and_process_error_element_tx(volatile struct mlx5_cqe64 *cqe, uint64_t* p_cq_poll_sn);
-#endif // DEFINED_VMAPOLL	
+#endif // DEFINED_VMAPOLL
 
 	/**
 	 * This will poll n_num_poll time on the cq or stop early if it gets
@@ -159,7 +160,7 @@ public:
 	 *         < 0 error
 	 */
 	virtual int	poll_and_process_element_rx(uint64_t* p_cq_poll_sn, void* pv_fd_ready_array = NULL);
-	int	poll_and_process_element_tx(uint64_t* p_cq_poll_sn);
+	virtual int	poll_and_process_element_tx(uint64_t* p_cq_poll_sn);
 
 	/**
 	 * This will check if the cq was drained, and if it wasn't it will drain it.
@@ -179,7 +180,7 @@ public:
 	virtual void	del_qp_rx(qp_mgr *qp);
 	virtual uint32_t	clean_cq();
 	
-	void 	add_qp_tx(qp_mgr* qp);
+	virtual void 	add_qp_tx(qp_mgr* qp);
 
 	bool	reclaim_recv_buffers(descq_t *rx_reuse);
 	bool	reclaim_recv_buffers_no_lock(descq_t *rx_reuse);
@@ -227,6 +228,8 @@ protected:
 	inline uint32_t process_recv_queue(void* pv_fd_ready_array = NULL);
 
 	virtual void	prep_ibv_cq(vma_ibv_cq_init_attr &attr) const;
+	//returns list of buffers to the owner.
+	void		process_tx_buffer_list(mem_buf_desc_t* p_mem_buf_desc);
 
 	struct ibv_cq*		m_p_ibv_cq;
 	bool			m_b_is_rx;
@@ -283,9 +286,6 @@ private:
 	int 		vma_poll_reclaim_single_recv_buffer_helper(mem_buf_desc_t* buff);
 	void		vma_poll_reclaim_recv_buffer_helper(mem_buf_desc_t* buff);
 #endif // DEFINED_VMAPOLL
-
-	//returns list of buffers to the owner.
-	void		process_tx_buffer_list(mem_buf_desc_t* p_mem_buf_desc);
 
 	// requests safe_mce_sys().qp_compensation_level buffers from global pool
 	bool 		request_more_buffers() __attribute__((noinline));

--- a/src/vma/dev/cq_mgr.h
+++ b/src/vma/dev/cq_mgr.h
@@ -149,7 +149,6 @@ public:
 	volatile struct mlx5_cqe64 *mlx5_check_error_completion(volatile struct mlx5_cqe64 *cqe, volatile uint16_t *ci, uint8_t op_own);
 	inline void mlx5_cqe64_to_vma_wc(volatile struct mlx5_cqe64 *cqe, vma_ibv_wc *wce);
 	int mlx5_poll_and_process_error_element_rx(volatile struct mlx5_cqe64 *cqe, void* pv_fd_ready_array);
-	int mlx5_poll_and_process_error_element_tx(volatile struct mlx5_cqe64 *cqe, uint64_t* p_cq_poll_sn);
 #endif // DEFINED_VMAPOLL
 
 	/**

--- a/src/vma/dev/cq_mgr_mlx5.cpp
+++ b/src/vma/dev/cq_mgr_mlx5.cpp
@@ -39,6 +39,7 @@
 #include "cq_mgr.inl"
 #include "cq_mgr_mlx5.inl"
 #include "qp_mgr.h"
+#include "qp_mgr_eth_mlx5.h"
 #include "ring_simple.h"
 
 #define MODULE_NAME "cqm_mlx5"
@@ -60,6 +61,7 @@ cq_mgr_mlx5::cq_mgr_mlx5(ring_simple* p_ring, ib_ctx_handler* p_ib_ctx_handler,
 	,m_rq(NULL)
 	,m_rx_hot_buffer(NULL)
 	,m_p_rq_wqe_idx_to_wrid(NULL)
+	,m_qp(NULL)
 {
 	cq_logfunc("");
 }
@@ -417,6 +419,151 @@ int cq_mgr_mlx5::poll_and_process_element_rx(uint64_t* p_cq_poll_sn, void* pv_fd
 	return ret_rx_processed;
 }
 
+inline void cq_mgr_mlx5::cqe64_to_vma_wc(volatile struct mlx5_cqe64 *cqe, vma_ibv_wc *wc)
+{
+	struct mlx5_err_cqe* ecqe = (struct mlx5_err_cqe *)cqe;
+
+	switch (cqe->op_own >> 4) {
+	case MLX5_CQE_RESP_WR_IMM:
+		cq_logerr("IBV_WC_RECV_RDMA_WITH_IMM is not supported");
+		break;
+	case MLX5_CQE_RESP_SEND:
+	case MLX5_CQE_RESP_SEND_IMM:
+	case MLX5_CQE_RESP_SEND_INV:
+		vma_wc_opcode(*wc) = VMA_IBV_WC_RECV;
+		wc->byte_len = ntohl(cqe->byte_cnt);
+		wc->status = IBV_WC_SUCCESS;
+		return;
+	case MLX5_CQE_REQ:
+		wc->status = IBV_WC_SUCCESS;
+		return;
+	default:
+		break;
+	}
+
+	/* Only IBV_WC_WR_FLUSH_ERR is used in code */
+	if (MLX5_CQE_SYNDROME_WR_FLUSH_ERR == ecqe->syndrome) {
+		wc->status = IBV_WC_WR_FLUSH_ERR;
+	} else {
+		wc->status = IBV_WC_GENERAL_ERR;
+	}
+
+	wc->vendor_err = ecqe->vendor_err_synd;
+}
+
+int cq_mgr_mlx5::poll_and_process_error_element_tx(volatile struct mlx5_cqe64 *cqe, uint64_t* p_cq_poll_sn)
+{
+	uint16_t wqe_ctr = ntohs(cqe->wqe_counter);
+	int index = wqe_ctr & (m_qp->m_tx_num_wr - 1);
+	mem_buf_desc_t* buff = NULL;
+	vma_ibv_wc wce;
+
+	m_qp->m_hw_qp->sq.tail += NUM_TX_WRE_TO_SIGNAL_MAX;
+
+	// spoil the global sn if we have packets ready
+	union __attribute__((packed)) {
+		uint64_t global_sn;
+		struct {
+			uint32_t cq_id;
+			uint32_t cq_sn;
+		} bundle;
+	} next_sn;
+	next_sn.bundle.cq_sn = ++m_n_cq_poll_sn;
+	next_sn.bundle.cq_id = m_cq_id;
+
+	*p_cq_poll_sn = m_n_global_sn = next_sn.global_sn;
+
+	memset(&wce, 0, sizeof(wce));
+	wce.wr_id = m_qp->m_sq_wqe_idx_to_wrid[index];
+
+	cqe64_to_vma_wc(cqe, &wce);
+
+	buff = cq_mgr::process_cq_element_tx(&wce);
+	if (buff) {
+		cq_mgr::process_tx_buffer_list(buff);
+	}
+
+	return 1;
+}
+
+inline volatile struct mlx5_cqe64* cq_mgr_mlx5::check_error_completion(volatile struct mlx5_cqe64 *cqe,
+								 volatile uint32_t *ci, uint8_t op_own)
+{
+	switch (op_own >> 4) {
+	case MLX5_CQE_REQ_ERR:
+	case MLX5_CQE_RESP_ERR:
+		++(*ci);
+		wmb();
+		*m_cq_dbell = htonl(m_cq_cons_index);
+		return cqe;
+
+	case MLX5_CQE_INVALID:
+	default:
+		return NULL; /* No CQE */
+	}
+}
+
+inline volatile struct mlx5_cqe64 *cq_mgr_mlx5::get_cqe64(volatile struct mlx5_cqe64 **cqe_err)
+{
+
+	volatile struct mlx5_cqe64 *cqe= &(*m_cqes)[m_cq_cons_index & (m_cq_size - 1)];
+	uint8_t op_own = cqe->op_own;
+
+	*cqe_err = NULL;
+	if (unlikely((op_own & MLX5_CQE_OWNER_MASK) == !(m_cq_cons_index & m_cq_size))) {
+		return NULL;
+	} else if (unlikely(op_own & 0x80)) {
+		*cqe_err = check_error_completion(cqe, &m_cq_cons_index, op_own);
+		return NULL;
+	}
+
+	++m_cq_cons_index;
+	wmb();
+	*m_cq_dbell = htonl(m_cq_cons_index);
+
+	return cqe;
+}
+
+int cq_mgr_mlx5::poll_and_process_element_tx(uint64_t* p_cq_poll_sn)
+{
+	// Assume locked!!!
+	cq_logfuncall("");
+
+	int ret = 0;
+	volatile mlx5_cqe64 *cqe_err = NULL;
+	volatile mlx5_cqe64 *cqe = get_cqe64(&cqe_err);
+
+	if (likely(cqe)) {
+		m_qp->m_hw_qp->sq.tail += NUM_TX_WRE_TO_SIGNAL_MAX;
+		uint16_t wqe_ctr = ntohs(cqe->wqe_counter);
+		int index = wqe_ctr & (m_qp->m_tx_num_wr - 1);
+		mem_buf_desc_t* buff = (mem_buf_desc_t*)(uintptr_t)m_qp->m_sq_wqe_idx_to_wrid[index];
+
+		// spoil the global sn if we have packets ready
+		union __attribute__((packed)) {
+			uint64_t global_sn;
+			struct {
+				uint32_t cq_id;
+				uint32_t cq_sn;
+			} bundle;
+		} next_sn;
+		next_sn.bundle.cq_sn = ++m_n_cq_poll_sn;
+		next_sn.bundle.cq_id = m_cq_id;
+
+		*p_cq_poll_sn = m_n_global_sn = next_sn.global_sn;
+
+		cq_mgr::process_tx_buffer_list(buff);
+		ret = 1;
+	}
+	else if (cqe_err) {
+		ret = poll_and_process_error_element_tx(cqe_err, p_cq_poll_sn);
+	}
+	else {
+		*p_cq_poll_sn = m_n_global_sn;
+	}
+
+	return ret;
+}
 
 void cq_mgr_mlx5::set_qp_rq(qp_mgr* qp)
 {
@@ -435,6 +582,7 @@ void cq_mgr_mlx5::set_qp_rq(qp_mgr* qp)
 
 void cq_mgr_mlx5::add_qp_rx(qp_mgr* qp)
 {
+	cq_logfunc("");
 	set_qp_rq(qp);
 	cq_mgr::add_qp_rx(qp);
 }
@@ -463,6 +611,18 @@ int cq_mgr_mlx5::wait_for_notification_and_process_element(uint64_t* p_cq_poll_s
 {
 	update_consumer_index();
 	return cq_mgr::wait_for_notification_and_process_element(p_cq_poll_sn, pv_fd_ready_array);
+}
+
+void cq_mgr_mlx5::add_qp_tx(qp_mgr* qp)
+{
+	//Assume locked!
+	cq_mgr::add_qp_tx(qp);
+	struct ibv_cq *ibcq = m_p_ibv_cq; // ibcp is used in next macro: _to_mxxx
+	struct mlx5_cq *mlx5_cq = _to_mxxx(cq, cq);
+	m_qp = static_cast<qp_mgr_eth_mlx5*> (qp);
+	m_cq_dbell = mlx5_cq->dbrec;
+	m_cqes = (struct mlx5_cqe64 (*)[])(uintptr_t)mlx5_cq->active_buf->buf;
+	cq_logfunc("qp_mgr=%p m_cq_dbell=%p m_cqes=%p", m_qp, m_cq_dbell, m_cqes);
 }
 
 #endif//HAVE_INFINIBAND_MLX5_HW_H

--- a/src/vma/dev/cq_mgr_mlx5.cpp
+++ b/src/vma/dev/cq_mgr_mlx5.cpp
@@ -592,7 +592,7 @@ void cq_mgr_mlx5::del_qp_rx(qp_mgr *qp)
 	m_p_rq_wqe_idx_to_wrid = NULL;
 }
 
-void cq_mgr_mlx5::update_consumer_index()
+inline void cq_mgr_mlx5::update_consumer_index()
 {
 	struct ibv_cq *ibcq = m_p_ibv_cq; // ibcp is used in next macro: _to_mxxx
 	struct mlx5_cq* mlx5_cq = _to_mxxx(cq, cq);

--- a/src/vma/dev/cq_mgr_mlx5.h
+++ b/src/vma/dev/cq_mgr_mlx5.h
@@ -82,7 +82,6 @@ protected:
 	volatile uint32_t*	    m_cq_dbell;
 	struct mlx5_wq*		    m_rq;
 
-	volatile struct mlx5_cqe64* check_cqe(void);
 private:
 	mem_buf_desc_t              *m_rx_hot_buffer;
 	uint64_t                    *m_p_rq_wqe_idx_to_wrid;

--- a/src/vma/dev/cq_mgr_mlx5.h
+++ b/src/vma/dev/cq_mgr_mlx5.h
@@ -35,8 +35,10 @@
 #define CQ_MGR_MLX5_H
 
 #include "cq_mgr.h"
+#include "qp_mgr_eth_mlx5.h"
 
 #ifdef HAVE_INFINIBAND_MLX5_HW_H
+class qp_mgr_eth_mlx5;
 
 /* Get CQE opcode. */
 #define MLX5_CQE_OPCODE(op_own) ((op_own) >> 4)
@@ -57,31 +59,39 @@ public:
 
 	virtual mem_buf_desc_t*     poll(enum buff_status_e& status);
 	inline volatile struct mlx5_cqe64* check_cqe(void);
+	inline volatile struct mlx5_cqe64* get_cqe64(volatile struct mlx5_cqe64 **cqe_err);
 	inline void                 cqe64_to_mem_buff_desc(volatile struct mlx5_cqe64 *cqe, mem_buf_desc_t* p_rx_wc_buf_desc, enum buff_status_e& status);
 	virtual int                 drain_and_proccess(uintptr_t* p_recycle_buffers_last_wr_id = NULL);
 	virtual int                 poll_and_process_element_rx(uint64_t* p_cq_poll_sn, void* pv_fd_ready_array = NULL);
+	virtual int		    poll_and_process_element_tx(uint64_t* p_cq_poll_sn);
+	int			    poll_and_process_error_element_tx(volatile struct mlx5_cqe64 *cqe, uint64_t* p_cq_poll_sn);
+
 	virtual mem_buf_desc_t*     process_cq_element_rx(mem_buf_desc_t* p_mem_buf_desc, enum buff_status_e status);
 	virtual void                add_qp_rx(qp_mgr* qp);
 	virtual void                del_qp_rx(qp_mgr* qp);
-	void                        set_qp_rq(qp_mgr* qp);
+	void			    set_qp_rq(qp_mgr* qp);
+	virtual	void		    add_qp_tx(qp_mgr* qp);
 	virtual uint32_t            clean_cq();
 	virtual int                 request_notification(uint64_t poll_sn);
 	virtual int                 wait_for_notification_and_process_element(uint64_t* p_cq_poll_sn, void* pv_fd_ready_array = NULL);
-
-private:
-	void                        update_consumer_index();
-	inline void                 update_global_sn(uint64_t& cq_poll_sn, uint32_t rettotal);
 
 protected:
 	uint32_t                    m_cq_size;
 	uint32_t                    m_cq_cons_index;
 	struct mlx5_cqe64           (*m_cqes)[];
-	volatile uint32_t           *m_cq_dbell;
-	struct mlx5_wq              *m_rq;
+	volatile uint32_t*	    m_cq_dbell;
+	struct mlx5_wq*		    m_rq;
 
+	volatile struct mlx5_cqe64* check_cqe(void);
 private:
 	mem_buf_desc_t              *m_rx_hot_buffer;
 	uint64_t                    *m_p_rq_wqe_idx_to_wrid;
+	qp_mgr_eth_mlx5*            m_qp; //for tx
+
+	void cqe64_to_vma_wc(volatile struct mlx5_cqe64 *cqe, vma_ibv_wc *wc);
+	inline volatile struct mlx5_cqe64* check_error_completion(volatile struct mlx5_cqe64 *cqe,volatile uint32_t *ci, uint8_t op_own);
+	void                        update_consumer_index();
+	inline void                 update_global_sn(uint64_t& cq_poll_sn, uint32_t rettotal);
 };
 
 #endif //HAVE_INFINIBAND_MLX5_HW_H

--- a/src/vma/dev/cq_mgr_mlx5.h
+++ b/src/vma/dev/cq_mgr_mlx5.h
@@ -58,7 +58,6 @@ public:
 	virtual ~cq_mgr_mlx5();
 
 	virtual mem_buf_desc_t*     poll(enum buff_status_e& status);
-	inline volatile struct mlx5_cqe64* check_cqe(void);
 	inline volatile struct mlx5_cqe64* get_cqe64(volatile struct mlx5_cqe64 **cqe_err);
 	inline void                 cqe64_to_mem_buff_desc(volatile struct mlx5_cqe64 *cqe, mem_buf_desc_t* p_rx_wc_buf_desc, enum buff_status_e& status);
 	virtual int                 drain_and_proccess(uintptr_t* p_recycle_buffers_last_wr_id = NULL);
@@ -76,6 +75,8 @@ public:
 	virtual int                 wait_for_notification_and_process_element(uint64_t* p_cq_poll_sn, void* pv_fd_ready_array = NULL);
 
 protected:
+	inline volatile struct mlx5_cqe64* check_cqe(void);
+
 	uint32_t                    m_cq_size;
 	uint32_t                    m_cq_cons_index;
 	struct mlx5_cqe64           (*m_cqes)[];
@@ -89,7 +90,7 @@ private:
 
 	void cqe64_to_vma_wc(volatile struct mlx5_cqe64 *cqe, vma_ibv_wc *wc);
 	inline volatile struct mlx5_cqe64* check_error_completion(volatile struct mlx5_cqe64 *cqe,volatile uint32_t *ci, uint8_t op_own);
-	void                        update_consumer_index();
+	inline void		    update_consumer_index();
 	inline void                 update_global_sn(uint64_t& cq_poll_sn, uint32_t rettotal);
 };
 

--- a/src/vma/dev/ib_ctx_handler.cpp
+++ b/src/vma/dev/ib_ctx_handler.cpp
@@ -231,9 +231,10 @@ void ib_ctx_handler::set_dev_configuration()
 	m_conf_attr_rx_num_wre                  = safe_mce_sys().rx_num_wr;
 	m_conf_attr_tx_max_inline               = safe_mce_sys().tx_max_inline;
 	m_conf_attr_tx_num_wre                  = safe_mce_sys().tx_num_wr;
-#ifdef DEFINED_VMAPOLL
+//TODO: TX PSPRM  use only from tx_num_wr_to_signal after dynamic signaling
+// would be done for TX PostSend PRM!#ifdef DEFINED_VMAPOLL
 	m_conf_attr_tx_num_to_signal = NUM_TX_WRE_TO_SIGNAL_MAX;
-#else
+#if 0 //!else
 	m_conf_attr_tx_num_to_signal = 	safe_mce_sys().tx_num_wr_to_signal;
 #endif // DEFINED_VMAPOLL
 

--- a/src/vma/dev/ib_ctx_handler.cpp
+++ b/src/vma/dev/ib_ctx_handler.cpp
@@ -228,15 +228,10 @@ ibv_port_attr ib_ctx_handler::get_ibv_port_attr(int port_num)
 void ib_ctx_handler::set_dev_configuration()
 {
 	ibch_logdbg("Setting configuration for the MLX card %s", m_p_ibv_device->name);
-	m_conf_attr_rx_num_wre                  = safe_mce_sys().rx_num_wr;
-	m_conf_attr_tx_max_inline               = safe_mce_sys().tx_max_inline;
-	m_conf_attr_tx_num_wre                  = safe_mce_sys().tx_num_wr;
-//TODO: TX PSPRM  use only from tx_num_wr_to_signal after dynamic signaling
-// would be done for TX PostSend PRM!#ifdef DEFINED_VMAPOLL
-	m_conf_attr_tx_num_to_signal = NUM_TX_WRE_TO_SIGNAL_MAX;
-#if 0 //!else
-	m_conf_attr_tx_num_to_signal = 	safe_mce_sys().tx_num_wr_to_signal;
-#endif // DEFINED_VMAPOLL
+	m_conf_attr_rx_num_wre       = safe_mce_sys().rx_num_wr;
+	m_conf_attr_tx_max_inline    = safe_mce_sys().tx_max_inline;
+	m_conf_attr_tx_num_wre       = safe_mce_sys().tx_num_wr;
+	m_conf_attr_tx_num_to_signal = safe_mce_sys().tx_num_wr_to_signal;
 
 	if (m_conf_attr_tx_num_wre < (m_conf_attr_tx_num_to_signal * 2)) {
 		m_conf_attr_tx_num_wre = m_conf_attr_tx_num_to_signal * 2;

--- a/src/vma/dev/qp_mgr.cpp
+++ b/src/vma/dev/qp_mgr.cpp
@@ -82,9 +82,7 @@ qp_mgr::qp_mgr(const ring_simple* p_ring, const ib_ctx_handler* p_context,
 	,m_tx_num_wr(tx_num_wr)
 	,m_hw_dummy_send_support(false)
 	,m_n_sysvar_rx_num_wr_to_post_recv(safe_mce_sys().rx_num_wr_to_post_recv)
-	,m_n_sysvar_tx_num_wr_to_signal(NUM_TX_WRE_TO_SIGNAL_MAX)
-//TODO:replace previous by this when dynamic signaling to be implemented for TX PostSend PRM
-//	,m_n_sysvar_tx_num_wr_to_signal(safe_mce_sys().tx_num_wr_to_signal)
+	,m_n_sysvar_tx_num_wr_to_signal(safe_mce_sys().tx_num_wr_to_signal)
 	,m_n_sysvar_rx_prefetch_bytes_before_poll(safe_mce_sys().rx_prefetch_bytes_before_poll)
 	,m_curr_rx_wr(0)
 	,m_last_posted_rx_wr_id(0)
@@ -562,7 +560,6 @@ inline int qp_mgr::send_to_wire(vma_ibv_send_wr* p_send_wqe)
 	} ENDIF_VERBS_FAILURE;
 	return 0;
 }
-//#endif // DEFINED_VMAPOLL
 
 int qp_mgr::send(vma_ibv_send_wr* p_send_wqe)
 {

--- a/src/vma/dev/qp_mgr.cpp
+++ b/src/vma/dev/qp_mgr.cpp
@@ -233,14 +233,6 @@ int qp_mgr::configure(struct ibv_comp_channel* p_rx_comp_event_channel)
 		return -1;
 	}
 
-	int attr_mask = IBV_QP_CAP;
-	struct ibv_qp_attr tmp_ibv_qp_attr;
-	struct ibv_qp_init_attr tmp_ibv_qp_init_attr;
-	IF_VERBS_FAILURE(ibv_query_qp(m_qp, &tmp_ibv_qp_attr, (enum ibv_qp_attr_mask)attr_mask, &tmp_ibv_qp_init_attr)) {
-		qp_logerr("ibv_query_qp failed (errno=%d %m)", errno);
-		return -1;
-	} ENDIF_VERBS_FAILURE;
-
 	// All buffers will be allocated from this qp_mgr buffer pool so we can already set the Rx & Tx lkeys
 	for (uint32_t wr_idx = 0; wr_idx < m_n_sysvar_rx_num_wr_to_post_recv; wr_idx++) {
 		m_ibv_rx_wr_array[wr_idx].sg_list = &m_ibv_rx_sg_array[wr_idx];

--- a/src/vma/dev/qp_mgr.cpp
+++ b/src/vma/dev/qp_mgr.cpp
@@ -430,7 +430,7 @@ void qp_mgr::trigger_completion_for_all_sent_packets()
 		}
 		m_p_ring->m_tx_num_wr_free--;
 
-		send_to_wire(&send_wr);
+		send_to_wire(&send_wr, (vma_wr_tx_packet_attr)(VMA_TX_PACKET_L3_CSUM|VMA_TX_PACKET_L4_CSUM));
 		if (p_ah) {
 			IF_VERBS_FAILURE(ibv_destroy_ah(p_ah))
 			{
@@ -538,8 +538,9 @@ int qp_mgr::post_recv(mem_buf_desc_t* p_mem_buf_desc)
 	return 0;
 }
 
-inline int qp_mgr::send_to_wire(vma_ibv_send_wr* p_send_wqe)
+inline int qp_mgr::send_to_wire(vma_ibv_send_wr* p_send_wqe, vma_wr_tx_packet_attr attr)
 {
+	NOT_IN_USE(attr);
 	vma_ibv_send_wr *bad_wr = NULL;
 
 	IF_VERBS_FAILURE(vma_ibv_post_send(m_qp, p_send_wqe, &bad_wr)) {
@@ -553,7 +554,7 @@ inline int qp_mgr::send_to_wire(vma_ibv_send_wr* p_send_wqe)
 	return 0;
 }
 
-int qp_mgr::send(vma_ibv_send_wr* p_send_wqe)
+int qp_mgr::send(vma_ibv_send_wr* p_send_wqe, vma_wr_tx_packet_attr attr)
 {
 	mem_buf_desc_t* p_mem_buf_desc = (mem_buf_desc_t *)p_send_wqe->wr_id;
 
@@ -570,7 +571,7 @@ int qp_mgr::send(vma_ibv_send_wr* p_send_wqe)
 	RDTSC_TAKE_START(g_rdtsc_instr_info_arr[RDTSC_FLOW_TX_VERBS_POST_SEND]);
 #endif //RDTSC_MEASURE_TX_SENDTO_TO_AFTER_POST_SEND
 
-	if (send_to_wire(p_send_wqe)) {
+	if (send_to_wire(p_send_wqe,attr)) {
 #ifdef VMA_TIME_MEASURE
 		INC_ERR_TX_COUNT;
 #endif

--- a/src/vma/dev/qp_mgr.h
+++ b/src/vma/dev/qp_mgr.h
@@ -53,7 +53,6 @@
 
 #ifdef HAVE_INFINIBAND_MLX5_HW_H
 #include <infiniband/mlx5_hw.h>
-#include "vma/hw/mlx5/wqe.h" //!TODO: remove when enable VMAPOLL in *mlx5
 #endif // HAVE_INFINIBAND_MLX5_HW_H
 
 class buffer_pool;
@@ -146,20 +145,10 @@ public:
 	static inline bool  is_lib_mlx5(const char* device_name) {return strstr(device_name, "mlx5");}
 
 protected:
-	uint64_t                    m_rq_wqe_counter;
-	uint64_t*                   m_rq_wqe_idx_to_wrid;
+	uint64_t            m_rq_wqe_counter;
+	uint64_t*           m_rq_wqe_idx_to_wrid;
 #ifdef DEFINED_VMAPOLL
-	struct mlx5_qp*	            m_mlx5_hw_qp;
-	volatile struct mlx5_wqe64* m_sq_hot_wqe;
-	int                         m_sq_hot_wqe_index;
-	volatile struct mlx5_wqe64  (*m_mlx5_sq_wqes)[];
-	volatile uint32_t*          m_sq_db;
-	volatile void*              m_sq_bf_reg;
-	uint16_t                    m_sq_bf_offset;
-	uint16_t                    m_sq_bf_buf_size;
-	uint16_t                    m_sq_wqe_counter;
-	uint64_t*                   m_sq_wqe_idx_to_wrid;
-	unsigned int                m_qp_num;
+	struct mlx5_qp*	    m_mlx5_hw_qp;
 #endif // DEFINED_VMAPOLL
 	struct ibv_qp*      m_qp;
 
@@ -213,10 +202,6 @@ protected:
 
 	virtual int     post_qp_create(void) { return 0;};
 	virtual int     send_to_wire(vma_ibv_send_wr* p_send_wqe);
-#ifdef DEFINED_VMAPOLL
-	virtual void	set_signal_in_next_send_wqe();
-	virtual void	init_sq();
-#endif // DEFINED_VMAPOLL
 };
 
 class qp_mgr_eth : public qp_mgr

--- a/src/vma/dev/qp_mgr.h
+++ b/src/vma/dev/qp_mgr.h
@@ -51,10 +51,10 @@
 #include "vma/dev/ah_cleaner.h"
 #include "vma/dev/cq_mgr.h"
 
-#ifdef DEFINED_VMAPOLL
+#ifdef HAVE_INFINIBAND_MLX5_HW_H
 #include <infiniband/mlx5_hw.h>
-#include "vma/hw/mlx5/wqe.h"
-#endif // DEFINED_VMAPOLL
+#include "vma/hw/mlx5/wqe.h" //!TODO: remove when enable VMAPOLL in *mlx5
+#endif // HAVE_INFINIBAND_MLX5_HW_H
 
 class buffer_pool;
 class cq_mgr;
@@ -99,10 +99,7 @@ typedef hash_map<ibv_gid, uint32_t> mgid_ref_count_map_t;
  */
 class qp_mgr
 {
-#ifdef DEFINED_VMAPOLL
 friend class cq_mgr;
-#endif // DEFINED_VMAPOLL
-
 friend class cq_mgr_mlx5;
 friend class cq_mgr_mp;
 public:
@@ -143,35 +140,26 @@ public:
 
 	void                release_rx_buffers();
 	void                release_tx_buffers();
-	void                trigger_completion_for_all_sent_packets();
+	virtual void        trigger_completion_for_all_sent_packets();
 	bool                set_qp_ratelimit(const uint32_t ratelimit_kbps);
 	int                 modify_qp_ratelimit(const uint32_t ratelimit_kbps);
-	static inline bool  is_lib_mlx5(const char* divace_name)
-	{
-		return strstr(divace_name, "mlx5");
-	}
-
-#ifdef DEFINED_VMAPOLL
-	void                set_signal_in_next_send_wqe();
-	void                mlx5_send(vma_ibv_send_wr* p_send_wqe);
-	void                mlx5_init_sq();
-#endif // DEFINED_VMAPOLL
+	static inline bool  is_lib_mlx5(const char* device_name) {return strstr(device_name, "mlx5");}
 
 protected:
-	uint64_t            m_rq_wqe_counter;
-	uint64_t            *m_rq_wqe_idx_to_wrid;
+	uint64_t                    m_rq_wqe_counter;
+	uint64_t*                   m_rq_wqe_idx_to_wrid;
 #ifdef DEFINED_VMAPOLL
-	struct mlx5_qp      *m_mlx5_hw_qp;
-	volatile struct     mlx5_wqe64* m_sq_hot_wqe;
-	int                 m_sq_hot_wqe_index;
-	volatile struct     mlx5_wqe64 (*m_mlx5_sq_wqes)[];
-	volatile uint32_t   *m_sq_db;
-	volatile void       *m_sq_bf_reg;
-	uint16_t            m_sq_bf_offset;
-	uint16_t            m_sq_bf_buf_size;
-	uint16_t            m_sq_wqe_counter;
-	uint64_t            *m_sq_wqe_idx_to_wrid;
-	unsigned int        m_qp_num;
+	struct mlx5_qp*	            m_mlx5_hw_qp;
+	volatile struct mlx5_wqe64* m_sq_hot_wqe;
+	int                         m_sq_hot_wqe_index;
+	volatile struct mlx5_wqe64  (*m_mlx5_sq_wqes)[];
+	volatile uint32_t*          m_sq_db;
+	volatile void*              m_sq_bf_reg;
+	uint16_t                    m_sq_bf_offset;
+	uint16_t                    m_sq_bf_buf_size;
+	uint16_t                    m_sq_wqe_counter;
+	uint64_t*                   m_sq_wqe_idx_to_wrid;
+	unsigned int                m_qp_num;
 #endif // DEFINED_VMAPOLL
 	struct ibv_qp*      m_qp;
 
@@ -218,10 +206,17 @@ protected:
 
 	int             configure(struct ibv_comp_channel* p_rx_comp_event_channel);
 	virtual int     prepare_ibv_qp(vma_ibv_qp_init_attr& qp_init_attr) = 0;
-	inline void     set_unsignaled_count();
+	inline void     set_unsignaled_count(void) { m_n_unsignaled_count = m_n_sysvar_tx_num_wr_to_signal - 1;	}
+
 	virtual cq_mgr* init_rx_cq_mgr(struct ibv_comp_channel* p_rx_comp_event_channel);
 	virtual cq_mgr* init_tx_cq_mgr(void);
+
 	virtual int     post_qp_create(void) { return 0;};
+	virtual int     send_to_wire(vma_ibv_send_wr* p_send_wqe);
+#ifdef DEFINED_VMAPOLL
+	virtual void	set_signal_in_next_send_wqe();
+	virtual void	init_sq();
+#endif // DEFINED_VMAPOLL
 };
 
 class qp_mgr_eth : public qp_mgr

--- a/src/vma/dev/qp_mgr.h
+++ b/src/vma/dev/qp_mgr.h
@@ -109,7 +109,7 @@ public:
 	void                down();
 
 	int                 post_recv(mem_buf_desc_t* p_mem_buf_desc); // Post for receive a list of mem_buf_desc
-	int                 send(vma_ibv_send_wr* p_send_wqe);
+	int                 send(vma_ibv_send_wr* p_send_wqe, vma_wr_tx_packet_attr attr);
 
 	uint32_t            get_max_inline_tx_data() const {return m_max_inline_data; }
 	int                 get_port_num() const { return m_port_num; }
@@ -201,7 +201,7 @@ protected:
 	virtual cq_mgr* init_tx_cq_mgr(void);
 
 	virtual int     post_qp_create(void) { return 0;};
-	virtual int     send_to_wire(vma_ibv_send_wr* p_send_wqe);
+	virtual int     send_to_wire(vma_ibv_send_wr* p_send_wqe, vma_wr_tx_packet_attr attr);
 };
 
 class qp_mgr_eth : public qp_mgr

--- a/src/vma/dev/qp_mgr_eth_mlx5.cpp
+++ b/src/vma/dev/qp_mgr_eth_mlx5.cpp
@@ -60,11 +60,6 @@ static inline uint64_t align_to_WQEBB_up(uint64_t val)
 	return ((val+4-1)>>2)<<2;
 }
 
-static inline uint8_t* align_ptr_up(uint8_t* ptr)
-{
-	return (uint8_t *)align_to_octoword_up((uint64_t)ptr);
-}
-
 //
 void qp_mgr_eth_mlx5::init_sq()
 {
@@ -136,11 +131,7 @@ qp_mgr_eth_mlx5::qp_mgr_eth_mlx5(const ring_simple* p_ring, const ib_ctx_handler
 
 	init_sq();
 
-	if (m_p_cq_mgr_tx) {
-		m_p_cq_mgr_tx->add_qp_tx(this);
-	}
-
-	qp_logfunc("cq_mgr_tx= %p", m_p_cq_mgr_tx);
+	qp_logfunc("m_p_cq_mgr_tx= %p", m_p_cq_mgr_tx);
 
 }
 

--- a/src/vma/dev/qp_mgr_eth_mlx5.cpp
+++ b/src/vma/dev/qp_mgr_eth_mlx5.cpp
@@ -30,25 +30,99 @@
  * SOFTWARE.
  */
 
-#undef  MODULE_NAME
-#define MODULE_NAME 		"qpm_mlx5"
-
 #include "qp_mgr_eth_mlx5.h"
 
-#if !defined(DEFINED_VMAPOLL) && defined(HAVE_INFINIBAND_MLX5_HW_H)
+#if defined(HAVE_INFINIBAND_MLX5_HW_H)
 
 #include <sys/mman.h>
+#include "vma/hw/mlx5/wqe.h"
 #include "cq_mgr_mlx5.h"
 #include "vma/util/utils.h"
 #include "vlogger/vlogger.h"
-#define qp_logerr __log_info_err
+#include "ring_simple.h"
+
+#undef  MODULE_NAME
+#define MODULE_NAME 	"qpm_mlx5"
+#define qp_logpanic 	__log_info_panic
+#define qp_logerr	__log_info_err
+#define qp_logwarn	__log_info_warn
+#define qp_loginfo	__log_info_info
+#define qp_logdbg	__log_info_dbg
+#define qp_logfunc	__log_info_func
+#define qp_logfuncall	__log_info_funcall
+
+//
+void qp_mgr_eth_mlx5::init_sq()
+{
+	struct verbs_qp *vqp = (struct verbs_qp *)m_qp;
+	m_hw_qp = (struct mlx5_qp*)container_of(vqp, struct mlx5_qp, verbs_qp);
+	m_qp_num	 = m_hw_qp->ctrl_seg.qp_num;
+	m_sq_wqes	 = (volatile struct mlx5_wqe64 (*)[])(uintptr_t)m_hw_qp->gen_data.sqstart;
+	m_sq_wqe_hot	 = &(*m_sq_wqes)[0];
+	m_sq_wqes_end	 = (uint8_t*)m_hw_qp->gen_data.sqend;
+
+	m_sq_db		 = &m_hw_qp->gen_data.db[MLX5_SND_DBR];
+	m_sq_bf_reg	 = m_hw_qp->gen_data.bf->reg;
+	m_sq_bf_buf_size = m_hw_qp->gen_data.bf->buf_size;
+
+	m_sq_wqe_hot_index = 0;
+	m_sq_bf_offset	 = m_hw_qp->gen_data.bf->offset;
+/*
+ * Preliminary fill WQE for completetion request
+ * TODO: temporary - exclude for dynamic WQE
+ */
+	unsigned int comp = NUM_TX_WRE_TO_SIGNAL_MAX;
+
+	for (uint32_t i = 0; i < m_tx_num_wr; ++i) {
+		volatile struct mlx5_wqe64 *wqe = &(*m_sq_wqes)[i];
+
+		memset((void *)(uintptr_t)wqe, 0, sizeof(struct mlx5_wqe64));
+		wqe->eseg.inline_hdr_sz = htons(MLX5_ETH_INLINE_HEADER_SIZE);
+		wqe->eseg.cs_flags = MLX5_ETH_WQE_L3_CSUM | MLX5_ETH_WQE_L4_CSUM;
+		wqe->ctrl.data[1] = htonl((m_qp_num << 8) | 4);
+		//wqe->dseg.lkey = (m_p_ring->get_lkey());
+		/* Store the completion request in the WQE. */
+		if (--comp == 0) {
+			wqe->ctrl.data[2] = htonl(8);
+			comp = NUM_TX_WRE_TO_SIGNAL_MAX;
+		}
+		else
+			wqe->ctrl.data[2] = 0;
+	}
+	m_sq_wqe_hot->ctrl.data[0] = htonl(MLX5_OPCODE_SEND);
+
+	qp_logdbg("%p: %p allocated for %d QP and configured %u WRs BlueFlame buf_size: %d offset: %d",
+		  this, m_qp, m_qp_num, m_tx_num_wr, m_sq_bf_buf_size, m_sq_bf_offset);
+}
 
 qp_mgr_eth_mlx5::qp_mgr_eth_mlx5(const ring_simple* p_ring, const ib_ctx_handler* p_context, const uint8_t port_num,
 		struct ibv_comp_channel* p_rx_comp_event_channel, const uint32_t tx_num_wr, const uint16_t vlan) throw (vma_error):
-		qp_mgr_eth(p_ring, p_context, port_num, p_rx_comp_event_channel, tx_num_wr, vlan, false) {
+	qp_mgr_eth(p_ring, p_context, port_num, p_rx_comp_event_channel, tx_num_wr, vlan, false)
+	,m_hw_qp(NULL)
+	,m_sq_wqe_idx_to_wrid(NULL)
+	,m_sq_wqes(NULL)
+	,m_sq_wqe_hot(NULL)
+	,m_sq_wqes_end(NULL)
+	,m_sq_db(NULL)
+	,m_sq_bf_reg(NULL)
+	,m_qp_num(0)
+	,m_sq_wqe_hot_index(0)
+	,m_sq_bf_offset(0)
+	,m_sq_bf_buf_size(0)
+	,m_sq_wqe_cntr(0)
+{
 	if(configure(p_rx_comp_event_channel)) {
 		throw_vma_exception("failed creating qp_mgr_eth");
 	}
+
+	init_sq();
+
+	if (m_p_cq_mgr_tx) {
+		m_p_cq_mgr_tx->add_qp_tx(this);
+	}
+
+	qp_logfunc("cq_mgr_tx= %p", m_p_cq_mgr_tx);
+
 }
 
 qp_mgr_eth_mlx5::~qp_mgr_eth_mlx5()
@@ -59,6 +133,13 @@ qp_mgr_eth_mlx5::~qp_mgr_eth_mlx5()
 		}
 
 		m_rq_wqe_idx_to_wrid = NULL;
+	}
+	if (m_sq_wqe_idx_to_wrid) {
+		if (0 != munmap(m_sq_wqe_idx_to_wrid, m_tx_num_wr * sizeof(*m_sq_wqe_idx_to_wrid))) {
+			qp_logerr("Failed deallocating memory with munmap m_sq_wqe_idx_to_wrid (errno=%d %m)", errno);
+		}
+
+		m_sq_wqe_idx_to_wrid = NULL;
 	}
 }
 
@@ -74,4 +155,154 @@ cq_mgr* qp_mgr_eth_mlx5::init_rx_cq_mgr(struct ibv_comp_channel* p_rx_comp_event
 
 	return new cq_mgr_mlx5(m_p_ring, m_p_ib_ctx_handler, m_rx_num_wr, p_rx_comp_event_channel, true);
 }
+
+cq_mgr* qp_mgr_eth_mlx5::init_tx_cq_mgr()
+{
+	m_tx_num_wr = align32pow2(m_tx_num_wr);
+	if (m_sq_wqe_idx_to_wrid == NULL) {
+		m_sq_wqe_idx_to_wrid = (uint64_t*)mmap(NULL, m_tx_num_wr * sizeof(*m_sq_wqe_idx_to_wrid),
+			PROT_READ | PROT_WRITE, MAP_ANONYMOUS | MAP_PRIVATE, -1, 0);
+		if (m_sq_wqe_idx_to_wrid == MAP_FAILED) {
+			qp_logerr("Failed allocating m_sq_wqe_idx_to_wrid (errno=%d %m)", errno);
+			return NULL;
+		}
+	}
+	qp_logfunc("m_tx_num_wr=%d m_sq_wqe_idx_to_wrid=%p", m_tx_num_wr, m_sq_wqe_idx_to_wrid);
+
+	return new cq_mgr_mlx5(m_p_ring, m_p_ib_ctx_handler, m_tx_num_wr, m_p_ring->get_tx_comp_event_channel(), false);
+}
+
+inline void qp_mgr_eth_mlx5::set_signal_in_next_send_wqe()
+{
+	volatile struct mlx5_wqe64 *wqe = &(*m_sq_wqes)[m_sq_wqe_cntr & (m_tx_num_wr - 1)];
+	wqe->ctrl.data[2] = htonl(8);
+}
+
+static inline void mlx5_bf_copy(volatile uintptr_t *dst, volatile uintptr_t *src)
+{
+	COPY_64B_NT(dst, src);
+}
+
+int qp_mgr_eth_mlx5::send_to_wire(vma_ibv_send_wr *p_send_wqe)
+{
+	uintptr_t addr = 0;
+	uint32_t length = 0;
+	uint32_t lkey = 0;
+
+	addr = p_send_wqe->sg_list[0].addr;
+	length = p_send_wqe->sg_list[0].length;
+	lkey = p_send_wqe->sg_list[0].lkey;
+
+	/* Copy the first bytes into the inline header */
+	/* This suppress warning due to mlx5_wqe_eth_seg struct format as
+	 * uint8_t inline_hdr_start[2];
+	 * uint8_t inline_hdr[16];
+	 */
+	/* coverity[buffer_size] */
+	/* coverity[overrun-buffer-arg] */
+	memcpy((void *)m_sq_wqe_hot->eseg.inline_hdr_start,
+	       (void *)addr, MLX5_ETH_INLINE_HEADER_SIZE);
+
+	addr += MLX5_ETH_INLINE_HEADER_SIZE;
+	length -= MLX5_ETH_INLINE_HEADER_SIZE;
+
+	m_sq_wqe_hot->dseg.byte_count = htonl(length);
+	m_sq_wqe_hot->dseg.lkey = htonl(lkey);
+	m_sq_wqe_hot->dseg.addr = htonll(addr);
+
+	++m_sq_wqe_cntr;
+
+	/*
+	 * Make sure that descriptors are written before
+	 * updating doorbell record and ringing the doorbell
+	 */
+	wmb();
+	*m_sq_db = htonl(m_sq_wqe_cntr);
+
+	/* This wc_wmb ensures ordering between DB record and BF copy */
+	wc_wmb();
+
+	/*
+	 * Avoid using memcpy() to copy to BlueFlame page, since memcpy()
+	 * implementations may use move-string-buffer assembler instructions,
+	 * which do not guarantee order of copying.
+	 */
+	mlx5_bf_copy((volatile uintptr_t *)((uintptr_t)m_sq_bf_reg + m_sq_bf_offset),
+		(volatile uintptr_t *)m_sq_wqe_hot);
+
+	m_sq_bf_offset ^= m_sq_bf_buf_size;
+
+	m_sq_wqe_idx_to_wrid[m_sq_wqe_hot_index] = (uintptr_t)p_send_wqe->wr_id;
+
+	/*Set the next WQE and index*/
+	m_sq_wqe_hot = &(*m_sq_wqes)[m_sq_wqe_cntr & (m_tx_num_wr - 1)];
+	/* Write only data[0] which is the single element which changes.
+	 * Other fields are already initialised in mlx5_init_sq. */
+	m_sq_wqe_hot->ctrl.data[0] = htonl((m_sq_wqe_cntr << 8) | MLX5_OPCODE_SEND);
+	m_sq_wqe_hot_index = m_sq_wqe_cntr & (m_tx_num_wr - 1);
+	return 0;
+}
+
+// Handle releasing of Tx buffers
+// Single post send with SIGNAL of a dummy packet
+
+// NOTE: Since the QP is in ERROR state no packets will be sent on the wire!
+// So we can post_send anything we want :)
+void qp_mgr_eth_mlx5::trigger_completion_for_all_sent_packets()
+{
+	qp_logfunc("unsignaled count=%d, last=%p", m_n_unsignaled_count, m_p_last_tx_mem_buf_desc);
+
+	if (m_p_last_tx_mem_buf_desc) { // Meaning that there is at least one post_send in the QP mem_buf_desc that wasn't signaled for completion
+		qp_logdbg("Need to send closing tx wr...");
+		// Allocate new send buffer
+		mem_buf_desc_t* p_mem_buf_desc = m_p_ring->mem_buf_tx_get(0, true);
+		m_p_ring->m_missing_buf_ref_count--; // Align Tx buffer accounting since we will be bypassing the normal send calls
+		if (!p_mem_buf_desc) {
+			qp_logerr("no buffer in pool");
+			return;
+		}
+		p_mem_buf_desc->p_next_desc = m_p_last_tx_mem_buf_desc;
+
+		// Prepare dummy packet: zeroed payload ('0000').
+		// For ETH it replaces the MAC header!! (Nothing is going on the wire, QP in error state)
+		/* need to send at least eth+ip, since libmlx5 will drop just eth header */
+		ethhdr* p_buffer_ethhdr = (ethhdr *)p_mem_buf_desc->p_buffer;
+		memset(p_buffer_ethhdr, 0, sizeof(*p_buffer_ethhdr));
+		p_buffer_ethhdr->h_proto = htons(ETH_P_IP);
+		iphdr* p_buffer_iphdr = (iphdr *)(p_mem_buf_desc->p_buffer + sizeof(*p_buffer_ethhdr));
+		memset(p_buffer_iphdr, 0, sizeof(*p_buffer_iphdr));
+
+		ibv_sge sge[1];
+		sge[0].length = sizeof(ethhdr) + sizeof(iphdr);
+		sge[0].addr = (uintptr_t)(p_mem_buf_desc->p_buffer);
+		sge[0].lkey = m_p_ring->m_tx_lkey;
+
+		// Prepare send wr for (does not care if it is UD/IB or RAW/ETH)
+		// UD requires AH+qkey, RAW requires minimal payload instead of MAC header.
+		vma_ibv_send_wr send_wr;
+
+		memset(&send_wr, 0, sizeof(send_wr));
+		send_wr.wr_id = (uintptr_t)p_mem_buf_desc;
+		send_wr.wr.ud.ah = NULL;
+		send_wr.sg_list = sge;
+		send_wr.num_sge = 1;
+		send_wr.next = NULL;
+		vma_send_wr_opcode(send_wr) = VMA_IBV_WR_SEND;
+		vma_send_wr_send_flags(send_wr) = (vma_ibv_send_flags)(VMA_IBV_SEND_SIGNALED /*| VMA_IBV_SEND_INLINE*/); //todo inline only if inline is on
+
+		// Close the Tx unsignaled send list
+		set_unsignaled_count();
+		m_p_last_tx_mem_buf_desc = NULL;
+
+		if (!m_p_ring->m_tx_num_wr_free) {
+			qp_logdbg("failed to trigger completion for all packets due to no available wr");
+			return;
+		}
+		m_p_ring->m_tx_num_wr_free--;
+
+		set_signal_in_next_send_wqe();
+		send_to_wire(&send_wr);
+	}
+}
+
 #endif

--- a/src/vma/dev/qp_mgr_eth_mlx5.cpp
+++ b/src/vma/dev/qp_mgr_eth_mlx5.cpp
@@ -68,6 +68,12 @@ static inline uint8_t* align_ptr_up(uint8_t* ptr)
 //
 void qp_mgr_eth_mlx5::init_sq()
 {
+	struct ibv_mlx5_qp_info qpi;
+	if (!ibv_mlx5_exp_get_qp_info(m_qp,&qpi)) {
+		qp_logfunc("QPN: %d dbrec: %p QP.info.SQ. buf: %p wqe_cnt: %d stride: %d bf.reg: %p bf.need_lock: %d",
+			qpi.qpn, qpi.dbrec, qpi.sq.buf, qpi.sq.wqe_cnt, qpi.sq.stride, qpi.bf.reg, qpi.bf.need_lock);
+	}
+
 	struct verbs_qp *vqp = (struct verbs_qp *)m_qp;
 	m_hw_qp = (struct mlx5_qp*)container_of(vqp, struct mlx5_qp, verbs_qp);
 	m_qp_num	 = m_hw_qp->ctrl_seg.qp_num;
@@ -81,28 +87,28 @@ void qp_mgr_eth_mlx5::init_sq()
 
 	m_sq_wqe_hot_index = 0;
 	m_sq_bf_offset	 = m_hw_qp->gen_data.bf->offset;
-/*
- * Preliminary fill WQE for completetion request
- * TODO: temporary - exclude for dynamic WQE
- */
-	unsigned int comp = NUM_TX_WRE_TO_SIGNAL_MAX;
 
-	for (uint32_t i = 0; i < m_tx_num_wr; ++i) {
-		volatile struct mlx5_wqe64 *wqe = &(*m_sq_wqes)[i];
+	m_tx_num_wr = (m_sq_wqes_end-(uint8_t *)m_sq_wqe_hot)/WQEBB;
+	m_max_inline_data = 3*WQEBB+OCTOWORD-4;
 
-		memset((void *)(uintptr_t)wqe, 0, sizeof(struct mlx5_wqe64));
-		wqe->eseg.inline_hdr_sz = htons(MLX5_ETH_INLINE_HEADER_SIZE);
-		wqe->eseg.cs_flags = MLX5_ETH_WQE_L3_CSUM | MLX5_ETH_WQE_L4_CSUM;
-		wqe->ctrl.data[1] = htonl((m_qp_num << 8) | 4);
-		//wqe->dseg.lkey = (m_p_ring->get_lkey());
-		/* Store the completion request in the WQE. */
-		if (--comp == 0) {
-			wqe->ctrl.data[2] = htonl(8);
-			comp = NUM_TX_WRE_TO_SIGNAL_MAX;
+	if (m_sq_wqe_idx_to_wrid == NULL) {
+		m_sq_wqe_idx_to_wrid = (uint64_t*)mmap(NULL, m_tx_num_wr * sizeof(*m_sq_wqe_idx_to_wrid),
+			PROT_READ | PROT_WRITE, MAP_ANONYMOUS | MAP_PRIVATE, -1, 0);
+		if (m_sq_wqe_idx_to_wrid == MAP_FAILED) {
+			qp_logerr("Failed allocating m_sq_wqe_idx_to_wrid (errno=%d %m)", errno);
+			return;
 		}
-		else
-			wqe->ctrl.data[2] = 0;
 	}
+
+	qp_logfunc("m_tx_num_wr=%d m_max_inline_data: %d m_sq_wqe_idx_to_wrid=%p",
+		    m_tx_num_wr, m_max_inline_data, m_sq_wqe_idx_to_wrid);
+
+	memset((void *)(uintptr_t)m_sq_wqe_hot, 0, sizeof(struct mlx5_wqe64));
+	m_sq_wqe_hot->ctrl.data[0] = htonl(MLX5_OPCODE_SEND);
+	m_sq_wqe_hot->ctrl.data[1] = htonl((m_qp_num << 8) | 4);
+	m_sq_wqe_hot->ctrl.data[2] = 0;
+	m_sq_wqe_hot->eseg.inline_hdr_sz = htons(MLX5_ETH_INLINE_HEADER_SIZE);
+	m_sq_wqe_hot->eseg.cs_flags = MLX5_ETH_WQE_L3_CSUM | MLX5_ETH_WQE_L4_CSUM;
 
 	qp_logfunc("%p allocated for %d QPs sq_wqes:%p sq_wqes_end: %p and configured %d WRs BlueFlame: %p buf_size: %d offset: %d",
 			m_qp, m_qp_num, m_sq_wqes, m_sq_wqes_end,  m_tx_num_wr, m_sq_bf_reg, m_sq_bf_buf_size, m_sq_bf_offset);
@@ -165,6 +171,7 @@ cq_mgr* qp_mgr_eth_mlx5::init_rx_cq_mgr(struct ibv_comp_channel* p_rx_comp_event
 		qp_logerr("Failed allocating m_rq_wqe_idx_to_wrid (errno=%d %m)", errno);
 		return NULL;
 	}
+
 #ifdef DEFINED_VMAPOLL
 	return new cq_mgr(m_p_ring, m_p_ib_ctx_handler, m_rx_num_wr, p_rx_comp_event_channel, true);
 #else
@@ -183,72 +190,247 @@ inline void qp_mgr_eth_mlx5::set_signal_in_next_send_wqe()
 	wqe->ctrl.data[2] = htonl(8);
 }
 
-static inline void mlx5_bf_copy(volatile uintptr_t *dst, volatile uintptr_t *src)
+//! Copying src to BlueFlame register buffer by Write Combining by WQEBB times
+static inline void copy_bf(uint64_t *dst, uint64_t *src, int times)
 {
-	COPY_64B_NT(dst, src);
+	while( times-- ) {
+		COPY_64B_NT(dst, src);
+	}
 }
 
+//! Copying two data chunks in wrap around case to BlueFlame register buffer
+//  by Write Combining
+static inline void copy_2bf(uint64_t* bot_dst, uint64_t* bot_src, uint64_t* top_src, int bot, int top)
+{
+	while( bot-- ) {
+		COPY_64B_NT(bot_dst, bot_src);
+	}
+	while( top-- ) {
+		COPY_64B_NT(bot_dst, top_src);
+	}
+}
+
+#define dump_wqe(addr, size) {\
+	uint32_t* wqe = (addr);\
+	int sz_=(size);\
+	qp_logfunc("Dumping %d bytes from %p", (size), (wqe));\
+	for(int i=0; i<sz_/4+1; i+=4) {\
+		qp_logfunc("%08x %08x %08x %08x",ntohl(wqe[i+0]), ntohl(wqe[i+1]), ntohl(wqe[i+2]), ntohl(wqe[i+3]));\
+	}\
+}
+
+inline void qp_mgr_eth_mlx5::send_by_bf(uint64_t* addr, int size_wqebb)
+{
+	m_sq_wqe_counter = (m_sq_wqe_counter + size_wqebb) & 0xFFFF;
+
+	// Make sure that descriptors are written before
+	// updating doorbell record and ringing the doorbell
+	wmb();
+	*m_sq_db = htonl(m_sq_wqe_counter);
+	// This wc_wmb ensures ordering between DB record and BF copy
+	wc_wmb();
+
+	// Avoid using memcpy() to copy to BlueFlame page, since memcpy()
+	// implementations may use move-string-buffer assembler instructions,
+	// which do not guarantee order of copying.
+	copy_bf((uint64_t *)((uint8_t*)m_sq_bf_reg+m_sq_bf_offset),addr,size_wqebb);
+//	dump_wqe((uint32_t*)addr,size_wqebb*WQEBB);
+	m_sq_bf_offset ^= m_sq_bf_buf_size;
+}
+
+inline void qp_mgr_eth_mlx5::send_by_bf_wrap_up(uint64_t* bot_addr, int bot_times, int top_times)
+{
+	m_sq_wqe_counter = (m_sq_wqe_counter + bot_times + top_times) & 0xFFFF;
+	// Make sure that descriptors are written before
+	// updating doorbell record and ringing the doorbell
+	wmb();
+	*m_sq_db = htonl(m_sq_wqe_counter);
+
+	// This wc_wmb ensures ordering between DB record and BF copy */
+	wc_wmb();
+	// Copying two times for wrap-up, first at the end of SQ and second from the start
+	copy_2bf((uint64_t*)((uint8_t*)m_sq_bf_reg+m_sq_bf_offset),bot_addr,(uint64_t*)m_sq_wqes,bot_times,top_times);
+	m_sq_bf_offset ^= m_sq_bf_buf_size;
+}
+
+inline int qp_mgr_eth_mlx5::fill_inl_seg(sg_array &sga, uint8_t *cur_seg, uint8_t* data_addr,
+			     int max_inline_len, int inline_len)
+{
+	int wqe_inline_size = 0;
+	while ((data_addr!=NULL) && inline_len) {
+		//{uint32_t len=inline_len; dump_wqe((uint32_t *)data_addr,len);}
+		memcpy(cur_seg,data_addr,inline_len);
+		wqe_inline_size += inline_len;
+		cur_seg += inline_len;
+		inline_len = max_inline_len-wqe_inline_size;
+		data_addr = sga.get_data(&inline_len);
+		qp_logfunc("data_addr:%p cur_seg: %p inline_len: %d wqe_inline_size: %d",
+			  data_addr, cur_seg, inline_len, wqe_inline_size);
+
+	}
+	return wqe_inline_size;
+}
+
+inline int qp_mgr_eth_mlx5::fill_ptr_seg(sg_array &sga, struct mlx5_wqe_data_seg* dp_seg, uint8_t* data_addr,
+			     int data_len)
+{
+	int wqe_seg_size = 0;
+	int len = data_len;
+	while ((data_addr!=NULL) && data_len) {
+		wqe_seg_size += sizeof(struct mlx5_wqe_data_seg);
+		dp_seg->lkey = htonl(sga.get_current_lkey());
+		data_addr = sga.get_data(&len);
+		dp_seg->byte_count = htonl(len);
+		dp_seg->addr = htonll((uint64_t)data_addr);
+		data_len -= len;
+		qp_logfunc("data_addr:%llx data_len: %d len: %d lkey: %x", data_addr, data_len, len, dp_seg->lkey);
+		dp_seg++;
+	}
+	return wqe_seg_size;
+}
+
+//! Fill WQE dynamically, based on amount of free WQEBB in SQ
+inline int qp_mgr_eth_mlx5::fill_wqe(vma_ibv_send_wr *pswr)
+{
+	// control segment is mostly filled by preset after previous packet
+	// we always inline ETH header
+	sg_array sga(pswr->sg_list, pswr->num_sge);
+	int      inline_len = MLX5_ETH_INLINE_HEADER_SIZE;
+	int      data_len   = sga.length()-inline_len;
+	int      max_inline_len = m_max_inline_data;
+	int      wqe_size = sizeof(struct mlx5_wqe_ctrl_seg)/OCTOWORD + sizeof(struct mlx5_wqe_eth_seg)/OCTOWORD;
+
+	uint8_t* cur_seg = (uint8_t*)m_sq_wqe_hot+sizeof(struct mlx5_wqe_ctrl_seg);
+	uint8_t* data_addr  = sga.get_data(&inline_len); // data for inlining in ETH header
+
+	qp_logfunc("wqe_hot:%p num_sge: %d data_addr: %p data_len: %d max_inline_len: %d inline_len$ %d",
+		m_sq_wqe_hot, pswr->num_sge, data_addr, data_len, max_inline_len, inline_len);
+
+	// Fill Ethernet segment with header inline, static data
+	// were populated in preset after previous packet send
+	memcpy(cur_seg+offsetof(struct mlx5_wqe_eth_seg,inline_hdr_start),data_addr,MLX5_ETH_INLINE_HEADER_SIZE);
+	data_addr  += MLX5_ETH_INLINE_HEADER_SIZE;
+	cur_seg += sizeof(struct mlx5_wqe_eth_seg);
+
+	// assume packet is full inline
+	if (likely(data_len <= max_inline_len)) {
+		max_inline_len = data_len;
+		// Filling inline data segment
+		// size of BlueFlame buffer is 4*WQEBBs, 3*OCTOWORDS of the first
+		// was allocated for control and ethernet segment so we have 3*WQEBB+16-4
+		int rest_space = min((int)(m_sq_wqes_end-cur_seg-4), (3*WQEBB+OCTOWORD-4));
+		// Filling till the end of inline WQE segment or
+		// to end of WQEs
+		if (likely(max_inline_len <= rest_space)) {
+			inline_len = max_inline_len;
+			qp_logfunc("NO WRAP data_addr:%p cur_seg: %p rest_space: %d inline_len: %d wqe_size: %d",
+					data_addr, cur_seg, rest_space, inline_len, wqe_size);
+			//bypass inline size and fill inline data segment
+			data_addr = sga.get_data(&inline_len);
+			inline_len = fill_inl_seg(sga,cur_seg+4,data_addr,max_inline_len,inline_len);
+
+			// store inline data size
+			*(uint32_t*)((uint8_t* )m_sq_wqe_hot+sizeof(struct mlx5_wqe_ctrl_seg)+sizeof(struct mlx5_wqe_eth_seg))
+					= htonl(0x80000000|inline_len);
+			rest_space = align_to_octoword_up(inline_len+4); // align to OCTOWORDs
+			wqe_size += rest_space/OCTOWORD;
+			//assert((data_len-inline_len)==0);
+			// configuring control
+			m_sq_wqe_hot->ctrl.data[1] = htonl((m_qp_num << 8) | wqe_size);
+			rest_space = align_to_WQEBB_up(wqe_size)/4;
+			qp_logfunc("data_len: %d inline_len: %d wqe_size: %d wqebbs: %d",
+				data_len-inline_len, inline_len, wqe_size, rest_space);
+			send_by_bf((uint64_t *)m_sq_wqe_hot, rest_space);
+			//dump_wqe((uint32_t *)m_sq_wqe_hot,wqe_size*16);
+			return rest_space;
+		} else {
+			// wrap around case, first filling till the end of m_sq_wqes
+			int wrap_up_size = max_inline_len-rest_space;
+			inline_len = rest_space;
+			qp_logfunc("WRAP_UP_SIZE: %d data_addr:%p cur_seg: %p rest_space: %d inline_len: %d wqe_size: %d",
+				wrap_up_size, data_addr, cur_seg, rest_space, inline_len, wqe_size);
+
+			data_addr  = sga.get_data(&inline_len);
+			inline_len = fill_inl_seg(sga,cur_seg+4,data_addr,rest_space,inline_len);
+			data_len  -= inline_len;
+			rest_space = align_to_octoword_up(inline_len+4);
+			wqe_size  += rest_space/OCTOWORD;
+			rest_space = align_to_WQEBB_up(rest_space/OCTOWORD)/4;// size of 1st chunk at the end
+
+			qp_logfunc("END chunk data_addr: %p data_len: %d inline_len: %d wqe_size: %d wqebbs: %d",
+				data_addr, data_len, inline_len, wqe_size, rest_space);
+			// Wrap around
+			//
+			cur_seg = (uint8_t*)m_sq_wqes;
+			data_addr  = sga.get_data(&wrap_up_size);
+
+			wrap_up_size = fill_inl_seg(sga,cur_seg,data_addr,data_len,wrap_up_size);
+			inline_len    += wrap_up_size;
+			max_inline_len = align_to_octoword_up(wrap_up_size);
+			wqe_size      += max_inline_len/OCTOWORD;
+			max_inline_len = align_to_WQEBB_up(max_inline_len/OCTOWORD)/4;
+			// store inline data size
+			*(uint32_t*)((uint8_t* )m_sq_wqe_hot+sizeof(struct mlx5_wqe_ctrl_seg)+sizeof(struct mlx5_wqe_eth_seg))
+					= htonl(0x80000000|inline_len);
+			qp_logfunc("BEGIN_CHUNK data_addr: %p data_len: %d wqe_size: %d inline_len: %d end_wqebbs: %d wqebbs: %d",
+				data_addr, data_len-wrap_up_size, wqe_size, inline_len+wrap_up_size, rest_space, max_inline_len);
+			//assert((data_len-wrap_up_size)==0);
+			// configuring control
+			m_sq_wqe_hot->ctrl.data[1] = htonl((m_qp_num << 8) | wqe_size);
+			//{int len=rest_space*4*16; dump_wqe((uint32_t *)m_sq_wqe_hot,len);}
+			//{int len=max_inline_len*4*16; dump_wqe((uint32_t *)m_sq_wqes,len);}
+
+			send_by_bf_wrap_up((uint64_t*)m_sq_wqe_hot,rest_space,max_inline_len);
+			return rest_space+max_inline_len;
+		}
+	} else {
+		// data is bigger than max to inline we inlined only ETH header + uint from IP (18 bytes)
+		// the rest will be in data pointer segment
+		// adding data seg with pointer if there still data to transfer
+		inline_len = fill_ptr_seg(sga,(struct mlx5_wqe_data_seg*)cur_seg, data_addr,data_len);
+		wqe_size  += inline_len/OCTOWORD;
+		qp_logfunc("data_addr: %p data_len: %d rest_space: %d wqe_size: %d",
+			data_addr, data_len, inline_len, wqe_size);
+		// configuring control
+		m_sq_wqe_hot->ctrl.data[1] = htonl((m_qp_num << 8) | wqe_size);
+		inline_len = align_to_WQEBB_up(wqe_size)/4;
+		send_by_bf((uint64_t*)m_sq_wqe_hot, inline_len);
+		//dump_wqe((uint32_t *)m_sq_wqe_hot,wqe_size*16);
+	}
+	return 1;
+}
+
+//! Send one RAW packet by MLX5 BlueFlame
+//
 int qp_mgr_eth_mlx5::send_to_wire(vma_ibv_send_wr *p_send_wqe)
 {
-	uintptr_t addr = 0;
-	uint32_t length = 0;
-	uint32_t lkey = 0;
+	fill_wqe(p_send_wqe);
+	m_sq_wqe_idx_to_wrid[m_sq_wqe_hot_index] = (uintptr_t)p_send_wqe->wr_id;
 
-	addr = p_send_wqe->sg_list[0].addr;
-	length = p_send_wqe->sg_list[0].length;
-	lkey = p_send_wqe->sg_list[0].lkey;
+	// Preparing next WQE and index
+	m_sq_wqe_hot = &(*m_sq_wqes)[m_sq_wqe_counter & (m_tx_num_wr - 1)];
+	qp_logdbg("m_sq_wqe_hot: %p m_sq_wqe_hot_index: %d wqe_counter: %d new_hot_index: %d wr_id: %llx",
+		   m_sq_wqe_hot, m_sq_wqe_hot_index, m_sq_wqe_counter, (m_sq_wqe_counter&(m_tx_num_wr-1)), p_send_wqe->wr_id);
+	m_sq_wqe_hot_index = m_sq_wqe_counter & (m_tx_num_wr - 1);
 
-	/* Copy the first bytes into the inline header */
-	/* This suppress warning due to mlx5_wqe_eth_seg struct format as
-	* uint8_t inline_hdr_start[2];
-	* uint8_t inline_hdr[16];
-	*/
-	/* coverity[buffer_size] */
-	/* coverity[overrun-buffer-arg] */
-	memcpy((void *)m_sq_wqe_hot->eseg.inline_hdr_start,
-		(void *)addr, MLX5_ETH_INLINE_HEADER_SIZE);
+	memset((void *)(uintptr_t)m_sq_wqe_hot, 0, sizeof(struct mlx5_wqe64));
+	//
+	// Write only data[0] which is the single element which changes.
+	// Other fields are already initialised in mlx5_init_sq.
+	//	memset(cur_seg, 0, 2*OCTOWORD);
+	m_sq_wqe_hot->ctrl.data[0] = htonl((m_sq_wqe_counter << 8) | MLX5_OPCODE_SEND);
+	m_sq_wqe_hot->ctrl.data[2] = m_n_unsignaled_count-1 == 0 ? htonl(8) : 0 ;
 
-	addr += MLX5_ETH_INLINE_HEADER_SIZE;
-	length -= MLX5_ETH_INLINE_HEADER_SIZE;
-
-	m_sq_wqe_hot->dseg.byte_count = htonl(length);
-	m_sq_wqe_hot->dseg.lkey = htonl(lkey);
-	m_sq_wqe_hot->dseg.addr = htonll(addr);
-
-	++m_sq_wqe_cntr;
-
-	/*
-	* Make sure that descriptors are written before
-	* updating doorbell record and ringing the doorbell
-	*/
-	wmb();
-	*m_sq_db = htonl(m_sq_wqe_cntr);
-	/* This wc_wmb ensures ordering between DB record and BF copy */
-        wc_wmb();
-
-	/*
-	 * Avoid using memcpy() to copy to BlueFlame page, since memcpy()
-	 * implementations may use move-string-buffer assembler instructions,
-	 * which do not guarantee order of copying.
-	 */
-	mlx5_bf_copy((volatile uintptr_t *)((uintptr_t)m_sq_bf_reg + m_sq_bf_offset),
-		     (volatile uintptr_t *)m_sq_wqe_hot);
-	m_sq_bf_offset ^= m_sq_bf_buf_size;
-        m_sq_wqe_idx_to_wrid[m_sq_wqe_hot_index] = (uintptr_t)p_send_wqe->wr_id;
-
-	/*Set the next WQE and index*/
-	m_sq_wqe_hot = &(*m_sq_wqes)[m_sq_wqe_cntr & (m_tx_num_wr - 1)];
-	/* Write only data[0] which is the single element which changes.
-	 * Other fields are already initialised in mlx5_init_sq. */
-	m_sq_wqe_hot->ctrl.data[0] = htonl((m_sq_wqe_cntr << 8) | MLX5_OPCODE_SEND);
-	m_sq_wqe_hot_index = m_sq_wqe_cntr & (m_tx_num_wr - 1);
+	// Fill Ethernet segment with header inline
+	struct mlx5_wqe_eth_seg* eth_seg = (struct mlx5_wqe_eth_seg*)((uint8_t*)m_sq_wqe_hot+sizeof(struct mlx5_wqe_ctrl_seg));
+	eth_seg->inline_hdr_sz = htons(MLX5_ETH_INLINE_HEADER_SIZE);
+	eth_seg->cs_flags = MLX5_ETH_WQE_L3_CSUM | MLX5_ETH_WQE_L4_CSUM;
 
 	return 0;
 }
 
 //! Handle releasing of Tx buffers
-//  Single post send with SIGNAL of a dummy packet
-
+// Single post send with SIGNAL of a dummy packet
 // NOTE: Since the QP is in ERROR state no packets will be sent on the wire!
 // So we can post_send anything we want :)
 void qp_mgr_eth_mlx5::trigger_completion_for_all_sent_packets()

--- a/src/vma/dev/qp_mgr_eth_mlx5.cpp
+++ b/src/vma/dev/qp_mgr_eth_mlx5.cpp
@@ -135,6 +135,7 @@ qp_mgr_eth_mlx5::qp_mgr_eth_mlx5(const ring_simple* p_ring, const ib_ctx_handler
 
 }
 
+//! Cleanup resources QP itself will be freed by base class DTOR
 qp_mgr_eth_mlx5::~qp_mgr_eth_mlx5()
 {
 	if (m_rq_wqe_idx_to_wrid) {

--- a/src/vma/dev/qp_mgr_eth_mlx5.cpp
+++ b/src/vma/dev/qp_mgr_eth_mlx5.cpp
@@ -29,7 +29,6 @@
  * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
-
 #include "qp_mgr_eth_mlx5.h"
 
 #if defined(HAVE_INFINIBAND_MLX5_HW_H)
@@ -51,13 +50,28 @@
 #define qp_logfunc	__log_info_func
 #define qp_logfuncall	__log_info_funcall
 
+static inline uint64_t align_to_octoword_up(uint64_t val)
+{
+	return ((val+16-1)>>4)<<4;
+}
+
+static inline uint64_t align_to_WQEBB_up(uint64_t val)
+{
+	return ((val+4-1)>>2)<<2;
+}
+
+static inline uint8_t* align_ptr_up(uint8_t* ptr)
+{
+	return (uint8_t *)align_to_octoword_up((uint64_t)ptr);
+}
+
 //
 void qp_mgr_eth_mlx5::init_sq()
 {
 	struct verbs_qp *vqp = (struct verbs_qp *)m_qp;
 	m_hw_qp = (struct mlx5_qp*)container_of(vqp, struct mlx5_qp, verbs_qp);
 	m_qp_num	 = m_hw_qp->ctrl_seg.qp_num;
-	m_sq_wqes	 = (volatile struct mlx5_wqe64 (*)[])(uintptr_t)m_hw_qp->gen_data.sqstart;
+	m_sq_wqes	 = (struct mlx5_wqe64 (*)[])(uintptr_t)m_hw_qp->gen_data.sqstart;
 	m_sq_wqe_hot	 = &(*m_sq_wqes)[0];
 	m_sq_wqes_end	 = (uint8_t*)m_hw_qp->gen_data.sqend;
 
@@ -89,10 +103,9 @@ void qp_mgr_eth_mlx5::init_sq()
 		else
 			wqe->ctrl.data[2] = 0;
 	}
-	m_sq_wqe_hot->ctrl.data[0] = htonl(MLX5_OPCODE_SEND);
 
-	qp_logdbg("%p: %p allocated for %d QP and configured %u WRs BlueFlame buf_size: %d offset: %d",
-		  this, m_qp, m_qp_num, m_tx_num_wr, m_sq_bf_buf_size, m_sq_bf_offset);
+	qp_logfunc("%p allocated for %d QPs sq_wqes:%p sq_wqes_end: %p and configured %d WRs BlueFlame: %p buf_size: %d offset: %d",
+			m_qp, m_qp_num, m_sq_wqes, m_sq_wqes_end,  m_tx_num_wr, m_sq_bf_reg, m_sq_bf_buf_size, m_sq_bf_offset);
 }
 
 qp_mgr_eth_mlx5::qp_mgr_eth_mlx5(const ring_simple* p_ring, const ib_ctx_handler* p_context, const uint8_t port_num,
@@ -109,7 +122,7 @@ qp_mgr_eth_mlx5::qp_mgr_eth_mlx5(const ring_simple* p_ring, const ib_ctx_handler
 	,m_sq_wqe_hot_index(0)
 	,m_sq_bf_offset(0)
 	,m_sq_bf_buf_size(0)
-	,m_sq_wqe_cntr(0)
+	,m_sq_wqe_counter(0)
 {
 	if(configure(p_rx_comp_event_channel)) {
 		throw_vma_exception("failed creating qp_mgr_eth");
@@ -152,29 +165,21 @@ cq_mgr* qp_mgr_eth_mlx5::init_rx_cq_mgr(struct ibv_comp_channel* p_rx_comp_event
 		qp_logerr("Failed allocating m_rq_wqe_idx_to_wrid (errno=%d %m)", errno);
 		return NULL;
 	}
-
+#ifdef DEFINED_VMAPOLL
+	return new cq_mgr(m_p_ring, m_p_ib_ctx_handler, m_rx_num_wr, p_rx_comp_event_channel, true);
+#else
 	return new cq_mgr_mlx5(m_p_ring, m_p_ib_ctx_handler, m_rx_num_wr, p_rx_comp_event_channel, true);
+#endif
 }
 
 cq_mgr* qp_mgr_eth_mlx5::init_tx_cq_mgr()
 {
-	m_tx_num_wr = align32pow2(m_tx_num_wr);
-	if (m_sq_wqe_idx_to_wrid == NULL) {
-		m_sq_wqe_idx_to_wrid = (uint64_t*)mmap(NULL, m_tx_num_wr * sizeof(*m_sq_wqe_idx_to_wrid),
-			PROT_READ | PROT_WRITE, MAP_ANONYMOUS | MAP_PRIVATE, -1, 0);
-		if (m_sq_wqe_idx_to_wrid == MAP_FAILED) {
-			qp_logerr("Failed allocating m_sq_wqe_idx_to_wrid (errno=%d %m)", errno);
-			return NULL;
-		}
-	}
-	qp_logfunc("m_tx_num_wr=%d m_sq_wqe_idx_to_wrid=%p", m_tx_num_wr, m_sq_wqe_idx_to_wrid);
-
 	return new cq_mgr_mlx5(m_p_ring, m_p_ib_ctx_handler, m_tx_num_wr, m_p_ring->get_tx_comp_event_channel(), false);
 }
 
 inline void qp_mgr_eth_mlx5::set_signal_in_next_send_wqe()
 {
-	volatile struct mlx5_wqe64 *wqe = &(*m_sq_wqes)[m_sq_wqe_cntr & (m_tx_num_wr - 1)];
+	volatile struct mlx5_wqe64 *wqe = &(*m_sq_wqes)[m_sq_wqe_counter & (m_tx_num_wr - 1)];
 	wqe->ctrl.data[2] = htonl(8);
 }
 
@@ -195,13 +200,13 @@ int qp_mgr_eth_mlx5::send_to_wire(vma_ibv_send_wr *p_send_wqe)
 
 	/* Copy the first bytes into the inline header */
 	/* This suppress warning due to mlx5_wqe_eth_seg struct format as
-	 * uint8_t inline_hdr_start[2];
-	 * uint8_t inline_hdr[16];
-	 */
+	* uint8_t inline_hdr_start[2];
+	* uint8_t inline_hdr[16];
+	*/
 	/* coverity[buffer_size] */
 	/* coverity[overrun-buffer-arg] */
 	memcpy((void *)m_sq_wqe_hot->eseg.inline_hdr_start,
-	       (void *)addr, MLX5_ETH_INLINE_HEADER_SIZE);
+		(void *)addr, MLX5_ETH_INLINE_HEADER_SIZE);
 
 	addr += MLX5_ETH_INLINE_HEADER_SIZE;
 	length -= MLX5_ETH_INLINE_HEADER_SIZE;
@@ -213,14 +218,13 @@ int qp_mgr_eth_mlx5::send_to_wire(vma_ibv_send_wr *p_send_wqe)
 	++m_sq_wqe_cntr;
 
 	/*
-	 * Make sure that descriptors are written before
-	 * updating doorbell record and ringing the doorbell
-	 */
+	* Make sure that descriptors are written before
+	* updating doorbell record and ringing the doorbell
+	*/
 	wmb();
 	*m_sq_db = htonl(m_sq_wqe_cntr);
-
 	/* This wc_wmb ensures ordering between DB record and BF copy */
-	wc_wmb();
+        wc_wmb();
 
 	/*
 	 * Avoid using memcpy() to copy to BlueFlame page, since memcpy()
@@ -228,11 +232,9 @@ int qp_mgr_eth_mlx5::send_to_wire(vma_ibv_send_wr *p_send_wqe)
 	 * which do not guarantee order of copying.
 	 */
 	mlx5_bf_copy((volatile uintptr_t *)((uintptr_t)m_sq_bf_reg + m_sq_bf_offset),
-		(volatile uintptr_t *)m_sq_wqe_hot);
-
+		     (volatile uintptr_t *)m_sq_wqe_hot);
 	m_sq_bf_offset ^= m_sq_bf_buf_size;
-
-	m_sq_wqe_idx_to_wrid[m_sq_wqe_hot_index] = (uintptr_t)p_send_wqe->wr_id;
+        m_sq_wqe_idx_to_wrid[m_sq_wqe_hot_index] = (uintptr_t)p_send_wqe->wr_id;
 
 	/*Set the next WQE and index*/
 	m_sq_wqe_hot = &(*m_sq_wqes)[m_sq_wqe_cntr & (m_tx_num_wr - 1)];
@@ -240,11 +242,12 @@ int qp_mgr_eth_mlx5::send_to_wire(vma_ibv_send_wr *p_send_wqe)
 	 * Other fields are already initialised in mlx5_init_sq. */
 	m_sq_wqe_hot->ctrl.data[0] = htonl((m_sq_wqe_cntr << 8) | MLX5_OPCODE_SEND);
 	m_sq_wqe_hot_index = m_sq_wqe_cntr & (m_tx_num_wr - 1);
+
 	return 0;
 }
 
-// Handle releasing of Tx buffers
-// Single post send with SIGNAL of a dummy packet
+//! Handle releasing of Tx buffers
+//  Single post send with SIGNAL of a dummy packet
 
 // NOTE: Since the QP is in ERROR state no packets will be sent on the wire!
 // So we can post_send anything we want :)
@@ -306,3 +309,4 @@ void qp_mgr_eth_mlx5::trigger_completion_for_all_sent_packets()
 }
 
 #endif
+

--- a/src/vma/dev/qp_mgr_eth_mlx5.h
+++ b/src/vma/dev/qp_mgr_eth_mlx5.h
@@ -35,6 +35,7 @@
 #define QP_MGR_ETH_MLX5_H
 
 #include "qp_mgr.h"
+#include "vma/util/sg_array.h"
 
 #if defined(HAVE_INFINIBAND_MLX5_HW_H)
 
@@ -60,16 +61,11 @@ private:
 
 	inline void	set_signal_in_next_send_wqe();
 
-//	int		fill_wqe(vma_ibv_send_wr* p_send_wqe);
-//	inline void	send_by_bf(volatile uintptr_t *addr, int size);
-//	inline void	send_by_bf_wrap_up(volatile uintptr_t *first_addr, int first_times, volatile uintptr_t *sec_addr, int sec_times);
-//	inline void	bf_copy(volatile uintptr_t *dst, volatile uintptr_t *src, int times);
-
 	void		init_sq();
 
-	volatile struct mlx5_wqe64	(*m_sq_wqes)[];
-	volatile struct mlx5_wqe64*	m_sq_wqe_hot;
-	uint8_t*			m_sq_wqes_end;
+	struct mlx5_wqe64	(*m_sq_wqes)[];
+	struct mlx5_wqe64*	m_sq_wqe_hot;
+	uint8_t*		m_sq_wqes_end;
 
 	volatile uint32_t*	m_sq_db;
 	volatile void*		m_sq_bf_reg;
@@ -78,7 +74,7 @@ private:
 	int                 m_sq_wqe_hot_index;
 	uint16_t            m_sq_bf_offset;
 	uint16_t            m_sq_bf_buf_size;
-	uint16_t            m_sq_wqe_cntr;
+	uint16_t            m_sq_wqe_counter;
 };
-#endif //!defined(DEFINED_VMAPOLL) && defined(HAVE_INFINIBAND_MLX5_HW_H)
+#endif //defined(HAVE_INFINIBAND_MLX5_HW_H)
 #endif //QP_MGR_ETH_MLX5_H

--- a/src/vma/dev/qp_mgr_eth_mlx5.h
+++ b/src/vma/dev/qp_mgr_eth_mlx5.h
@@ -50,7 +50,6 @@ public:
 	virtual ~qp_mgr_eth_mlx5();
 
 protected:
-	int			send_to_wire(vma_ibv_send_wr* p_send_wqe);
 	void			trigger_completion_for_all_sent_packets();
 	struct mlx5_qp*		m_hw_qp;
 	uint64_t*               m_sq_wqe_idx_to_wrid;
@@ -61,6 +60,7 @@ private:
 
 	inline void	set_signal_in_next_send_wqe();
 
+	int		send_to_wire(vma_ibv_send_wr* p_send_wqe, vma_wr_tx_packet_attr attr);
 	inline int	fill_wqe(vma_ibv_send_wr* p_send_wqe);
 	inline void	send_by_bf(uint64_t *addr, int size);
 	inline void	send_by_bf_wrap_up(uint64_t *bot_addr, int bot_size,  int top_size);

--- a/src/vma/dev/qp_mgr_eth_mlx5.h
+++ b/src/vma/dev/qp_mgr_eth_mlx5.h
@@ -61,6 +61,11 @@ private:
 
 	inline void	set_signal_in_next_send_wqe();
 
+	inline int	fill_wqe(vma_ibv_send_wr* p_send_wqe);
+	inline void	send_by_bf(uint64_t *addr, int size);
+	inline void	send_by_bf_wrap_up(uint64_t *bot_addr, int bot_size,  int top_size);
+	inline int	fill_inl_seg(sg_array &sga, uint8_t *cur_seg, uint8_t* data_addr, int max_inline_len, int inline_len);
+	inline int	fill_ptr_seg(sg_array &sga, struct mlx5_wqe_data_seg* dp_seg, uint8_t* data_addr, int data_len);
 	void		init_sq();
 
 	struct mlx5_wqe64	(*m_sq_wqes)[];

--- a/src/vma/dev/ring.h
+++ b/src/vma/dev/ring.h
@@ -293,7 +293,7 @@ public:
 	// Get/Release memory buffer descriptor with a linked data memory buffer
 	virtual mem_buf_desc_t*	mem_buf_tx_get(ring_user_id_t id, bool b_block, int n_num_mem_bufs = 1) = 0;
 	virtual int		mem_buf_tx_release(mem_buf_desc_t* p_mem_buf_desc_list, bool b_accounting, bool trylock = false) = 0;
-	virtual void		send_ring_buffer(ring_user_id_t id, vma_ibv_send_wr* p_send_wqe, bool b_block) = 0;
+	virtual void		send_ring_buffer(ring_user_id_t id, vma_ibv_send_wr* p_send_wqe, vma_wr_tx_packet_attr attr) = 0;
 	virtual void		send_lwip_buffer(ring_user_id_t id, vma_ibv_send_wr* p_send_wqe, bool b_block) = 0;
 
 	// Funcs taken from cq_mgr.h

--- a/src/vma/dev/ring_bond.cpp
+++ b/src/vma/dev/ring_bond.cpp
@@ -213,13 +213,13 @@ void ring_bond::mem_buf_desc_return_single_to_owner_tx(mem_buf_desc_t* p_mem_buf
 	((ring_simple*)p_mem_buf_desc->p_desc_owner)->mem_buf_desc_return_single_to_owner_tx(p_mem_buf_desc);
 }
 
-void ring_bond::send_ring_buffer(ring_user_id_t id, vma_ibv_send_wr* p_send_wqe, bool b_block)
+void ring_bond::send_ring_buffer(ring_user_id_t id, vma_ibv_send_wr* p_send_wqe, vma_wr_tx_packet_attr attr)
 {
 	mem_buf_desc_t* p_mem_buf_desc = (mem_buf_desc_t*)(p_send_wqe->wr_id);
 	ring_simple* active_ring = m_active_rings[id];
 
 	if (likely(active_ring && p_mem_buf_desc->p_desc_owner == active_ring)) {
-		active_ring->send_ring_buffer(id, p_send_wqe, b_block);
+		active_ring->send_ring_buffer(id, p_send_wqe, attr);
 	} else {
 		ring_logfunc("active ring=%p, silent packet drop (%p), (HA event?)", active_ring, p_mem_buf_desc);
 		p_mem_buf_desc->p_next_desc = NULL;

--- a/src/vma/dev/ring_bond.h
+++ b/src/vma/dev/ring_bond.h
@@ -58,7 +58,7 @@ public:
 	virtual mem_buf_desc_t* mem_buf_tx_get(ring_user_id_t id, bool b_block, int n_num_mem_bufs = 1);
 	virtual int		mem_buf_tx_release(mem_buf_desc_t* p_mem_buf_desc_list, bool b_accounting, bool trylock = false);
 	virtual void		inc_tx_retransmissions(ring_user_id_t id);
-	virtual void		send_ring_buffer(ring_user_id_t id, vma_ibv_send_wr* p_send_wqe, bool b_block);
+	virtual void		send_ring_buffer(ring_user_id_t id, vma_ibv_send_wr* p_send_wqe, vma_wr_tx_packet_attr attr);
 	virtual void		send_lwip_buffer(ring_user_id_t id, vma_ibv_send_wr* p_send_wqe, bool b_block);
 	virtual void		mem_buf_desc_return_single_to_owner_tx(mem_buf_desc_t* p_mem_buf_desc);
 	virtual bool		is_member(mem_buf_desc_owner* rng);

--- a/src/vma/dev/ring_simple.cpp
+++ b/src/vma/dev/ring_simple.cpp
@@ -50,7 +50,7 @@
 #include "vma/dev/rfs_uc.h"
 #include "vma/dev/rfs_uc_tcp_gro.h"
 #include "vma/dev/cq_mgr.h"
-#if !defined(DEFINED_VMAPOLL) && defined(HAVE_INFINIBAND_MLX5_HW_H)
+#if defined(HAVE_INFINIBAND_MLX5_HW_H)
 #include "qp_mgr_eth_mlx5.h"
 #endif
 
@@ -85,7 +85,7 @@ inline void ring_simple::send_status_handler(int ret, vma_ibv_send_wr* p_send_wq
 
 qp_mgr* ring_eth::create_qp_mgr(const ib_ctx_handler* ib_ctx, uint8_t port_num, struct ibv_comp_channel* p_rx_comp_event_channel) throw (vma_error)
 {
-#if !defined(DEFINED_VMAPOLL) && defined(HAVE_INFINIBAND_MLX5_HW_H)
+#if defined(HAVE_INFINIBAND_MLX5_HW_H)
 	if (qp_mgr::is_lib_mlx5(((ib_ctx_handler*)ib_ctx)->get_ibv_device()->name)) {
 		return new qp_mgr_eth_mlx5(this, ib_ctx, port_num, p_rx_comp_event_channel, get_tx_num_wr(), get_partition());
 	}
@@ -1527,6 +1527,9 @@ int ring_simple::get_max_tx_inline()
 /* note that this function is inline, so keep it above the functions using it */
 inline int ring_simple::send_buffer(vma_ibv_send_wr* p_send_wqe, bool b_block)
 {
+	//Note: this is debatable logic as it count of WQEs waiting completion but
+	//our SQ is cyclic buffer so in reality only last WQE is still being sent
+	//and other SQ is mostly free to work on.
 	int ret = 0;
 	if (likely(m_tx_num_wr_free > 0)) {
 		ret = m_p_qp_mgr->send(p_send_wqe);
@@ -1780,7 +1783,7 @@ mem_buf_desc_t* ring_simple::get_tx_buffers(uint32_t n_num_mem_bufs)
 //call under m_lock_ring_tx lock
 int ring_simple::put_tx_buffers(mem_buf_desc_t* buff_list)
 {
-	int count = 0;
+	int count = 0,freed=0;
 	mem_buf_desc_t *next;
 
 	while (buff_list) {
@@ -1796,10 +1799,12 @@ int ring_simple::put_tx_buffers(mem_buf_desc_t* buff_list)
 		if (buff_list->lwip_pbuf.pbuf.ref == 0) {
 			free_lwip_pbuf(&buff_list->lwip_pbuf);
 			m_tx_pool.push_back(buff_list);
+			freed++;
 		}
 		count++;
 		buff_list = next;
 	}
+	ring_logfunc("buf_list: %p count: %d freed: %d\n", buff_list, count, freed);
 
 	if (unlikely(m_tx_pool.size() > (m_tx_num_bufs / 2) &&  m_tx_num_bufs >= RING_TX_BUFS_COMPENSATE * 2)) {
 		int return_to_global_pool = m_tx_pool.size() / 2;

--- a/src/vma/dev/ring_simple.cpp
+++ b/src/vma/dev/ring_simple.cpp
@@ -1527,17 +1527,17 @@ int ring_simple::get_max_tx_inline()
 }
 
 /* note that this function is inline, so keep it above the functions using it */
-inline int ring_simple::send_buffer(vma_ibv_send_wr* p_send_wqe, bool b_block)
+inline int ring_simple::send_buffer(vma_ibv_send_wr* p_send_wqe, vma_wr_tx_packet_attr attr)
 {
 	//Note: this is debatable logic as it count of WQEs waiting completion but
 	//our SQ is cyclic buffer so in reality only last WQE is still being sent
 	//and other SQ is mostly free to work on.
 	int ret = 0;
 	if (likely(m_tx_num_wr_free > 0)) {
-		ret = m_p_qp_mgr->send(p_send_wqe);
+		ret = m_p_qp_mgr->send(p_send_wqe,attr);
 		--m_tx_num_wr_free;
-	} else if (is_available_qp_wr(b_block)) {
-		ret = m_p_qp_mgr->send(p_send_wqe);
+	} else if (is_available_qp_wr(is_set(attr,VMA_TX_PACKET_BLOCK))) {
+		ret = m_p_qp_mgr->send(p_send_wqe,attr);
 	} else {
 		ring_logdbg("silent packet drop, no available WR in QP!");
 		ret = -1;
@@ -1557,12 +1557,12 @@ bool ring_simple::get_hw_dummy_send_support(ring_user_id_t id, vma_ibv_send_wr* 
 	return m_p_qp_mgr->get_hw_dummy_send_support();
 }
 
-void ring_simple::send_ring_buffer(ring_user_id_t id, vma_ibv_send_wr* p_send_wqe, bool b_block)
+void ring_simple::send_ring_buffer(ring_user_id_t id, vma_ibv_send_wr* p_send_wqe, vma_wr_tx_packet_attr attr)
 {
 	NOT_IN_USE(id);
 	auto_unlocker lock(m_lock_ring_tx);
 	p_send_wqe->sg_list[0].lkey = m_tx_lkey;	// The ring keeps track of the current device lkey (In case of bonding event...)
-	int ret = send_buffer(p_send_wqe, b_block);
+	int ret = send_buffer(p_send_wqe, attr);
 	send_status_handler(ret, p_send_wqe);
 }
 
@@ -1573,7 +1573,8 @@ void ring_simple::send_lwip_buffer(ring_user_id_t id, vma_ibv_send_wr* p_send_wq
 	p_send_wqe->sg_list[0].lkey = m_tx_lkey; // The ring keeps track of the current device lkey (In case of bonding event...)
 	mem_buf_desc_t* p_mem_buf_desc = (mem_buf_desc_t*)(p_send_wqe->wr_id);
 	p_mem_buf_desc->lwip_pbuf.pbuf.ref++;
-	int ret = send_buffer(p_send_wqe, b_block);
+	vma_wr_tx_packet_attr attr = (vma_wr_tx_packet_attr)((b_block*VMA_TX_PACKET_BLOCK)|VMA_TX_PACKET_L3_CSUM|VMA_TX_PACKET_L4_CSUM);
+	int ret = send_buffer(p_send_wqe, attr);
 	send_status_handler(ret, p_send_wqe);
 }
 

--- a/src/vma/dev/ring_simple.h
+++ b/src/vma/dev/ring_simple.h
@@ -114,7 +114,6 @@ protected:
 	bool			request_more_tx_buffers(uint32_t count);
 	uint32_t		get_tx_num_wr() { return m_tx_num_wr; }
 	uint16_t		get_partition() { return m_partition; }
-	uint16_t		get_lkey() { return m_tx_lkey; }
 	ib_ctx_handler*		m_p_ib_ctx;
 	qp_mgr*			m_p_qp_mgr;
 	struct cq_moderation_info m_cq_moderation_info;

--- a/src/vma/dev/ring_simple.h
+++ b/src/vma/dev/ring_simple.h
@@ -90,6 +90,7 @@ public:
 	friend class cq_mgr;
 	friend class cq_mgr_mlx5;
 	friend class qp_mgr;
+	friend class qp_mgr_eth_mlx5;
 	friend class rfs;
 	friend class rfs_uc;
 	friend class rfs_uc_tcp_gro;
@@ -113,9 +114,7 @@ protected:
 	bool			request_more_tx_buffers(uint32_t count);
 	uint32_t		get_tx_num_wr() { return m_tx_num_wr; }
 	uint16_t		get_partition() { return m_partition; }
-#ifdef DEFINED_VMAPOLL		
 	uint16_t		get_lkey() { return m_tx_lkey; }
-#endif // DEFINED_VMAPOLL		
 	ib_ctx_handler*		m_p_ib_ctx;
 	qp_mgr*			m_p_qp_mgr;
 	struct cq_moderation_info m_cq_moderation_info;

--- a/src/vma/dev/ring_simple.h
+++ b/src/vma/dev/ring_simple.h
@@ -63,7 +63,7 @@ public:
 	virtual void		mem_buf_desc_return_to_owner_rx(mem_buf_desc_t* p_mem_buf_desc, void* pv_fd_ready_array = NULL);
 	virtual void		mem_buf_desc_return_to_owner_tx(mem_buf_desc_t* p_mem_buf_desc);
 	virtual int		get_max_tx_inline();
-	inline int		send_buffer(vma_ibv_send_wr* p_send_wqe, bool b_block);
+	inline int		send_buffer(vma_ibv_send_wr* p_send_wqe, vma_wr_tx_packet_attr attr);
 	virtual bool		attach_flow(flow_tuple& flow_spec_5t, pkt_rcvr_sink* sink);
 	virtual bool		detach_flow(flow_tuple& flow_spec_5t, pkt_rcvr_sink* sink);
 	virtual void		restart(ring_resource_creation_info_t* p_ring_info);
@@ -73,7 +73,7 @@ public:
 	virtual mem_buf_desc_t*	mem_buf_tx_get(ring_user_id_t id, bool b_block, int n_num_mem_bufs = 1);
 	virtual int		mem_buf_tx_release(mem_buf_desc_t* p_mem_buf_desc_list, bool b_accounting, bool trylock = false);
 	virtual void		inc_tx_retransmissions(ring_user_id_t id);
-	virtual void		send_ring_buffer(ring_user_id_t id, vma_ibv_send_wr* p_send_wqe, bool b_block);
+	virtual void		send_ring_buffer(ring_user_id_t id, vma_ibv_send_wr* p_send_wqe, vma_wr_tx_packet_attr attr);
 	virtual void		send_lwip_buffer(ring_user_id_t id, vma_ibv_send_wr* p_send_wqe, bool b_block);
 	virtual void		mem_buf_desc_return_single_to_owner_tx(mem_buf_desc_t* p_mem_buf_desc);
 	virtual bool		is_member(mem_buf_desc_owner* rng);

--- a/src/vma/hw/mlx5/wqe.h
+++ b/src/vma/hw/mlx5/wqe.h
@@ -33,7 +33,8 @@
 #ifndef WQE_H
 #define WQE_H
 
-#define MLX5_ETH_INLINE_HEADER_SIZE 16
+#define OCTOWORD	16
+#define WQEBB		64
 
 #ifndef DEFINED_MLX5_HW_ETH_WQE_HEADER
 enum {

--- a/src/vma/hw/mlx5/wqe.h
+++ b/src/vma/hw/mlx5/wqe.h
@@ -33,6 +33,10 @@
 #ifndef WQE_H
 #define WQE_H
 
+#if !defined(MLX5_ETH_INLINE_HEADER_SIZE)
+#define MLX5_ETH_INLINE_HEADER_SIZE 18
+#endif
+
 #define OCTOWORD	16
 #define WQEBB		64
 

--- a/src/vma/hw/mlx5/wqe.h
+++ b/src/vma/hw/mlx5/wqe.h
@@ -41,10 +41,6 @@
 #define WQEBB		64
 
 #ifndef DEFINED_MLX5_HW_ETH_WQE_HEADER
-enum {
-	MLX5_ETH_WQE_L3_CSUM	=	(1 << 6),
-	MLX5_ETH_WQE_L4_CSUM	=	(1 << 7),
-};
 
 struct mlx5_wqe_eth_seg {
 	uint32_t        rsvd0;

--- a/src/vma/proto/dst_entry.h
+++ b/src/vma/proto/dst_entry.h
@@ -165,12 +165,12 @@ protected:
 	void			do_ring_migration(lock_base& socket_lock);
 	inline void		set_tx_buff_list_pending(bool is_pending = true) {m_b_tx_mem_buf_desc_list_pending = is_pending;}
 
-	inline void		send_ring_buffer(ring_user_id_t id, vma_ibv_send_wr* p_send_wqe, bool b_block, bool b_dummy)
+	inline void		send_ring_buffer(ring_user_id_t id, vma_ibv_send_wr* p_send_wqe, vma_wr_tx_packet_attr attr)
 	{
-		if (unlikely(b_dummy)) {
+		if (unlikely(is_set(attr,VMA_TX_PACKET_DUMMY))) {
 			if (m_p_ring->get_hw_dummy_send_support(id, p_send_wqe)) {
 				vma_ibv_wr_opcode last_opcode = m_p_send_wqe_handler->set_opcode(*p_send_wqe, VMA_IBV_WR_NOP);
-				m_p_ring->send_ring_buffer(id, p_send_wqe, b_block);
+				m_p_ring->send_ring_buffer(id, p_send_wqe, attr);
 				m_p_send_wqe_handler->set_opcode(*p_send_wqe, last_opcode);
 			} else {
 				/* free the buffer if dummy send is not supported */
@@ -178,7 +178,7 @@ protected:
 				m_p_ring->mem_buf_tx_release(p_mem_buf_desc, true);
 			}
 		} else {
-			m_p_ring->send_ring_buffer(id, p_send_wqe, b_block);
+			m_p_ring->send_ring_buffer(id, p_send_wqe, attr);
 		}
 	}
 

--- a/src/vma/proto/dst_entry_tcp.cpp
+++ b/src/vma/proto/dst_entry_tcp.cpp
@@ -160,7 +160,11 @@ ssize_t dst_entry_tcp::fast_send(const iovec* p_iov, const ssize_t sz_iov, bool 
 #endif
 		m_p_send_wqe = &m_not_inline_send_wqe;
 		m_p_send_wqe->wr_id = (uintptr_t)p_mem_buf_desc;
-		send_ring_buffer(m_id, m_p_send_wqe, b_blocked, is_dummy);
+		vma_wr_tx_packet_attr attr = (vma_wr_tx_packet_attr)((VMA_TX_PACKET_BLOCK*b_blocked) | 
+								     (VMA_TX_PACKET_DUMMY*is_dummy)  |
+								      VMA_TX_PACKET_L3_CSUM          |
+								      VMA_TX_PACKET_L4_CSUM);
+		send_ring_buffer(m_id, m_p_send_wqe, attr);
 
 		/* for DEBUG */
 		if ((uint8_t*)m_sge[0].addr < p_mem_buf_desc->p_buffer) {

--- a/src/vma/proto/dst_entry_udp.h
+++ b/src/vma/proto/dst_entry_udp.h
@@ -60,8 +60,8 @@ protected:
 
 private:
 
-	inline ssize_t fast_send_not_fragmented(const iovec* p_iov, const ssize_t sz_iov, bool is_dummy, bool b_blocked, size_t sz_udp_payload, ssize_t sz_data_payload);
-	ssize_t fast_send_fragmented(const iovec* p_iov, const ssize_t sz_iov, bool is_dummy, bool b_blocked, size_t sz_udp_payload, ssize_t sz_data_payload);
+	inline ssize_t fast_send_not_fragmented(const iovec* p_iov, const ssize_t sz_iov, vma_wr_tx_packet_attr attr, size_t sz_udp_payload, ssize_t sz_data_payload);
+	ssize_t fast_send_fragmented(const iovec* p_iov, const ssize_t sz_iov, vma_wr_tx_packet_attr attr, size_t sz_udp_payload, ssize_t sz_data_payload);
 
 	const uint32_t m_n_sysvar_tx_bufs_batch_udp;
 	const bool m_b_sysvar_tx_nonblocked_eagains;

--- a/src/vma/proto/igmp_handler.cpp
+++ b/src/vma/proto/igmp_handler.cpp
@@ -215,7 +215,7 @@ bool igmp_handler::tx_igmp_report()
 	m_p_send_igmp_wqe.wr_id = (uintptr_t)p_mem_buf_desc;
 
 	igmp_hdlr_logdbg("Sending igmp report");
-	m_p_ring->send_ring_buffer(m_id, &m_p_send_igmp_wqe, false);
+	m_p_ring->send_ring_buffer(m_id, &m_p_send_igmp_wqe, VMA_TX_PACKET_L3_CSUM);
 	return true;
 }
 

--- a/src/vma/proto/mem_buf_desc.h
+++ b/src/vma/proto/mem_buf_desc.h
@@ -130,11 +130,9 @@ public:
 	inline int inc_ref_count() {return atomic_fetch_and_inc(&n_ref_count);}
 	inline int dec_ref_count() {return atomic_fetch_and_dec(&n_ref_count);}
 
-#ifdef DEFINED_VMAPOLL
 	inline unsigned int lwip_pbuf_inc_ref_count() {return ++lwip_pbuf.pbuf.ref;}
 	inline unsigned int lwip_pbuf_dec_ref_count() {if (likely(lwip_pbuf.pbuf.ref)) --lwip_pbuf.pbuf.ref; return lwip_pbuf.pbuf.ref;}
 	inline unsigned int lwip_pbuf_get_ref_count() const {return lwip_pbuf.pbuf.ref;}
-#endif // DEFINED_VMAPOLL
 };
 
 typedef vma_list_t<mem_buf_desc_t, mem_buf_desc_t::buffer_node_offset> descq_t;

--- a/src/vma/sock/sockinfo_tcp.cpp
+++ b/src/vma/sock/sockinfo_tcp.cpp
@@ -4315,8 +4315,8 @@ void sockinfo_tcp::tcp_tx_pbuf_free(void* p_conn, struct pbuf *p_buff)
 		mem_buf_desc_t * p_desc = (mem_buf_desc_t *)p_buff;
 
 		//potential race, ref is protected here by tcp lock, and in ring by ring_tx lock
-		if (likely(p_desc->lwip_pbuf.pbuf.ref))
-			p_desc->lwip_pbuf.pbuf.ref--;
+		if (likely(p_desc->lwip_pbuf_get_ref_count()))
+			p_desc->lwip_pbuf_dec_ref_count();
 		else
 			__log_err("ref count of %p is already zero, double free??", p_desc);
 

--- a/src/vma/util/sg_array.h
+++ b/src/vma/util/sg_array.h
@@ -1,0 +1,123 @@
+/*
+ * Copyright (c) 2017 Mellanox Technologies, Ltd. All rights reserved.
+ *
+ * This software is available to you under a choice of one of two
+ * licenses.  You may choose to be licensed under the terms of the GNU
+ * General Public License (GPL) Version 2, available from the file
+ * COPYING in the main directory of this source tree, or the
+ * BSD license below:
+ *
+ *     Redistribution and use in source and binary forms, with or
+ *     without modification, are permitted provided that the following
+ *     conditions are met:
+ *
+ *      - Redistributions of source code must retain the above
+ *        copyright notice, this list of conditions and the following
+ *        disclaimer.
+ *
+ *      - Redistributions in binary form must reproduce the above
+ *        copyright notice, this list of conditions and the following
+ *        disclaimer in the documentation and/or other materials
+ *        provided with the distribution.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+ * BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ * ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#ifndef SG_ARRAY_H
+#define SG_ARRAY_H
+
+#include <stdio.h>
+#include "util/verbs_extra.h"
+
+//! sg_array - helper class on top of scatter/gather elements array.
+//Represent it like a virtual one dimension vector/array.
+
+class sg_array {
+public:
+	sg_array(ibv_sge *sg_, int num_sge_):
+	 m_sg(sg_)
+	,m_current(sg_)
+	,m_num_sge(num_sge_)
+	,m_length(0)
+	,m_index(0)
+	,m_pos(0)
+	{
+	}
+//! Index operator
+#if 0 //TODO: testing
+	inline uint8_t* operator[](int ind_)
+	{
+		int index = -1;
+		int pos = 0;
+		if (unlikely(m_sg == NULL))
+			return NULL;
+		while (index++ <= m_num_sge) {
+
+			if (pos+(int)m_sg[index].length > ind_) {
+				return (uint8_t*)m_sg[index].addr+(ind_-pos);
+			} else {
+				pos += m_sg[index].length;
+			}
+		}
+		return NULL;
+	}
+#endif //0
+//! Get pointer to data for get_len size from current position.
+//In case there is no full requested range in current SGE returns
+//the rest in current sge. Next call will start from the beginning
+//of next SGE
+	inline uint8_t* get_data(int* get_len)
+	{
+		if (likely(m_index < m_num_sge)) {
+
+			m_current = m_sg + m_index;
+
+			if (likely((m_pos+*get_len) < (int)m_current->length)) {
+				uint8_t* old_p = (uint8_t*)m_sg[m_index].addr+m_pos;
+				m_pos += *get_len;
+				if (unlikely(m_pos < 0))
+					return NULL;
+				return old_p;
+			} else {
+				*get_len = m_current->length - m_pos;
+
+				if (unlikely(m_pos < 0))
+					return NULL;
+				uint8_t* old_p = (uint8_t*)m_sg[m_index++].addr+m_pos;
+				// moving to next sge
+				m_pos = 0;
+				return old_p;
+			}
+		}
+		return NULL;
+	}
+
+	inline int get_num_sge(void) { return m_sg ? m_num_sge : -1; }
+	inline int length(void) 
+	{
+		if (unlikely(m_sg==NULL || m_num_sge==0) )
+			return 0;
+		for (int i=0; i<m_num_sge; i++)
+			m_length += m_sg[i].length;
+		return m_length; 
+	}
+	inline int get_current_lkey(void) { return m_current->lkey; }
+
+private:
+	struct ibv_sge*	m_sg;
+	struct ibv_sge* m_current;
+	int     	m_num_sge;
+	int		m_length;
+	int		m_index;
+	int     	m_pos;
+
+};
+
+#endif // SG_ARRAY_H

--- a/src/vma/util/sys_vars.h
+++ b/src/vma/util/sys_vars.h
@@ -552,11 +552,7 @@ extern mce_sys_var & safe_mce_sys();
 #define MCE_DEFAULT_TX_NUM_BUFS				(200000)
 #define MCE_DEFAULT_TX_NUM_WRE				(2048)
 #define MCE_DEFAULT_TX_NUM_WRE_TO_SIGNAL		(64)
-//TODO: exclude when enable in-lining !#ifdef DEFINED_VMAPOLL
-#define MCE_DEFAULT_TX_MAX_INLINE                      (0) //220
-#if 0 //!else
 #define MCE_DEFAULT_TX_MAX_INLINE			(204) //+18(always inline ETH header) = 222
-#endif // DEFINED_VMAPOLL
 #define MCE_DEFAULT_TX_BUILD_IP_CHKSUM			(true)
 #define MCE_DEFAULT_TX_MC_LOOPBACK			(true)
 #define MCE_DEFAULT_TX_NONBLOCKED_EAGAINS		(false)

--- a/src/vma/util/sys_vars.h
+++ b/src/vma/util/sys_vars.h
@@ -553,9 +553,9 @@ extern mce_sys_var & safe_mce_sys();
 #define MCE_DEFAULT_TX_NUM_WRE				(2048)
 #define MCE_DEFAULT_TX_NUM_WRE_TO_SIGNAL		(64)
 //TODO: exclude when enable in-lining !#ifdef DEFINED_VMAPOLL
-#define MCE_DEFAULT_TX_MAX_INLINE			(0) //220
+#define MCE_DEFAULT_TX_MAX_INLINE                      (0) //220
 #if 0 //!else
-#define MCE_DEFAULT_TX_MAX_INLINE			(220) //224
+#define MCE_DEFAULT_TX_MAX_INLINE			(204) //+18(always inline ETH header) = 222
 #endif // DEFINED_VMAPOLL
 #define MCE_DEFAULT_TX_BUILD_IP_CHKSUM			(true)
 #define MCE_DEFAULT_TX_MC_LOOPBACK			(true)

--- a/src/vma/util/sys_vars.h
+++ b/src/vma/util/sys_vars.h
@@ -550,15 +550,11 @@ extern mce_sys_var & safe_mce_sys();
 #define MCE_DEFAULT_TCP_MAX_SYN_RATE                	(0)
 #define MCE_DEFAULT_TX_NUM_SEGS_TCP			(1000000)
 #define MCE_DEFAULT_TX_NUM_BUFS				(200000)
-#ifdef DEFINED_VMAPOLL
-#define MCE_DEFAULT_TX_NUM_WRE				(1024)
-#else
-#define MCE_DEFAULT_TX_NUM_WRE				(3000)
-#endif // DEFINED_VMAPOLL
+#define MCE_DEFAULT_TX_NUM_WRE				(2048)
 #define MCE_DEFAULT_TX_NUM_WRE_TO_SIGNAL		(64)
-#ifdef DEFINED_VMAPOLL
+//TODO: exclude when enable in-lining !#ifdef DEFINED_VMAPOLL
 #define MCE_DEFAULT_TX_MAX_INLINE			(0) //220
-#else
+#if 0 //!else
 #define MCE_DEFAULT_TX_MAX_INLINE			(220) //224
 #endif // DEFINED_VMAPOLL
 #define MCE_DEFAULT_TX_BUILD_IP_CHKSUM			(true)

--- a/src/vma/util/verbs_extra.h
+++ b/src/vma/util/verbs_extra.h
@@ -44,6 +44,9 @@
 #include <string.h>
 #include <netinet/in.h>
 #include <linux/if_ether.h>
+#ifdef HAVE_INFINIBAND_MLX5_HW_H
+# include <infiniband/mlx5_hw.h>
+#endif //HAVE_INFINIBAND_MLX5_HW_H
 
 #ifndef DEFINED_IBV_WC_WITH_VLAN
 //#warning probaly you are trying to compile on OFED which doesnt support VLAN for RAW QP.
@@ -306,6 +309,19 @@ typedef struct ibv_exp_flow_spec_action_tag	vma_ibv_flow_spec_action_tag;
 typedef struct ibv_exp_flow_spec_action_tag_dummy {}	vma_ibv_flow_spec_action_tag;
 #endif //DEFINED_IBV_EXP_FLOW_TAG
 #endif
+
+typedef enum vma_wr_tx_packet_attr {
+	VMA_TX_PACKET_BLOCK   = (1 << 0), // blocking send
+	VMA_TX_PACKET_DUMMY   = (1 << 1), // dummy send
+	VMA_TX_PACKET_LSO     = (1 << 2), // packet to send by LSO
+	VMA_TX_PACKET_L3_CSUM = (1 << 6), //MLX5_ETH_WQE_L3_CSUM offload to HW L3 (IP) header checksum
+	VMA_TX_PACKET_L4_CSUM = (1 << 7)  //MLX5_ETH_WQE_L4_CSUM offload to HW L4 (TCP/UDP) header checksum
+} vma_wr_tx_packet_attr;
+
+inline bool is_set(vma_wr_tx_packet_attr state_, vma_wr_tx_packet_attr tx_mode_)
+{
+	return (uint32_t)state_ & (uint32_t)tx_mode_;
+}
 
 int vma_rdma_lib_reset();
 

--- a/tests/gtest/Makefile.am
+++ b/tests/gtest/Makefile.am
@@ -23,6 +23,9 @@ gtest_SOURCES = \
 	sock/sock_base.cc \
 	sock/sock_socket.cc \
 	\
+	aux/aux_base.cc \
+	aux/sg_array.cc \
+	\
 	tcp/tcp_base.cc \
 	tcp/tcp_bind.cc \
 	tcp/tcp_connect.cc \
@@ -51,6 +54,8 @@ noinst_HEADERS = \
 	common/base.h \
 	\
 	sock/sock_base.h \
+	\
+	aux/aux_base.h \
 	\
 	tcp/tcp_base.h \
 	\

--- a/tests/gtest/aux/aux_base.cc
+++ b/tests/gtest/aux/aux_base.cc
@@ -1,0 +1,45 @@
+/*
+ * Copyright (c) 2017 Mellanox Technologies, Ltd. All rights reserved.
+ *
+ * This software is available to you under a choice of one of two
+ * licenses.  You may choose to be licensed under the terms of the GNU
+ * General Public License (GPL) Version 2, available from the file
+ * COPYING in the main directory of this source tree, or the
+ * BSD license below:
+ *
+ *     Redistribution and use in source and binary forms, with or
+ *     without modification, are permitted provided that the following
+ *     conditions are met:
+ *
+ *      - Redistributions of source code must retain the above
+ *        copyright notice, this list of conditions and the following
+ *        disclaimer.
+ *
+ *      - Redistributions in binary form must reproduce the above
+ *        copyright notice, this list of conditions and the following
+ *        disclaimer in the documentation and/or other materials
+ *        provided with the distribution.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+ * BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ * ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+#include "common/def.h"
+
+#include "aux_base.h"
+
+void aux_base::SetUp()
+{
+	errno = EOK;
+}
+
+void aux_base::TearDown()
+{
+
+}
+

--- a/tests/gtest/aux/aux_base.h
+++ b/tests/gtest/aux/aux_base.h
@@ -1,0 +1,48 @@
+/*
+ * Copyright (c) 2017 Mellanox Technologies, Ltd. All rights reserved.
+ *
+ * This software is available to you under a choice of one of two
+ * licenses.  You may choose to be licensed under the terms of the GNU
+ * General Public License (GPL) Version 2, available from the file
+ * COPYING in the main directory of this source tree, or the
+ * BSD license below:
+ *
+ *     Redistribution and use in source and binary forms, with or
+ *     without modification, are permitted provided that the following
+ *     conditions are met:
+ *
+ *      - Redistributions of source code must retain the above
+ *        copyright notice, this list of conditions and the following
+ *        disclaimer.
+ *
+ *      - Redistributions in binary form must reproduce the above
+ *        copyright notice, this list of conditions and the following
+ *        disclaimer in the documentation and/or other materials
+ *        provided with the distribution.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+ * BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ * ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+#ifndef TESTS_GTEST_AUX_BASE_H_
+
+#include "common/def.h"
+#include "common/log.h"
+#include "common/sys.h"
+#include "common/base.h"
+
+
+class aux_base : public testing::Test, public test_base
+{
+protected:
+	virtual void SetUp();
+	virtual void TearDown();
+};
+
+#endif //TESTS_GTEST_AUX_VASE_H_
+

--- a/tests/gtest/aux/sg_array.cc
+++ b/tests/gtest/aux/sg_array.cc
@@ -1,0 +1,175 @@
+/*
+ * Copyright (c) 2017 Mellanox Technologies, Ltd. All rights reserved.
+ *
+ * This software is available to you under a choice of one of two
+ * licenses.  You may choose to be licensed under the terms of the GNU
+ * General Public License (GPL) Version 2, available from the file
+ * COPYING in the main directory of this source tree, or the
+ * BSD license below:
+ *
+ *     Redistribution and use in source and binary forms, with or
+ *     without modification, are permitted provided that the following
+ *     conditions are met:
+ *
+ *      - Redistributions of source code must retain the above
+ *        copyright notice, this list of conditions and the following
+ *        disclaimer.
+ *
+ *      - Redistributions in binary form must reproduce the above
+ *        copyright notice, this list of conditions and the following
+ *        disclaimer in the documentation and/or other materials
+ *        provided with the distribution.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+ * BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ * ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+#include "common/def.h"
+#include "vma/util/verbs_extra.h"
+#include "vma/util/sg_array.h"
+
+class sg_array_test : public ::testing::Test {
+public:
+	struct ibv_sge*	sge0;
+	struct ibv_sge	sge1;
+	struct ibv_sge	sge2[2];
+	struct ibv_sge	sge3[3];
+	sg_array_test()
+	{
+		sge0 = NULL;
+
+		sge1.addr = (uint64_t)"0123456789";
+		sge1.length = 10;
+
+		sge2[0].addr = (uint64_t)"0123456789";
+		sge2[0].length = 10;
+		sge2[1].addr = (uint64_t)"0123456789";
+		sge2[1].length = 10;
+
+		sge3[0].addr = (uint64_t)"0123456789";
+		sge3[0].length = 10;
+		sge3[1].addr = (uint64_t)"0123456789";
+		sge3[1].length = 10;
+		sge3[2].addr = (uint64_t)"0123456789";
+		sge3[2].length = 10;
+	}
+
+};
+//! Tests for constructor
+TEST_F(sg_array_test, sga_ctr)
+{
+	sg_array	sa0(sge0,0);
+	EXPECT_EQ(-1,sa0.get_num_sge());
+	EXPECT_EQ(0,sa0.length());
+
+	sg_array	sa1(&sge1,1);
+	EXPECT_EQ(1,sa1.get_num_sge());
+	EXPECT_EQ(10,sa1.length());
+
+	sg_array	sa2(sge2,2);
+	EXPECT_EQ(2,sa2.get_num_sge());
+	EXPECT_EQ(20,sa2.length());
+
+	sg_array	sa3(sge3,3);
+	EXPECT_EQ(3,sa3.get_num_sge());
+	EXPECT_EQ(30,sa3.length());
+
+}
+
+//! Tests for relative index
+//
+TEST_F(sg_array_test, sga_index_0)
+{
+	sg_array sa0(sge0,0);
+	EXPECT_EQ(NULL,sa0.get_data(0));
+
+	sg_array sa1(&sge1,1);
+	EXPECT_EQ(NULL,sa0.get_data(0));
+}
+
+//! Tests for minimum bound
+//
+TEST_F(sg_array_test, sga_min_bound)
+{
+	sg_array sa0(sge0,0);
+	int	len=-1;
+	EXPECT_EQ(NULL,sa0.get_data(&len));
+
+	sg_array sa1(&sge1,1);
+	EXPECT_EQ(NULL,sa1.get_data(&len));
+}
+
+//! Test for maximum bound
+//
+TEST_F(sg_array_test, sga_max_bound)
+{
+	sg_array sa0(sge0,0);
+	int len = 1;
+	EXPECT_EQ(NULL,sa0.get_data(&len));
+
+	sg_array sa1(&sge1,1);
+	len = 11;
+	uint8_t *p = sa1.get_data(&len);
+	EXPECT_EQ(len,10);
+	EXPECT_EQ((uint64_t)p,sge1.addr);
+
+	p = sa1.get_data(&len);
+	EXPECT_EQ((uint64_t)p,NULL);
+}
+
+//! Tests for in_bound
+//
+TEST_F(sg_array_test, sga_in_bound)
+{
+	sg_array sa1(&sge1,1);
+
+	int len = 5;
+	uint8_t *p = sa1.get_data(&len);
+
+	EXPECT_EQ(len,5);
+	EXPECT_EQ((uint64_t)p,sge1.addr);
+
+	len = 10;
+	p = sa1.get_data(&len);
+
+	EXPECT_EQ(len,5);
+	EXPECT_EQ(*p,'5');
+}
+
+//! Tests for in_bound
+//
+TEST_F(sg_array_test, sga_in_bound_multi_sge)
+{
+	sg_array sa3(sge3,3);
+
+	int len = 5;
+	uint8_t *p = sa3.get_data(&len);
+
+	EXPECT_EQ(len,5);
+	EXPECT_EQ((uint64_t)p,sge3[0].addr);
+
+	len = 10;
+	p = sa3.get_data(&len);
+
+	EXPECT_EQ(len,5);
+	EXPECT_EQ(*p,'5');
+
+	len = 15;
+	p = sa3.get_data(&len);
+
+	EXPECT_EQ(len,10);
+	EXPECT_EQ((uint64_t)p,sge3[1].addr);
+
+	len = 10;
+	p = sa3.get_data(&len);
+
+	EXPECT_EQ(len,10);
+	EXPECT_EQ((uint64_t)p,sge3[2].addr);
+}
+
+

--- a/tests/gtest/aux/sg_array.cc
+++ b/tests/gtest/aux/sg_array.cc
@@ -64,20 +64,20 @@ public:
 TEST_F(sg_array_test, sga_ctr)
 {
 	sg_array	sa0(sge0,0);
-	EXPECT_EQ(-1,sa0.get_num_sge());
-	EXPECT_EQ(0,sa0.length());
+	EXPECT_EQ(-1, sa0.get_num_sge());
+	EXPECT_EQ(0, sa0.length());
 
 	sg_array	sa1(&sge1,1);
-	EXPECT_EQ(1,sa1.get_num_sge());
-	EXPECT_EQ(10,sa1.length());
+	EXPECT_EQ(1, sa1.get_num_sge());
+	EXPECT_EQ(10, sa1.length());
 
 	sg_array	sa2(sge2,2);
-	EXPECT_EQ(2,sa2.get_num_sge());
-	EXPECT_EQ(20,sa2.length());
+	EXPECT_EQ(2, sa2.get_num_sge());
+	EXPECT_EQ(20, sa2.length());
 
 	sg_array	sa3(sge3,3);
-	EXPECT_EQ(3,sa3.get_num_sge());
-	EXPECT_EQ(30,sa3.length());
+	EXPECT_EQ(3, sa3.get_num_sge());
+	EXPECT_EQ(30, sa3.length());
 
 }
 
@@ -85,91 +85,91 @@ TEST_F(sg_array_test, sga_ctr)
 //
 TEST_F(sg_array_test, sga_index_0)
 {
-	sg_array sa0(sge0,0);
-	EXPECT_EQ(NULL,sa0.get_data(0));
+	sg_array sa0(sge0, 0);
+	EXPECT_EQ(NULL, sa0.get_data(0));
 
-	sg_array sa1(&sge1,1);
-	EXPECT_EQ(NULL,sa0.get_data(0));
+	sg_array sa1(&sge1, 1);
+	EXPECT_EQ(NULL, sa0.get_data(0));
 }
 
 //! Tests for minimum bound
 //
 TEST_F(sg_array_test, sga_min_bound)
 {
-	sg_array sa0(sge0,0);
+	sg_array sa0(sge0, 0);
 	int	len=-1;
-	EXPECT_EQ(NULL,sa0.get_data(&len));
+	EXPECT_EQ(NULL, sa0.get_data(&len));
 
-	sg_array sa1(&sge1,1);
-	EXPECT_EQ(NULL,sa1.get_data(&len));
+	sg_array sa1(&sge1, 1);
+	EXPECT_EQ(NULL, sa1.get_data(&len));
 }
 
 //! Test for maximum bound
 //
 TEST_F(sg_array_test, sga_max_bound)
 {
-	sg_array sa0(sge0,0);
+	sg_array sa0(sge0, 0);
 	int len = 1;
-	EXPECT_EQ(NULL,sa0.get_data(&len));
+	EXPECT_EQ(NULL, sa0.get_data(&len));
 
-	sg_array sa1(&sge1,1);
+	sg_array sa1(&sge1, 1);
 	len = 11;
 	uint8_t *p = sa1.get_data(&len);
-	EXPECT_EQ(len,10);
-	EXPECT_EQ((uint64_t)p,sge1.addr);
+	EXPECT_EQ(len, 10);
+	EXPECT_EQ((uint64_t)p, sge1.addr);
 
 	p = sa1.get_data(&len);
-	EXPECT_EQ((uint64_t)p,NULL);
+	EXPECT_EQ((uint64_t)p, NULL);
 }
 
 //! Tests for in_bound
 //
 TEST_F(sg_array_test, sga_in_bound)
 {
-	sg_array sa1(&sge1,1);
+	sg_array sa1(&sge1, 1);
 
 	int len = 5;
 	uint8_t *p = sa1.get_data(&len);
 
-	EXPECT_EQ(len,5);
-	EXPECT_EQ((uint64_t)p,sge1.addr);
+	EXPECT_EQ(len, 5);
+	EXPECT_EQ((uint64_t)p, sge1.addr);
 
 	len = 10;
 	p = sa1.get_data(&len);
 
-	EXPECT_EQ(len,5);
-	EXPECT_EQ(*p,'5');
+	EXPECT_EQ(len, 5);
+	EXPECT_EQ(*p, '5');
 }
 
 //! Tests for in_bound
 //
 TEST_F(sg_array_test, sga_in_bound_multi_sge)
 {
-	sg_array sa3(sge3,3);
+	sg_array sa3(sge3, 3);
 
 	int len = 5;
 	uint8_t *p = sa3.get_data(&len);
 
-	EXPECT_EQ(len,5);
-	EXPECT_EQ((uint64_t)p,sge3[0].addr);
+	EXPECT_EQ(len, 5);
+	EXPECT_EQ((uint64_t)p, sge3[0].addr);
 
 	len = 10;
 	p = sa3.get_data(&len);
 
-	EXPECT_EQ(len,5);
-	EXPECT_EQ(*p,'5');
+	EXPECT_EQ(len, 5);
+	EXPECT_EQ(*p, '5');
 
 	len = 15;
 	p = sa3.get_data(&len);
 
-	EXPECT_EQ(len,10);
-	EXPECT_EQ((uint64_t)p,sge3[1].addr);
+	EXPECT_EQ(len, 10);
+	EXPECT_EQ((uint64_t)p, sge3[1].addr);
 
 	len = 10;
 	p = sa3.get_data(&len);
 
-	EXPECT_EQ(len,10);
-	EXPECT_EQ((uint64_t)p,sge3[2].addr);
+	EXPECT_EQ(len, 10);
+	EXPECT_EQ((uint64_t)p, sge3[2].addr);
 }
 
 


### PR DESCRIPTION
It was split and consists of several commits:
1. issue: 1055917 TX Post-Send PRM enabled for non-VMAPOLL 
2. issue: 1055917 Tx of VMAPOLL will use MLX5 PostSend PRM
3. issue: 1055917  Helper class of scatter-gather elements array
4. issue: 1055917 Dynamic WQE feeling and inlining in BlueFlame
5. issue: 1055917 Dynamic WQE confirmation

All rebased to 8.4.1