### PR TITLE
issue: 1085670 fix VMA_POLL crash when exiting

### DIFF
--- a/src/vma/dev/cq_mgr.h
+++ b/src/vma/dev/cq_mgr.h
@@ -237,7 +237,6 @@ protected:
 	ring_simple*		m_p_ring;
 	uint32_t		m_n_wce_counter;
 	bool			m_b_was_drained;
-	bool			m_b_is_clean;
 	bool			m_b_is_rx_hw_csum_on;
 	qp_rec			m_qp_rec;
 	const uint32_t		m_n_sysvar_cq_poll_batch_max;

--- a/src/vma/dev/cq_mgr_mlx5.cpp
+++ b/src/vma/dev/cq_mgr_mlx5.cpp
@@ -103,7 +103,6 @@ cq_mgr_mlx5::~cq_mgr_mlx5()
 	cq_logfunc("");
 	cq_logdbg("destroying CQ as %s", (m_b_is_rx?"Rx":"Tx"));
 	m_rq = NULL;
-	m_b_is_clean = true;
 }
 
 mem_buf_desc_t* cq_mgr_mlx5::poll(enum buff_status_e& status)


### PR DESCRIPTION
This commit fixes the release resources when VMA_POLL
is used. since commit 9660125 the clean method is called
from qp_mgr destructor not cq_mgr destructor

Signed-off-by: Rafi Wiener <rafiw@mellanox.com>