### PR TITLE
issue: 1078695 Disable ring migration for RING_LOGIC_PER_USER_ID mode

### DIFF
--- a/src/vma/dev/ring_allocation_logic.cpp
+++ b/src/vma/dev/ring_allocation_logic.cpp
@@ -123,11 +123,11 @@ resource_allocation_key* ring_allocation_logic::create_new_key(int suggested_cpu
 }
 
 /*
- * return true if ring migration is recommended for this thread.
+ * return true if ring migration is recommended.
  */
 bool ring_allocation_logic::should_migrate_ring()
 {
-	if (m_res_key.get_ring_alloc_logic() < RING_LOGIC_PER_USER_ID) {
+	if (m_res_key.get_ring_alloc_logic() < RING_LOGIC_PER_THREAD) {
 		return false;
 	}
 


### PR DESCRIPTION
This ring allocation logic provides the user the option to select the ring for
each socket. Hence, like for ring-per-socket mode, ring migration should be
disabled.

Signed-off-by: Liran Oz <lirano@mellanox.com>