### PR TITLE
issue: 1061103 Improve performance of epoll implementation

### DIFF
--- a/src/vma/iomux/epfd_info.cpp
+++ b/src/vma/iomux/epfd_info.cpp
@@ -30,14 +30,7 @@
  * SOFTWARE.
  */
 
-
-#include "utils/bullseye.h"
-#include "vlogger/vlogger.h"
-
-#include <vma/sock/sock-redirect.h>
-#include <vma/sock/socket_fd_api.h>
 #include <vma/sock/fd_collection.h>
-#include <vma/dev/net_device_table_mgr.h>
 #include <vma/iomux/epfd_info.h>
 
 #define MODULE_NAME "epfd_info:"
@@ -48,71 +41,7 @@
 
 #define CQ_FD_MARK 0xabcd
 
-inline void epfd_info::increase_ring_ref_count_no_lock(ring* ring)
-{
-	ring_map_t::iterator iter = m_ring_map.find(ring);
-	if (iter != m_ring_map.end()) {
-		//increase ref count
-		iter->second++;
-	} else {
-		m_ring_map[ring] = 1;
-
-		// add cq channel fd to the epfd
-		int num_ring_rx_fds = ring->get_num_resources();
-		int *ring_rx_fds_array = ring->get_rx_channel_fds();
-		for (int i = 0; i < num_ring_rx_fds; i++) {
-			epoll_event evt = {0, {0}};
-			evt.events = EPOLLIN | EPOLLPRI;
-			int fd = ring_rx_fds_array[i];
-			evt.data.u64 = (((uint64_t)CQ_FD_MARK << 32) | fd);
-			int ret = orig_os_api.epoll_ctl(m_epfd, EPOLL_CTL_ADD, fd, &evt);
-			BULLSEYE_EXCLUDE_BLOCK_START
-			if (ret < 0) {
-				__log_dbg("failed to add cq fd=%d to epoll epfd=%d (errno=%d %m)",
-						fd, m_epfd, errno);
-			} else {
-				__log_dbg("add cq fd=%d to epfd=%d", fd, m_epfd);
-			}
-			BULLSEYE_EXCLUDE_BLOCK_END
-		}
-	}
-}
-
-inline void epfd_info::decrease_ring_ref_count_no_lock(ring* ring)
-{
-	ring_map_t::iterator iter = m_ring_map.find(ring);
-	BULLSEYE_EXCLUDE_BLOCK_START
-	if (iter == m_ring_map.end()) {
-		__log_err("expected to find ring %p here!", ring);
-		return;
-	}
-	BULLSEYE_EXCLUDE_BLOCK_END
-
-	//decrease ref count
-	iter->second--;
-
-	if (iter->second == 0) {
-		m_ring_map.erase(iter);
-
-		// remove cq channel fd from the epfd
-		int num_ring_rx_fds = ring->get_num_resources();
-		int *ring_rx_fds_array = ring->get_rx_channel_fds();
-		for (int i = 0; i < num_ring_rx_fds; i++) {
-			// delete cq fd from epfd
-			int ret = orig_os_api.epoll_ctl(m_epfd, EPOLL_CTL_DEL, ring_rx_fds_array[i], NULL);
-			BULLSEYE_EXCLUDE_BLOCK_START
-			if (ret < 0) {
-				__log_dbg("failed to remove cq fd=%d from epfd=%d (errno=%d %m)",
-						ring_rx_fds_array[i], m_epfd, errno);
-			} else {
-				__log_dbg("remove cq fd=%d from epfd=%d", ring_rx_fds_array[i], m_epfd);
-			}
-			BULLSEYE_EXCLUDE_BLOCK_END
-		}
-	}
-}
-
-inline int epfd_info::remove_fd_from_epoll_os(int fd)
+int epfd_info::remove_fd_from_epoll_os(int fd)
 {
 	int ret = orig_os_api.epoll_ctl(m_epfd, EPOLL_CTL_DEL, fd, NULL);
 	BULLSEYE_EXCLUDE_BLOCK_START
@@ -159,6 +88,7 @@ epfd_info::epfd_info(int epfd, int size) :
 epfd_info::~epfd_info()
 {
 	__log_funcall("");
+	socket_fd_api* sock_fd;
 
 	// Meny: going over all handled fds and removing epoll context.
 
@@ -166,21 +96,26 @@ epfd_info::~epfd_info()
 
 	while(!m_ready_fds.empty())
 	{
-		socket_fd_api* sock_fd = m_ready_fds.get_and_pop_front();
+		sock_fd = m_ready_fds.get_and_pop_front();
 		sock_fd->m_epoll_event_flags = 0;
 	}
 
-	socket_fd_api* temp_sock_fd_api;
+	while(!m_fd_offloaded_list.empty())
+	{
+		sock_fd = m_fd_offloaded_list.get_and_pop_front();
+		sock_fd->m_fd_rec.reset();
+	}
+
 	for (int i = 0; i < m_n_offloaded_fds; i++) {
-		temp_sock_fd_api = fd_collection_get_sockfd(m_p_offloaded_fds[i]);
+		sock_fd = fd_collection_get_sockfd(m_p_offloaded_fds[i]);
 		BULLSEYE_EXCLUDE_BLOCK_START
-		if(temp_sock_fd_api) {
+		if (sock_fd) {
 			unlock();
 			m_ring_map_lock.lock();
-			temp_sock_fd_api->remove_epoll_context(this);
+			sock_fd->remove_epoll_context(this);
 			m_ring_map_lock.unlock();
 			lock();
-		}else {
+		} else {
 			__log_err("Invalid temp_sock_fd_api==NULL. Deleted fds should have been removed from epfd.");
 		}
 		BULLSEYE_EXCLUDE_BLOCK_END
@@ -225,29 +160,6 @@ int epfd_info::ctl(int op, int fd, epoll_event *event)
 	return ret;
 }
 
-#if _BullseyeCoverage
-    #pragma BullseyeCoverage off
-#endif
-
-int *epfd_info::get_offloaded_fds()
-{
-	return m_p_offloaded_fds;
-}
-
-int epfd_info::get_num_offloaded_fds()
-{
-	return m_n_offloaded_fds;
-}
-
-int *epfd_info::get_p_to_num_offloaded_fds()
-{
-	return &m_n_offloaded_fds;
-}
-
-#if _BullseyeCoverage
-    #pragma BullseyeCoverage on
-#endif
-
 void epfd_info::get_offloaded_fds_arr_and_size(int **p_p_num_offloaded_fds,
 					       int **p_p_offloadded_fds)
 {
@@ -271,6 +183,7 @@ bool epfd_info::is_cq_fd(uint64_t data)
 int epfd_info::add_fd(int fd, epoll_event *event)
 {
 	int ret;
+	epoll_fd_rec fd_rec;
 	epoll_event evt = {0, {0}};
 
 	bool is_offloaded = false;
@@ -295,7 +208,7 @@ int epfd_info::add_fd(int fd, epoll_event *event)
 	if (temp_sock_fd_api && temp_sock_fd_api->skip_os_select()) {
 		__log_dbg("fd=%d must be skipped from os epoll()", fd);
 		// Checking for duplicate fds
-		if (m_fd_info.find(fd) != m_fd_info.end()) {
+		if (get_fd_rec(fd, fd_rec)) {
 			errno = EEXIST;
 			__log_dbg("epoll_ctl: fd=%d is already registered with this epoll instance %d (errno=%d %m)", fd, m_epfd, errno);
 			return -1;
@@ -315,9 +228,9 @@ int epfd_info::add_fd(int fd, epoll_event *event)
 		BULLSEYE_EXCLUDE_BLOCK_END
 	}
 
-	m_fd_info[fd].events = event->events;
-	m_fd_info[fd].epdata = event->data;
-	m_fd_info[fd].offloaded_index = -1;
+	fd_rec.events = event->events;
+	fd_rec.epdata = event->data;
+
 	if (is_offloaded) {  // TODO: do we need to handle offloading only for one of read/write?
 		if (m_n_offloaded_fds >= m_size) {
 			__log_dbg("Reached max fds for epoll (%d)", m_size);
@@ -350,7 +263,10 @@ int epfd_info::add_fd(int fd, epoll_event *event)
 
 		m_p_offloaded_fds[m_n_offloaded_fds] = fd;
 		++m_n_offloaded_fds;
-		m_fd_info[fd].offloaded_index = m_n_offloaded_fds;
+
+		m_fd_offloaded_list.push_back(temp_sock_fd_api);
+		fd_rec.offloaded_index = m_n_offloaded_fds;
+		temp_sock_fd_api->m_fd_rec = fd_rec;
 
 		// if the socket is ready, add it to ready events
 		uint32_t events = 0;
@@ -364,12 +280,16 @@ int epfd_info::add_fd(int fd, epoll_event *event)
 			events |= EPOLLOUT;
 		}
 		if (events != 0) {
-			insert_epoll_event(fd, events); // mutex is recursive
+			insert_epoll_event(temp_sock_fd_api, events);
 		}
 		else{
 			do_wakeup();
 		}
+	} else {
+		fd_rec.offloaded_index = -1;
+		m_fd_non_offloaded_map[fd] = fd_rec;
 	}
+
 	__log_func("fd %d added in epfd %d with events=%#x and data=%#x", 
 		   fd, m_epfd, event->events, event->data);
 	return 0;
@@ -378,14 +298,69 @@ int epfd_info::add_fd(int fd, epoll_event *event)
 void epfd_info::increase_ring_ref_count(ring* ring)
 {
 	m_ring_map_lock.lock();
-	increase_ring_ref_count_no_lock(ring);
+	ring_map_t::iterator iter = m_ring_map.find(ring);
+	if (iter != m_ring_map.end()) {
+		//increase ref count
+		iter->second++;
+	} else {
+		m_ring_map[ring] = 1;
+
+		// add cq channel fd to the epfd
+		int num_ring_rx_fds = ring->get_num_resources();
+		int *ring_rx_fds_array = ring->get_rx_channel_fds();
+		for (int i = 0; i < num_ring_rx_fds; i++) {
+			epoll_event evt = {0, {0}};
+			evt.events = EPOLLIN | EPOLLPRI;
+			int fd = ring_rx_fds_array[i];
+			evt.data.u64 = (((uint64_t)CQ_FD_MARK << 32) | fd);
+			int ret = orig_os_api.epoll_ctl(m_epfd, EPOLL_CTL_ADD, fd, &evt);
+			BULLSEYE_EXCLUDE_BLOCK_START
+			if (ret < 0) {
+				__log_dbg("failed to add cq fd=%d to epoll epfd=%d (errno=%d %m)",
+						fd, m_epfd, errno);
+			} else {
+				__log_dbg("add cq fd=%d to epfd=%d", fd, m_epfd);
+			}
+			BULLSEYE_EXCLUDE_BLOCK_END
+		}
+	}
 	m_ring_map_lock.unlock();
 }
 
 void epfd_info::decrease_ring_ref_count(ring* ring)
 {
 	m_ring_map_lock.lock();
-	decrease_ring_ref_count_no_lock(ring);
+	ring_map_t::iterator iter = m_ring_map.find(ring);
+	BULLSEYE_EXCLUDE_BLOCK_START
+	if (iter == m_ring_map.end()) {
+		__log_err("expected to find ring %p here!", ring);
+		m_ring_map_lock.unlock();
+		return;
+	}
+	BULLSEYE_EXCLUDE_BLOCK_END
+
+	//decrease ref count
+	iter->second--;
+
+	if (iter->second == 0) {
+		m_ring_map.erase(iter);
+
+		// remove cq channel fd from the epfd
+		int num_ring_rx_fds = ring->get_num_resources();
+		int *ring_rx_fds_array = ring->get_rx_channel_fds();
+		for (int i = 0; i < num_ring_rx_fds; i++) {
+			// delete cq fd from epfd
+			int ret = orig_os_api.epoll_ctl(m_epfd, EPOLL_CTL_DEL, ring_rx_fds_array[i], NULL);
+			BULLSEYE_EXCLUDE_BLOCK_START
+			if (ret < 0) {
+				__log_dbg("failed to remove cq fd=%d from epfd=%d (errno=%d %m)",
+						ring_rx_fds_array[i], m_epfd, errno);
+			} else {
+				__log_dbg("remove cq fd=%d from epfd=%d", ring_rx_fds_array[i], m_epfd);
+			}
+			BULLSEYE_EXCLUDE_BLOCK_END
+		}
+	}
 	m_ring_map_lock.unlock();
 }
 
@@ -399,6 +374,7 @@ int epfd_info::del_fd(int fd, bool passthrough)
 {
 	__log_funcall("fd=%d", fd);
 
+	epoll_fd_rec fi;
 	socket_fd_api* temp_sock_fd_api = fd_collection_get_sockfd(fd);
 	if (temp_sock_fd_api && temp_sock_fd_api->skip_os_select()) {
 		__log_dbg("fd=%d must be skipped from os epoll()", fd);
@@ -407,18 +383,23 @@ int epfd_info::del_fd(int fd, bool passthrough)
 		remove_fd_from_epoll_os(fd);
 	}
 	
-	fd_info_map_t::iterator fd_iter = m_fd_info.find(fd);
-	if (fd_iter == m_fd_info.end()) {
+	if (!get_fd_rec(fd, fi)) {
 		errno = ENOENT;
 		return -1;
 	}
 	
-	// create a copy and remove the record from m_fd_info
-	epoll_fd_rec fi = fd_iter->second;
-	
-	if (!passthrough) m_fd_info.erase(fd_iter);
+	if (!passthrough) {
+		if (temp_sock_fd_api && temp_sock_fd_api->get_epoll_context_fd() == m_epfd) {
+			m_fd_offloaded_list.erase(temp_sock_fd_api);
+		} else {
+			fd_info_map_t::iterator fd_iter = m_fd_non_offloaded_map.find(fd);
+			if (fd_iter != m_fd_non_offloaded_map.end()) {
+				m_fd_non_offloaded_map.erase(fd_iter);
+			}
+		}
+	}
 
-	if(temp_sock_fd_api && temp_sock_fd_api->ep_ready_fd_node.is_list_member()) {
+	if (temp_sock_fd_api && temp_sock_fd_api->ep_ready_fd_node.is_list_member()) {
 		temp_sock_fd_api->m_epoll_event_flags = 0;
 		m_ready_fds.erase(temp_sock_fd_api);
 	}
@@ -434,14 +415,12 @@ int epfd_info::del_fd(int fd, bool passthrough)
 			m_p_offloaded_fds[fi.offloaded_index - 1] =
 					m_p_offloaded_fds[m_n_offloaded_fds - 1];
 
-			fd_iter = m_fd_info.find(m_p_offloaded_fds[m_n_offloaded_fds - 1]);
-
-			BULLSEYE_EXCLUDE_BLOCK_START
-			if (fd_iter == m_fd_info.end()) {
-				__log_warn("Failed to update the index of offloaded fd: %d\n", m_p_offloaded_fds[m_n_offloaded_fds - 1]);
-			BULLSEYE_EXCLUDE_BLOCK_END
-			}else {
-				fd_iter->second.offloaded_index = fi.offloaded_index;
+			socket_fd_api* last_socket = fd_collection_get_sockfd(m_p_offloaded_fds[m_n_offloaded_fds - 1]);
+			if (last_socket && last_socket->get_epoll_context_fd() == m_epfd) {
+				last_socket->m_fd_rec.offloaded_index = fi.offloaded_index;
+			} else {
+				__log_warn("Failed to update the index of offloaded fd: %d last_socket %p\n",
+						m_p_offloaded_fds[m_n_offloaded_fds - 1], last_socket);
 			}
 		}
 
@@ -449,6 +428,7 @@ int epfd_info::del_fd(int fd, bool passthrough)
 	}
 
 	if (temp_sock_fd_api) {
+		temp_sock_fd_api->m_fd_rec.reset();
 		unlock();
 		m_ring_map_lock.lock();
 		temp_sock_fd_api->remove_epoll_context(this);
@@ -460,33 +440,22 @@ int epfd_info::del_fd(int fd, bool passthrough)
 	return 0;
 }
 
-int epfd_info::clear_events_for_fd(int fd, uint32_t events)
-{
-	fd_info_map_t::iterator fd_iter = m_fd_info.find(fd);
-	if (fd_iter == m_fd_info.end()) {
-		errno = ENOENT;
-		return -1;
-	}
-	fd_iter->second.events &= ~events;
-	return 0;
-}
-
 int epfd_info::mod_fd(int fd, epoll_event *event)
 {
 	epoll_event evt;
+	epoll_fd_rec fd_rec;
 	int ret;
 
 	__log_funcall("fd=%d", fd);
-
 	// find the fd in local table
-	fd_info_map_t::iterator fd_iter = m_fd_info.find(fd);
-	if (fd_iter == m_fd_info.end()) {
+	if (!get_fd_rec(fd, fd_rec)) {
 		errno = ENOENT;
 		return -1;
 	}
 	
+	socket_fd_api* temp_sock_fd_api = fd_collection_get_sockfd(fd);
 	// check if fd is offloaded that new event mask is OK 
-	if (fd_iter->second.offloaded_index > 0) {
+	if (temp_sock_fd_api && temp_sock_fd_api->m_fd_rec.offloaded_index > 0) {
 		if (m_log_invalid_events && (event->events & ~SUPPORTED_EPOLL_EVENTS)) {
 			__log_dbg("invalid event mask 0x%x for offloaded fd=%d", event->events, fd);
 			__log_dbg("(event->events & ~%s)=0x%x", TO_STR(SUPPORTED_EPOLL_EVENTS),
@@ -495,7 +464,6 @@ int epfd_info::mod_fd(int fd, epoll_event *event)
 		}
 	}
 
-	socket_fd_api* temp_sock_fd_api = fd_collection_get_sockfd(fd);
 	if (temp_sock_fd_api && temp_sock_fd_api->skip_os_select()) {
 		__log_dbg("fd=%d must be skipped from os epoll()", fd);
 	}
@@ -514,8 +482,8 @@ int epfd_info::mod_fd(int fd, epoll_event *event)
 	}
 
 	// modify fd data in local table
-	fd_iter->second.epdata = event->data;
-	fd_iter->second.events = event->events;
+	fd_rec.epdata = event->data;
+	fd_rec.events = event->events;
 	
 	bool is_offloaded = temp_sock_fd_api && temp_sock_fd_api->get_type()== FD_TYPE_SOCKET;
 
@@ -532,11 +500,11 @@ int epfd_info::mod_fd(int fd, epoll_event *event)
 			events |= EPOLLOUT;
 		}
 		if (events != 0) {
-			insert_epoll_event(fd, events); // mutex is recursive
+			insert_epoll_event(temp_sock_fd_api, events);
 		}
 	}
 
-	if(event->events == 0 || events == 0){
+	if (event->events == 0 || events == 0) {
 		if (temp_sock_fd_api && temp_sock_fd_api->ep_ready_fd_node.is_list_member()) {
 			temp_sock_fd_api->m_epoll_event_flags = 0;
 			m_ready_fds.erase(temp_sock_fd_api);
@@ -548,104 +516,66 @@ int epfd_info::mod_fd(int fd, epoll_event *event)
 	return 0;
 }
 
-bool epfd_info::get_fd_rec_by_fd(int fd, epoll_fd_rec& fd_rec)
+bool epfd_info::get_fd_rec(int fd, epoll_fd_rec& fd_rec)
 {
-	fd_info_map_t::iterator iter = m_fd_info.find(fd);
-	if (iter != m_fd_info.end())
-		fd_rec = iter->second;
-	else {
-		__log_dbg("error - could not found fd %d in m_fd_info of epfd %d", fd, m_epfd);
-		return false;
-	}
-	return true;
-}
-
-bool epfd_info::get_data_by_fd(int fd, epoll_data *data)
-{
+	bool res = true;
+	socket_fd_api* temp_sock_fd_api = fd_collection_get_sockfd(fd);
 	lock();
-	fd_info_map_t::iterator iter = m_fd_info.find(fd);
-	if (iter != m_fd_info.end())
-		*data = m_fd_info[fd].epdata;
-	else {
-		__log_dbg("error - could not found fd %d in m_fd_info of epfd %d", fd, m_epfd);
-		unlock();
-		return false;
+
+	if (temp_sock_fd_api && temp_sock_fd_api->get_epoll_context_fd() == m_epfd) {
+		fd_rec = temp_sock_fd_api->m_fd_rec;
+	} else {
+		fd_info_map_t::iterator iter = m_fd_non_offloaded_map.find(fd);
+		if (iter != m_fd_non_offloaded_map.end()) {
+			fd_rec = iter->second;
+		} else {
+			res = false;
+		}
 	}
+
 	unlock();
-	return true;
+	return res;
 }
-
-#if _BullseyeCoverage
-    #pragma BullseyeCoverage off
-#endif
-
-bool epfd_info::is_offloaded_fd(int fd)
-{
-	fd_info_map_t::iterator iter;
-	iter = m_fd_info.find(fd);
-	return iter != m_fd_info.end() && iter->second.offloaded_index > 0;
-}
-
-#if _BullseyeCoverage
-    #pragma BullseyeCoverage on
-#endif
 
 void epfd_info::fd_closed(int fd, bool passthrough)
 {
+	epoll_fd_rec fd_rec;
 	lock();
-	if (m_fd_info.find(fd) != m_fd_info.end()) {
+	if (get_fd_rec(fd, fd_rec)) {
 		del_fd(fd, passthrough);
 	}
 	unlock();
 }
 
-void epfd_info::set_fd_as_offloaded_only(int fd)
+void epfd_info::insert_epoll_event_cb(socket_fd_api* sock_fd, uint32_t event_flags)
 {
 	lock();
-	if (m_fd_info.find(fd) != m_fd_info.end()) {
-		remove_fd_from_epoll_os(fd);
-	}
-	unlock();
-}
-
-void epfd_info::insert_epoll_event_cb(int fd, uint32_t event_flags)
-{
-	lock();
-	fd_info_map_t::iterator fd_iter = m_fd_info.find(fd);
-	if (fd_iter == m_fd_info.end()) {
-		unlock();
-		return;
-	}
 	//EPOLLHUP | EPOLLERR are reported without user request
-	if(event_flags & (fd_iter->second.events | EPOLLHUP | EPOLLERR)){
-		insert_epoll_event(fd, event_flags);
+	if (event_flags & (sock_fd->m_fd_rec.events | EPOLLHUP | EPOLLERR)) {
+		insert_epoll_event(sock_fd, event_flags);
 	}
 	unlock();
 }
 
-void epfd_info::insert_epoll_event(int fd, uint32_t event_flags)
+void epfd_info::insert_epoll_event(socket_fd_api *sock_fd, uint32_t event_flags)
 {
-	socket_fd_api* sock_fd = fd_collection_get_sockfd(fd);
-	if (sock_fd) {
-		if (sock_fd->ep_ready_fd_node.is_list_member()) {
-			sock_fd->m_epoll_event_flags |= event_flags;
-		}
-		else {
-			sock_fd->m_epoll_event_flags = event_flags;
-			m_ready_fds.push_back(sock_fd);
-		}
+	// assumed lock
+	if (sock_fd->ep_ready_fd_node.is_list_member()) {
+		sock_fd->m_epoll_event_flags |= event_flags;
 	}
+	else {
+		sock_fd->m_epoll_event_flags = event_flags;
+		m_ready_fds.push_back(sock_fd);
+	}
+
 	do_wakeup();
 }
 
-void epfd_info::remove_epoll_event(int fd, uint32_t event_flags)
+void epfd_info::remove_epoll_event(socket_fd_api *sock_fd, uint32_t event_flags)
 {
-	socket_fd_api* sock_fd = fd_collection_get_sockfd(fd);
-	if (sock_fd && sock_fd->ep_ready_fd_node.is_list_member()) {
-		sock_fd->m_epoll_event_flags &= ~event_flags;
-		if (sock_fd->m_epoll_event_flags == 0) {
-			m_ready_fds.erase(sock_fd);
-		}
+	sock_fd->m_epoll_event_flags &= ~event_flags;
+	if (sock_fd->m_epoll_event_flags == 0) {
+		m_ready_fds.erase(sock_fd);
 	}
 }
 

--- a/src/vma/iomux/epfd_info.h
+++ b/src/vma/iomux/epfd_info.h
@@ -34,33 +34,15 @@
 #ifndef VMA_EPOLL_H
 #define VMA_EPOLL_H
 
-#include <sys/epoll.h>
-#include <limits.h>
-#include <tr1/unordered_map>
-
-#include "utils/lock_wrapper.h"
-#include <vma/util/vma_stats.h>
-#include <vma/sock/cleanable_obj.h>
 #include <vma/util/wakeup_pipe.h>
-#include <vma/dev/ring.h>
+#include <vma/sock/cleanable_obj.h>
 #include <vma/sock/sockinfo.h>
 
-#define EP_MAX_EVENTS (int)((INT_MAX / sizeof(struct epoll_event)))
-
-typedef vma_list_t<socket_fd_api, socket_fd_api::ep_ready_fd_node_offset> ep_ready_fd_list_t;
-
-struct epoll_fd_rec
-{
-	uint32_t events;
-	epoll_data 	epdata;
-	int		offloaded_index; // offloaded fd index + 1
-	epoll_fd_rec():events(0), offloaded_index(0){}
-};
-
-
-typedef std::tr1::unordered_map<int, epoll_fd_rec> fd_info_map_t;
-typedef std::tr1::unordered_map<ring*, int /*ref count*/> ring_map_t;
-typedef std::deque<int> ready_cq_fd_q_t;
+typedef vma_list_t<socket_fd_api, socket_fd_api::ep_ready_fd_node_offset>   ep_ready_fd_list_t;
+typedef vma_list_t<socket_fd_api, socket_fd_api::ep_info_fd_node_offset>    fd_info_list_t;
+typedef std::tr1::unordered_map<int, epoll_fd_rec>                          fd_info_map_t;
+typedef std::tr1::unordered_map<ring*, int /*ref count*/>                   ring_map_t;
+typedef std::deque<int>                                                     ready_cq_fd_q_t;
 
 class epfd_info : public lock_mutex_recursive, public cleanable_obj, public wakeup_pipe
 {
@@ -73,21 +55,6 @@ public:
 	 * Arguments the same as for epoll_ctl()
 	 */
 	int ctl(int op, int fd, epoll_event *event);
-	
-	/**
-	 * @return Pointer to array of offloaded fd's.
-	 */
-	int *get_offloaded_fds();
-	
-	/**
-	 * @return Number of offloaded fds.
-	 */
-	int get_num_offloaded_fds();
-	
-	/**
-	 * @return pointer to the number of offloaded fds.
-	 */
-	int *get_p_to_num_offloaded_fds();
 
 	/**
 	 * Get the offloaded fds array and its length.
@@ -97,7 +64,6 @@ public:
 	void get_offloaded_fds_arr_and_size(int **p_p_num_offloaded_fds,
 				            int **p_p_offloadded_fds);
 
-
 	/**
 	 * check if fd is cq fd according to the data.
 	 * if it is, save the fd in ready cq fds queue.
@@ -105,27 +71,14 @@ public:
 	 * @return true if fd is cq fd
 	 */
 	bool is_cq_fd(uint64_t data);
-	
-	/**
-	 * Translates events from returned data to original user data
-	 * @return Number of events in dst
-	 */
-	int translate_ready_events(epoll_event *dst, epoll_event *src, int count);
-	
+
 	/**
 	 * Get the original user data posted with this fd.
 	 * @param fd File descriptor.
-	 * @param data Pointer to fill with user data.
+	 * @param fd_rec Reference to fill with user data.
+	 * @return True if the data for this fd was found.
 	 */
-	bool get_data_by_fd(int fd, epoll_data *data);
-
-	bool get_fd_rec_by_fd(int fd, epoll_fd_rec& fd_rec);
-
-	/**
-	 * @param fd File descriptor.
-	 * @return Whether given fd is and offloaded fd in this epfd set.
-	 */
-	bool is_offloaded_fd(int fd);
+	bool get_fd_rec(int fd, epoll_fd_rec& fd_rec);
 
 	/**
 	 * Called when fd is closed, to remove it from this set.
@@ -134,8 +87,6 @@ public:
 	void fd_closed(int fd, bool passthrough = false);
 
 	ep_ready_fd_list_t              m_ready_fds;
-
-	int clear_events_for_fd(int fd, uint32_t events);
 
 	/**
 	 * @return Pointer to statistics block for this group
@@ -157,180 +108,35 @@ public:
 
 private:
 
-	const int			m_epfd;
-	int					m_size;
-	int				*m_p_offloaded_fds;
-	int				m_n_offloaded_fds;
-	fd_info_map_t                   m_fd_info;
-	ring_map_t			m_ring_map;
-	lock_mutex_recursive		m_ring_map_lock;
-	const thread_mode_t		m_sysvar_thread_mode;
-	ready_cq_fd_q_t			m_ready_cq_fd_q;
-	epoll_stats_t                   m_local_stats;
-	epoll_stats_t                   *m_stats;
-	int				m_log_invalid_events;
-
-	/**
-	 * check whether a given file-descriptor is attached to epfd (offloaded)
-	 * ARGS: a file-descriptor to check for
-	 */
-	bool is_fd_in_use(int fd);
+	const int              m_epfd;
+	int                    m_size;
+	int                    *m_p_offloaded_fds;
+	int                    m_n_offloaded_fds;
+	fd_info_map_t          m_fd_non_offloaded_map;
+	fd_info_list_t         m_fd_offloaded_list;
+	ring_map_t             m_ring_map;
+	lock_mutex_recursive   m_ring_map_lock;
+	const thread_mode_t    m_sysvar_thread_mode;
+	ready_cq_fd_q_t        m_ready_cq_fd_q;
+	epoll_stats_t          m_local_stats;
+	epoll_stats_t          *m_stats;
+	int                    m_log_invalid_events;
 
 	int add_fd(int fd, epoll_event *event);
-
 	int del_fd(int fd, bool passthrough = false);
-
 	int mod_fd(int fd, epoll_event *event);
-
-	void increase_ring_ref_count_no_lock(ring* ring);
-	void decrease_ring_ref_count_no_lock(ring* ring);
-
-	inline int remove_fd_from_epoll_os(int fd);
 
 public:
 	int get_epoll_fd() {return m_epfd;};
-	const fd_info_map_t& get_fd_info() {return  m_fd_info;} // TODO: remove
-	void insert_epoll_event_cb(int fd, uint32_t event_flags);
-	void insert_epoll_event(int fd, uint32_t event_flags);
-	void remove_epoll_event(int fd, uint32_t event_flags);
+	int remove_fd_from_epoll_os(int fd);
+	inline size_t get_fd_non_offloaded_size() {return  m_fd_non_offloaded_map.size();}
+	inline size_t get_fd_offloaded_size() {return  m_fd_offloaded_list.size();}
+	void insert_epoll_event_cb(socket_fd_api* sock_fd, uint32_t event_flags);
+	void insert_epoll_event(socket_fd_api *sock_fd, uint32_t event_flags);
+	void remove_epoll_event(socket_fd_api *sock_fd, uint32_t event_flags);
 	void increase_ring_ref_count(ring* ring);
 	void decrease_ring_ref_count(ring* ring);
-	void set_fd_as_offloaded_only(int fd);
-
 };
 
-
-#if 0
-/**
- *-----------------------------------------------------------------------------
- *  class Epoll_fd_tbl
- *  Track the usage of epoll file descriptors per process
- *-----------------------------------------------------------------------------
- */
-
-class Epoll_fd_tbl {
-public:
-
-	typedef std::map<int /*epfd*/, epfd_info> epoll_handle_map_t;
-
-
-	// CTOR/DTOR
-	Epoll_fd_tbl()		{};
-	~Epoll_fd_tbl() 	{vlog_printf(VLOG_DEBUG,"%s\n", __func__);};
-
-	int insert_epfd(int epfd) {  // insert
-		epfd_info  newVal;
-		newVal.m_is_poll_last = false;
-		newVal.m_epfd = epfd;
-		epfd_map_mtx.lock();
-		//Sr_lock_t srl(&mtx);	// lock!
-		epoll_handle_map_t::iterator iter = epoll_handle_map.find(epfd);
-		if (iter != epoll_handle_map.end()) {
-			// 'epfd' entry exists in epoll_handle_map
-			epfd_map_mtx.unlock();
-			vlog_printf(VLOG_ERROR,"%s: epfd %d is already in poll_handle_map\n",__func__,epfd);
-			return -1;
-		}
-		else
-			epoll_handle_map[epfd] = newVal;    // insert entry into tbl & mark 'fd' valid
-		epfd_map_mtx.unlock();
-		return 0;
-	}
-
-	int del_epfd(int epfd) {  //del
-		vlog_printf(VLOG_FUNC,"%s epfd=%d\n",__func__,epfd);
-		epfd_map_mtx.lock();
-		epoll_handle_map_t::iterator iter = epoll_handle_map.find(epfd);
-		if (iter != epoll_handle_map.end()) {
-			iter->second.m_epfd_info_mtx.lock(); // Lock epfd
-			epoll_handle_map.erase(iter);
-			epfd_map_mtx.unlock();
-			vlog_printf(VLOG_DEBUG,"%s: epfd %d is deleted\n",__func__,epfd);
-			return 0;
-		}
-		// 'epfd' entry doesn't exist in tbl
-		vlog_printf(VLOG_ERROR,"%s: epfd %d doesn't exist\n",__func__,epfd);
-		epfd_map_mtx.unlock();
-		return -1;
-	}
-
-
-	bool find_and_lock_epfd_info(int epfd, epfd_info ** pData) {
-		epfd_map_mtx.lock();
-		epoll_handle_map_t::iterator iter = epoll_handle_map.find(epfd);
-		if (iter != epoll_handle_map.end()) {  // 'fd' entry exists in tbl
-			iter->second.m_epfd_info_mtx.lock();
-			*pData = &(iter->second);
-			epfd_map_mtx.unlock();
-			return true;
-		}
-		epfd_map_mtx.unlock();
-		vlog_printf(VLOG_DEBUG,"%s: epfd %d wasn't found\n",__func__, epfd);
-		pData = NULL;
-		errno = EINVAL;
-		return false;
-	}
-
-
-	/**
-	 * check whether given epoll file-descriptor is in the epoll_handle_map (i.e. used by the app)
-	 * ARGS:    I: file-descriptor to check for
-	 */
-	bool is_epfd_in_use(int epfd) {
-		epfd_map_mtx.lock();
-		epoll_handle_map_t::const_iterator iter = epoll_handle_map.find(epfd);
-		if (iter != epoll_handle_map.end()) {
-			// 'epfd' entry exists in tbl
-			epfd_map_mtx.unlock();
-			return true;
-		}
-		epfd_map_mtx.unlock();
-		return false;
-	}
-
-
-
-	 /**
-	  * erase a given file-descriptor from the DB ( offloaded map or not offloaded map).
-	  * ARGS:    I: file-descriptor to check for
-	  */
-	void del_fd(int fd) {
-		vlog_printf(VLOG_FUNC,"%s: fd %d\n",__func__,fd);
-		epfd_map_mtx.lock();
-		for (epoll_handle_map_t::iterator iter = epoll_handle_map.begin(); iter != epoll_handle_map.end(); iter++) {
-			iter->second.m_epfd_info_mtx.lock();
-			iter->second.del_not_offloaded_fd(fd);
-			iter->second.del_fd(fd);
-			iter->second.m_epfd_info_mtx.unlock();
-		 }
-		 epfd_map_mtx.unlock();
-	}
-
-
-	// list the content of the table - For Debug!
-	void list_epoll_fd_tbl() {
-		vlog_printf(VLOG_DEBUG,"%s: tbl contains %d socket(s)\n",__func__, epoll_handle_map.size());
-		//int num = 0;
-		for (epoll_handle_map_t::iterator iter = epoll_handle_map.begin(); iter != epoll_handle_map.end(); iter++) {
-			printf("%s: epfd=%d\n",__func__,iter->first);
-			for (epfd_info::offloaded_epoll_fd_map_t::iterator fd_iter = iter->second.m_offloaded_epoll_fd_map.begin(); fd_iter != iter->second.m_offloaded_epoll_fd_map.end(); fd_iter++)
-				printf("%s: \t offloaded fd = %d events = %d  events.fd = %d \n",__func__,fd_iter->first, fd_iter->second.events, fd_iter->second.data.fd);
-
-			for (epfd_info::not_offloaded_epoll_fd_map_t::iterator fd2_iter = iter->second.m_not_offloaded_epoll_fd_map.begin(); fd2_iter != iter->second.m_not_offloaded_epoll_fd_map.end(); fd2_iter++)
-				printf("%s: \t not offloaded fd = %d user fd = %ld\n",__func__, fd2_iter->first, (long int)fd2_iter->second);
-		}
-	}
-
-private:
-	epoll_handle_map_t	epoll_handle_map;
-	lock_mutex		epfd_map_mtx;
-};
-
-
-
-
-extern Epoll_fd_tbl * g_p_epfd_map;
-
-#endif
 #endif
 

--- a/src/vma/iomux/epfd_info.h
+++ b/src/vma/iomux/epfd_info.h
@@ -75,10 +75,9 @@ public:
 	/**
 	 * Get the original user data posted with this fd.
 	 * @param fd File descriptor.
-	 * @param fd_rec Reference to fill with user data.
-	 * @return True if the data for this fd was found.
+	 * @return Pointer to user data if the data for this fd was found.
 	 */
-	bool get_fd_rec(int fd, epoll_fd_rec& fd_rec);
+	epoll_fd_rec* get_fd_rec(int fd);
 
 	/**
 	 * Called when fd is closed, to remove it from this set.

--- a/src/vma/iomux/epoll_wait_call.cpp
+++ b/src/vma/iomux/epoll_wait_call.cpp
@@ -170,7 +170,7 @@ bool epoll_wait_call::_wait(int timeout)
 {
 	int i, ready_fds, fd;
 	bool cq_ready = false;
-	epoll_fd_rec fd_rec;
+	epoll_fd_rec* fd_rec;
 
 	__log_func("calling os epoll: %d", m_epfd);
 
@@ -231,8 +231,9 @@ bool epoll_wait_call::_wait(int timeout)
 
 		// Copy event bits and data
 		m_events[m_n_all_ready_fds].events = m_p_ready_events[i].events;
-		if (m_epfd_info->get_fd_rec(fd, fd_rec)) {
-			m_events[m_n_all_ready_fds].data = fd_rec.epdata;
+		fd_rec = m_epfd_info->get_fd_rec(fd);
+		if (fd_rec) {
+			m_events[m_n_all_ready_fds].data = fd_rec->epdata;
 			++m_n_all_ready_fds;
 		} else {
 			__log_dbg("error - could not found fd %d in m_fd_info of epfd %d", fd, m_epfd);

--- a/src/vma/iomux/epoll_wait_call.cpp
+++ b/src/vma/iomux/epoll_wait_call.cpp
@@ -69,8 +69,8 @@ void epoll_wait_call::init_offloaded_fds()
 	m_epfd_info->get_offloaded_fds_arr_and_size(&m_p_num_all_offloaded_fds, &m_p_all_offloaded_fds);
 	m_num_all_offloaded_fds = *m_p_num_all_offloaded_fds; // TODO: fix orig ugly code, and then remove this
 
-	__log_func("building: epfd=%d, m_epfd_info->get_fd_info().size()=%d, *m_p_num_all_offloaded_fds=%d", m_epfd, (int)m_epfd_info->get_fd_info().size(), (int)*m_p_num_all_offloaded_fds  );
-
+	__log_func("building: epfd=%d, m_epfd_info->get_fd_offloaded_size()=%zu, m_epfd_info->get_fd_non_offloaded_size()=%zu, *m_p_num_all_offloaded_fds=%d",
+			m_epfd, m_epfd_info->get_fd_offloaded_size(), m_epfd_info->get_fd_non_offloaded_size(), *m_p_num_all_offloaded_fds);
 }
 
 int epoll_wait_call::get_current_events()
@@ -81,24 +81,20 @@ int epoll_wait_call::get_current_events()
 
 	vma_list_t<socket_fd_api, socket_fd_api::socket_fd_list_node_offset> socket_fd_list;
 	lock();
-	int i,r,w,fd;
-	i = r = w = m_n_all_ready_fds;
+	int i, ready_rfds = 0, ready_wfds = 0;
+	i = m_n_all_ready_fds;
 	socket_fd_api *p_socket_object;
-	epoll_fd_rec fd_rec;
 	list_iterator_t<socket_fd_api, socket_fd_api::ep_ready_fd_node_offset> iter = m_epfd_info->m_ready_fds.begin();
 	while (iter != m_epfd_info->m_ready_fds.end() && i < m_maxevents) {
 		p_socket_object = *iter;
-		fd = p_socket_object->get_fd();
 		++iter;
-
-		if(!m_epfd_info->get_fd_rec_by_fd(fd, fd_rec)) continue;
 
 		m_events[i].events = 0; //initialize
 
 		bool got_event = false;
 
 		//epoll_wait will always wait for EPOLLERR and EPOLLHUP; it is not necessary to set it in events.
-		uint32_t mutual_events = p_socket_object->m_epoll_event_flags & (fd_rec.events | EPOLLERR | EPOLLHUP);
+		uint32_t mutual_events = p_socket_object->m_epoll_event_flags & (p_socket_object->m_fd_rec.events | EPOLLERR | EPOLLHUP);
 
 		//EPOLLHUP & EPOLLOUT are mutually exclusive. see poll man pages. epoll adapt poll behavior.
 		if ((mutual_events & EPOLLHUP) &&  (mutual_events & EPOLLOUT)) {
@@ -106,23 +102,23 @@ int epoll_wait_call::get_current_events()
 		}
 
 		if (mutual_events & EPOLLIN) {
-			if (handle_epoll_event(p_socket_object->is_readable(NULL), EPOLLIN, fd, fd_rec, i)) {
-				r++;
+			if (handle_epoll_event(p_socket_object->is_readable(NULL), EPOLLIN, p_socket_object, i)) {
+				ready_rfds++;
 				got_event = true;
 			}
 			mutual_events &= ~EPOLLIN;
 		}
 
 		if (mutual_events & EPOLLOUT) {
-			if (handle_epoll_event(p_socket_object->is_writeable(), EPOLLOUT, fd, fd_rec, i)) {
-				w++;
+			if (handle_epoll_event(p_socket_object->is_writeable(), EPOLLOUT, p_socket_object, i)) {
+				ready_wfds++;
 				got_event = true;
 			}
 			mutual_events &= ~EPOLLOUT;
 		}
 
 		if (mutual_events) {
-			if (handle_epoll_event(true, mutual_events, fd, fd_rec, i)) {
+			if (handle_epoll_event(true, mutual_events, p_socket_object, i)) {
 				got_event = true;
 			}
 		}
@@ -133,8 +129,6 @@ int epoll_wait_call::get_current_events()
 		}
 	}
 
-	int ready_rfds = r - m_n_all_ready_fds; //MNY: not only rfds, different counters for read/write ?
-	int ready_wfds = w - m_n_all_ready_fds;
 	m_n_ready_rfds += ready_rfds;
 	m_n_ready_wfds += ready_wfds;
 	m_p_stats->n_iomux_rx_ready += ready_rfds;
@@ -176,6 +170,7 @@ bool epoll_wait_call::_wait(int timeout)
 {
 	int i, ready_fds, fd;
 	bool cq_ready = false;
+	epoll_fd_rec fd_rec;
 
 	__log_func("calling os epoll: %d", m_epfd);
 
@@ -225,7 +220,7 @@ bool epoll_wait_call::_wait(int timeout)
 			continue;
 		}
 		
-		if ((m_p_ready_events[i].events & EPOLLIN)) {
+		if (m_p_ready_events[i].events & EPOLLIN) {
 			socket_fd_api* temp_sock_fd_api = fd_collection_get_sockfd(fd);
 			if (temp_sock_fd_api) {
 				// Instructing the socket to sample the OS immediately to prevent hitting EAGAIN on recvfrom(),
@@ -236,10 +231,12 @@ bool epoll_wait_call::_wait(int timeout)
 
 		// Copy event bits and data
 		m_events[m_n_all_ready_fds].events = m_p_ready_events[i].events;
-		if (!m_epfd_info->get_data_by_fd(fd, &m_events[m_n_all_ready_fds].data)) {
-			continue;
+		if (m_epfd_info->get_fd_rec(fd, fd_rec)) {
+			m_events[m_n_all_ready_fds].data = fd_rec.epdata;
+			++m_n_all_ready_fds;
+		} else {
+			__log_dbg("error - could not found fd %d in m_fd_info of epfd %d", fd, m_epfd);
 		}
-		++m_n_all_ready_fds;
 	}
 	
 	return cq_ready;
@@ -342,24 +339,25 @@ bool epoll_wait_call::immidiate_return()
 	return false;
 }
 
-bool epoll_wait_call::handle_epoll_event(bool is_ready, uint32_t events, int fd, epoll_fd_rec fd_rec, int index)
+bool epoll_wait_call::handle_epoll_event(bool is_ready, uint32_t events, socket_fd_api *socket_object, int index)
 {
 	if (is_ready) {
-
+		epoll_fd_rec& fd_rec = socket_object->m_fd_rec;
 		m_events[index].data = fd_rec.epdata;
 		m_events[index].events |= events;
 
 		if (fd_rec.events & EPOLLONESHOT) {
-			m_epfd_info->clear_events_for_fd(fd, events);
+			// Clear events for this fd
+			fd_rec.events &= ~events;
 		}
 		if (fd_rec.events & EPOLLET) {
-			m_epfd_info->remove_epoll_event(fd, events);
+			m_epfd_info->remove_epoll_event(socket_object, events);
 		}
 		return true;
 	}
 	else {
 		// not readable, need to erase from our ready list (LT support)
-		m_epfd_info->remove_epoll_event(fd, events);
+		m_epfd_info->remove_epoll_event(socket_object, events);
 		return false;
 	}
 

--- a/src/vma/iomux/epoll_wait_call.h
+++ b/src/vma/iomux/epoll_wait_call.h
@@ -104,7 +104,7 @@ public:
 
 	int get_current_events();
 
-	bool handle_epoll_event(bool is_ready, uint32_t events, int fd, epoll_fd_rec fd_rec, int index);
+	bool handle_epoll_event(bool is_ready, uint32_t events, socket_fd_api *socket_object, int index);
 
 protected:
 	virtual int ring_poll_and_process_element(uint64_t *p_poll_sn, void* pv_fd_ready_array = NULL);

--- a/src/vma/sock/sock-redirect.cpp
+++ b/src/vma/sock/sock-redirect.cpp
@@ -79,6 +79,7 @@ using namespace std;
 #define srdr_logdbg_exit	__log_exit_dbg
 #define srdr_logfunc_exit	__log_exit_func
 
+#define EP_MAX_EVENTS (int)((INT_MAX / sizeof(struct epoll_event)))
 
 struct os_api orig_os_api;
 struct sigaction g_act_prev;

--- a/src/vma/sock/socket_fd_api.cpp
+++ b/src/vma/sock/socket_fd_api.cpp
@@ -229,30 +229,18 @@ bool socket_fd_api::is_errorable(int *errors)
 	return false;
 }
 
-#if _BullseyeCoverage
-    #pragma BullseyeCoverage off
-#endif
 void socket_fd_api::statistics_print(vlog_levels_t log_level /* = VLOG_DEBUG */)
 {
-	int epoll_fd;
-	epoll_fd_rec epoll_fd_rec;
-
-	// Prepare data
-	if ((epoll_fd = socket_fd_api::get_epoll_context_fd())) {
-		m_econtext->get_fd_rec_by_fd(m_fd, epoll_fd_rec);
-	}
+	int epoll_fd = get_epoll_context_fd();
 
 	// Socket data
 	vlog_printf(log_level, "Fd number : %d\n", m_fd);
 	if (epoll_fd) {
 		vlog_printf(log_level, "Socket epoll Fd : %d\n", epoll_fd);
-		vlog_printf(log_level, "Socket epoll flags : 0x%x\n", epoll_fd_rec.events);
+		vlog_printf(log_level, "Socket epoll flags : 0x%x\n", m_fd_rec.events);
 	}
 
 }
-#if _BullseyeCoverage
-    #pragma BullseyeCoverage on
-#endif
 
 ssize_t socket_fd_api::rx_os(const rx_call_t call_type, iovec* p_iov,
 			     ssize_t sz_iov, const int flags, sockaddr *__from,
@@ -388,7 +376,7 @@ void socket_fd_api::remove_epoll_context(epfd_info *epfd)
 void socket_fd_api::notify_epoll_context(uint32_t events)
 {
 	if (m_econtext) {
-		m_econtext->insert_epoll_event_cb(m_fd, events);
+		m_econtext->insert_epoll_event_cb(this, events);
 	}
 }
 
@@ -414,7 +402,7 @@ bool socket_fd_api::notify_epoll_context_verify(epfd_info *epfd)
 void socket_fd_api::notify_epoll_context_fd_is_offloaded()
 {
 	if (m_econtext) {
-		m_econtext->set_fd_as_offloaded_only(m_fd);
+		m_econtext->remove_fd_from_epoll_os(m_fd);
 	}
 }
 

--- a/src/vma/sock/socket_fd_api.h
+++ b/src/vma/sock/socket_fd_api.h
@@ -56,8 +56,24 @@
 
 class cq_mgr;
 class epfd_info;
-
 class mem_buf_desc_t;
+
+struct epoll_fd_rec
+{
+	uint32_t    events;
+	epoll_data  epdata;
+	int         offloaded_index; // offloaded fd index + 1
+
+	epoll_fd_rec() {
+		reset();
+	}
+
+	void reset() {
+		this->events = 0;
+		memset(&this->epdata, 0, sizeof(this->epdata));
+		this->offloaded_index = 0;
+	}
+};
 
 typedef enum {
 	TX_WRITE = 13, TX_WRITEV, TX_SEND, TX_SENDTO, TX_SENDMSG, TX_UNDEF
@@ -225,8 +241,12 @@ public:
 
 	static inline size_t ep_ready_fd_node_offset(void) {return NODE_OFFSET(socket_fd_api, ep_ready_fd_node);}
 	list_node<socket_fd_api, socket_fd_api::ep_ready_fd_node_offset> ep_ready_fd_node;
-
 	uint32_t m_epoll_event_flags;
+
+	static inline size_t ep_info_fd_node_offset(void) {return NODE_OFFSET(socket_fd_api, ep_info_fd_node);}
+	list_node<socket_fd_api, socket_fd_api::ep_info_fd_node_offset> ep_info_fd_node;
+	epoll_fd_rec m_fd_rec;
+
 	virtual int get_rings_num() {return 0;}
 	virtual bool check_rings() {return false;}
 	virtual int* get_rings_fds(int& res_length) { res_length=0; return NULL;}


### PR DESCRIPTION
In fd_info_map_t (epoll_info.h) convert from std::tr1::unordered_map
to vma_list type

This PR include the following bug fixes:

1. Fix index in epoll_wait_call.cpp
2. Fix 1064536 register 1 socket to 2 epoll fds shows VMA Error buff is already a member in a list
3. Fix 1063125 ConnectX-4 Eth: Sockperf doesn't work on epoll management port
4. Fix 1063119 ConnectX-4 Eth: Sockperf doesn't work with management and multicast sockets

Signed-off-by: Liran Oz <lirano@mellanox.com>