### PR TITLE
issue: 1080207 Add an option to gracefully exit() on startup failure

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -1,4 +1,4 @@
-Updated: 14 May 2017
+Update: 10 Jul 2017
 
 Introduction
 ============
@@ -739,6 +739,7 @@ Default value is Enabled.
 VMA_EXCEPTION_HANDLING
 Mode for handling missing support or error cases in Socket API or functionality by VMA.
 Useful for quickly identifying VMA unsupported Socket API or features
+Use value of -2 to exit() on VMA startup failure.
 Use value of -1 for just handling at DEBUG severity.
 Use value of 0 to log DEBUG message and try recovering via Kernel network stack (un-offloading the socket).
 Use value of 1 to log ERROR message and try recovering via Kernel network stack (un-offloading the socket).

--- a/src/vma/sock/sock-redirect.cpp
+++ b/src/vma/sock/sock-redirect.cpp
@@ -101,6 +101,9 @@ void assign_dlsym(T &ptr, const char *name) {
 	if (__res) { \
 		vlog_printf(VLOG_ERROR, "%s vma failed to start errno: %m\n", \
 			__FUNCTION__, errno); \
+		if (safe_mce_sys().exception_handling == vma_exception_handling::MODE_EXIT) { \
+			exit(-1); \
+		} \
 		return -1; \
 	} \
 } while (0)

--- a/src/vma/util/sys_vars.cpp
+++ b/src/vma/util/sys_vars.cpp
@@ -983,7 +983,7 @@ void mce_sys_var::get_env_params()
 
 	// TODO: this should be replaced by calling "exception_handling.init()" that will be called from init()
 	if ((env_ptr = getenv(vma_exception_handling::getSysVar())) != NULL) {
-		exception_handling = vma_exception_handling(atoi(env_ptr)); // vma_exception_handling is responsible for its invariant
+		exception_handling = vma_exception_handling(strtol(env_ptr, NULL, 10)); // vma_exception_handling is responsible for its invariant
 	}
 
 	if ((env_ptr = getenv(SYS_VAR_AVOID_SYS_CALLS_ON_TCP_FD)) != NULL) {

--- a/src/vma/util/sys_vars.h
+++ b/src/vma/util/sys_vars.h
@@ -210,6 +210,8 @@ public:
 	}
 
 	typedef enum {
+		MODE_FIRST = -3,
+		MODE_EXIT = -2,
 		MODE_DEBUG = -1,
 		MODE_UNOFFLOAD = 0,
 		MODE_LOG_ERROR,
@@ -223,6 +225,7 @@ public:
 	const char* to_str()
 	{
 		switch (m_mode) {
+		case MODE_EXIT:         return "(exit on failed startup)";
 		case MODE_DEBUG:        return "(just log debug message)";
 		case MODE_UNOFFLOAD:    return "(log debug and un-offload)";
 		case MODE_LOG_ERROR:    return "(log error and un-offload)";
@@ -239,6 +242,7 @@ public:
 
 	vlog_levels_t get_log_severity() {
 		switch (m_mode) {
+		case MODE_EXIT:
 		case MODE_DEBUG:
 		case MODE_UNOFFLOAD:
 			return VLOG_DEBUG;
@@ -255,12 +259,12 @@ public:
 	//
 
 	vma_exception_handling(mode _mode = MODE_DEFAULT) : m_mode(_mode) {
-		if (m_mode >= MODE_LAST || m_mode < MODE_DEBUG)
+		if (m_mode >= MODE_LAST || m_mode <= MODE_FIRST)
 			m_mode = MODE_DEFAULT;
 	}
 
 	explicit vma_exception_handling(int _mode) : m_mode((mode)_mode) {
-		if (m_mode >= MODE_LAST || m_mode < MODE_DEBUG)
+		if (m_mode >= MODE_LAST || m_mode <= MODE_FIRST)
 			m_mode = MODE_DEFAULT;
 	}
 


### PR DESCRIPTION
Add VMA an option to gracefully exit() in case of a failure at startup.
Add "-2" value to VMA_EXCEPTION_HANDLING parameter to indicate this
option.

Signed-off-by: Ophir Munk <ophirmu@mellanox.com>