### PR TITLE
issue: 1067880 Scatter/gather array helper

### DIFF
--- a/src/vma/Makefile.am
+++ b/src/vma/Makefile.am
@@ -273,12 +273,14 @@ libvma_la_SOURCES := \
 	sock/sockinfo_udp.h \
 	sock/sock-redirect.h \
 	\
+	util/chunk_list.h \
 	util/hash_map.h \
 	util/if.h \
 	util/instrumentation.h \
 	util/libvma.h \
 	util/linked_unordered_map.h \
 	util/list.h \
+	util/sg_array.h \
 	util/sock_addr.h \
 	util/sysctl_reader.h \
 	util/sys_vars.h \
@@ -287,7 +289,6 @@ libvma_la_SOURCES := \
 	util/valgrind.h \
 	util/verbs_extra.h \
 	util/vma_list.h \
-	util/chunk_list.h \
 	util/vma_stats.h \
 	util/vtypes.h \
 	util/wakeup.h \

--- a/src/vma/util/sg_array.h
+++ b/src/vma/util/sg_array.h
@@ -1,0 +1,118 @@
+/*
+ * Copyright (c) 2017 Mellanox Technologies, Ltd. All rights reserved.
+ *
+ * This software is available to you under a choice of one of two
+ * licenses.  You may choose to be licensed under the terms of the GNU
+ * General Public License (GPL) Version 2, available from the file
+ * COPYING in the main directory of this source tree, or the
+ * BSD license below:
+ *
+ *     Redistribution and use in source and binary forms, with or
+ *     without modification, are permitted provided that the following
+ *     conditions are met:
+ *
+ *      - Redistributions of source code must retain the above
+ *        copyright notice, this list of conditions and the following
+ *        disclaimer.
+ *
+ *      - Redistributions in binary form must reproduce the above
+ *        copyright notice, this list of conditions and the following
+ *        disclaimer in the documentation and/or other materials
+ *        provided with the distribution.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+ * BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ * ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#ifndef SG_ARRAY_H
+#define SG_ARRAY_H
+
+#include <stdio.h>
+#include "util/verbs_extra.h"
+
+//@@ sg_array - helper class on top of scatter/gather elements array.
+//Represent it like a virtual one dimension vector/array.
+
+class sg_array {
+public:
+	sg_array(ibv_sge *sg_, int num_sge_):
+	 m_sg(sg_)
+	,m_current(sg_)
+	,m_num_sge(num_sge_)
+	,m_length(0)
+	,m_index(0)
+	,m_pos(0)
+	{
+		if (m_sg == NULL)
+			return;
+
+		for (int i=0; i<m_num_sge; i++)
+			m_length += m_sg[i].length;
+	}
+//@@ Index operator
+//TODO: testing
+	inline uint8_t* operator[](int ind_)
+	{
+		int index = -1;
+		int pos = 0;
+		if (unlikely(m_sg == NULL))
+			return NULL;
+		while (index++ <= m_num_sge) {
+
+			if (pos+m_sg[index].length > ind_) {
+				return (uint8_t*)m_sg[index].addr+(ind_-pos);
+			} else {
+				pos += m_sg[index].length;
+			}
+		}
+		return NULL;
+	}
+//@@ Get pointer to data for get_len size from current position.
+//In case there is no full requested range in current SGE returns
+//the rest in current sge. Next call will start from the beginning
+//of next SGE
+	inline uint8_t* get_data(int* get_len)
+	{
+		if (likely(m_sg != NULL && m_index < m_num_sge)) {
+
+			m_current = m_sg + m_index;
+
+			if (likely((m_pos+*get_len) < (int)m_current->length)) {
+				m_pos += *get_len;
+				if (unlikely(m_pos < 0))
+					return NULL;
+				return (uint8_t*)m_current->addr;
+			} else {
+				*get_len = m_current->length - m_pos;
+
+				if (unlikely(m_pos < 0))
+					return NULL;
+				uint8_t* old_p = (uint8_t*)m_sg[m_index++].addr+m_pos;
+				// moving to next sge
+				m_pos = 0;
+				return old_p;
+			}
+		}
+		return NULL;
+	}
+
+	inline int get_num_sge(void) { return m_sg ? m_num_sge : -1; }
+	inline int length(void) { return m_length; }
+
+private:
+	struct ibv_sge*	m_sg;
+	struct ibv_sge* m_current;
+	int     	m_num_sge;
+	int		m_length;
+	int		m_index;
+	int     	m_pos;
+
+};
+
+#endif // SG_ARRAY_H

--- a/tests/gtest/Makefile.am
+++ b/tests/gtest/Makefile.am
@@ -18,6 +18,8 @@ gtest_SOURCES = \
 	\
 	common/base.cc \
 	\
+	aux/sg_array.cc \
+	\
 	tcp/tcp_base.cc \
 	tcp/tcp_socket.cc \
 	tcp/tcp_bind.cc \

--- a/tests/gtest/aux/sg_array.cc
+++ b/tests/gtest/aux/sg_array.cc
@@ -1,0 +1,175 @@
+/*
+ * Copyright (c) 2017 Mellanox Technologies, Ltd. All rights reserved.
+ *
+ * This software is available to you under a choice of one of two
+ * licenses.  You may choose to be licensed under the terms of the GNU
+ * General Public License (GPL) Version 2, available from the file
+ * COPYING in the main directory of this source tree, or the
+ * BSD license below:
+ *
+ *     Redistribution and use in source and binary forms, with or
+ *     without modification, are permitted provided that the following
+ *     conditions are met:
+ *
+ *      - Redistributions of source code must retain the above
+ *        copyright notice, this list of conditions and the following
+ *        disclaimer.
+ *
+ *      - Redistributions in binary form must reproduce the above
+ *        copyright notice, this list of conditions and the following
+ *        disclaimer in the documentation and/or other materials
+ *        provided with the distribution.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+ * BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ * ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+#include "common/def.h"
+#include "vma/util/verbs_extra.h"
+#include "vma/util/sg_array.h"
+
+class sg_array_test : public ::testing::Test {
+public:
+	struct ibv_sge*	sge0;
+	struct ibv_sge	sge1;
+	struct ibv_sge	sge2[2];
+	struct ibv_sge	sge3[3];
+	sg_array_test()
+	{
+		sge0 = NULL;
+
+		sge1.addr = (uint64_t)"0123456789";
+		sge1.length = 10;
+
+		sge2[0].addr = (uint64_t)"0123456789";
+		sge2[0].length = 10;
+		sge2[1].addr = (uint64_t)"0123456789";
+		sge2[1].length = 10;
+
+		sge3[0].addr = (uint64_t)"0123456789";
+		sge3[0].length = 10;
+		sge3[1].addr = (uint64_t)"0123456789";
+		sge3[1].length = 10;
+		sge3[2].addr = (uint64_t)"0123456789";
+		sge3[2].length = 10;
+	}
+
+};
+//@@ Tests for constructor
+TEST_F(sg_array_test, sga_ctr)
+{
+	sg_array	sa0(sge0,0);
+	EXPECT_EQ(-1,sa0.get_num_sge());
+	EXPECT_EQ(0,sa0.length());
+
+	sg_array	sa1(&sge1,1);
+	EXPECT_EQ(1,sa1.get_num_sge());
+	EXPECT_EQ(10,sa1.length());
+
+	sg_array	sa2(sge2,2);
+	EXPECT_EQ(2,sa2.get_num_sge());
+	EXPECT_EQ(20,sa2.length());
+
+	sg_array	sa3(sge3,3);
+	EXPECT_EQ(3,sa3.get_num_sge());
+	EXPECT_EQ(30,sa3.length());
+
+}
+
+//@@ Tests for relative index
+//
+TEST_F(sg_array_test, sga_index_0)
+{
+	sg_array sa0(sge0,0);
+	EXPECT_EQ(NULL,sa0.get_data(0));
+
+	sg_array sa1(&sge1,1);
+	EXPECT_EQ(NULL,sa0.get_data(0));
+}
+
+//@@ Tests for minimum bound
+//
+TEST_F(sg_array_test, sga_min_bound)
+{
+	sg_array sa0(sge0,0);
+	int	len=-1;
+	EXPECT_EQ(NULL,sa0.get_data(&len));
+
+	sg_array sa1(&sge1,1);
+	EXPECT_EQ(NULL,sa1.get_data(&len));
+}
+
+//@@ Test for maximum bound
+//
+TEST_F(sg_array_test, sga_max_bound)
+{
+	sg_array sa0(sge0,0);
+	int len = 1;
+	EXPECT_EQ(NULL,sa0.get_data(&len));
+
+	sg_array sa1(&sge1,1);
+	len = 11;
+	uint8_t *p = sa1.get_data(&len);
+	EXPECT_EQ(len,10);
+	EXPECT_EQ((uint64_t)p,sge1.addr);
+
+	p = sa1.get_data(&len);
+	EXPECT_EQ((uint64_t)p,NULL);
+}
+
+// @@ Tests for in_bound
+//
+TEST_F(sg_array_test, sga_in_bound)
+{
+	sg_array sa1(&sge1,1);
+
+	int len = 5;
+	uint8_t *p = sa1.get_data(&len);
+
+	EXPECT_EQ(len,5);
+	EXPECT_EQ((uint64_t)p,sge1.addr);
+
+	len = 10;
+	p = sa1.get_data(&len);
+
+	EXPECT_EQ(len,5);
+	EXPECT_EQ(*p,'5');
+}
+
+// @@ Tests for in_bound
+//
+TEST_F(sg_array_test, sga_in_bound_multi_sge)
+{
+	sg_array sa3(sge3,3);
+
+	int len = 5;
+	uint8_t *p = sa3.get_data(&len);
+
+	EXPECT_EQ(len,5);
+	EXPECT_EQ((uint64_t)p,sge3[0].addr);
+
+	len = 10;
+	p = sa3.get_data(&len);
+
+	EXPECT_EQ(len,5);
+	EXPECT_EQ(*p,'5');
+
+	len = 15;
+	p = sa3.get_data(&len);
+
+	EXPECT_EQ(len,10);
+	EXPECT_EQ((uint64_t)p,sge3[1].addr);
+
+	len = 10;
+	p = sa3.get_data(&len);
+
+	EXPECT_EQ(len,10);
+	EXPECT_EQ((uint64_t)p,sge3[2].addr);
+}
+
+


### PR DESCRIPTION
sg_array allows to represent scatter/gather buffers array as virtually
contiguous one-dimensional vector/array of one buffer.

get_data() requests some amount of data and returns pointer to it.
When there is no requested amount of data get_data() will return
remaining from current SGE and next call will move to next SGE or
return NULL.

Signed-off-by: Oleg Kuporosov <olegk@mellanox.com>