### PR TITLE
issue: 1081001 Add cyclic buffer readable status

### DIFF
--- a/src/vma/dev/ring_eth_cb.cpp
+++ b/src/vma/dev/ring_eth_cb.cpp
@@ -225,6 +225,19 @@ inline bool ring_eth_cb::reload_wq()
 	return false;
 }
 
+int ring_eth_cb::cyclic_buffer_is_readable()
+{
+	volatile struct mlx5_cqe64 *cqe64;
+	uint16_t size = 0;
+	uint32_t flags = 0;
+
+	int ret = ((cq_mgr_mp *)m_p_cq_mgr_rx)->poll_mp_cq(size, m_curr_wqe_used_strides, flags, cqe64);
+	if (unlikely(ret == -1)) {
+		return ret;
+	}
+	return size;
+}
+
 int ring_eth_cb::cyclic_buffer_read(vma_completion_cb_t &completion,
 				    size_t min, size_t max, int flags)
 {

--- a/src/vma/dev/ring_eth_cb.h
+++ b/src/vma/dev/ring_eth_cb.h
@@ -70,6 +70,7 @@ public:
 	virtual int	poll_and_process_element_rx(uint64_t* p_cq_poll_sn, void* pv_fd_ready_array = NULL);
 	int		cyclic_buffer_read(vma_completion_cb_t &completion,
 					   size_t min, size_t max, int flags);
+	int		cyclic_buffer_is_readable();
 protected:
 	void		create_resources(ring_resource_creation_info_t* p_ring_info,
 					 bool active) throw (vma_error);

--- a/src/vma/vma_extra.h
+++ b/src/vma/vma_extra.h
@@ -572,6 +572,14 @@ struct __attribute__ ((packed)) vma_api_t {
 				      size_t min, size_t max, int flags);
 
 	/**
+	 * Get the size of the packet arrived to MP_RQ cyclic buffer to return, if not available
+	 * will return 0
+	 * @param fd - the fd of the ring to query - get it using @ref get_socket_rings_fds
+	 * @return the size of the packet arrived on success -1 on failure
+	 */
+	int (*vma_cyclic_buffer_is_readable)(int fd);
+
+	/**
 	 * add a ring profile to VMA ring profile list. you can use this
 	 * to create advacned rings like MP_RQ ring
 	 * the need to pass vma the ring profile using the fd's setsockopt


### PR DESCRIPTION
Returns the size of the packet arrived to MP_RQ cyclic buffer and can be extended to provide similar to the poll functionality. Please review.
@rafiw @ilansmith  
Signed-off-by: Sergey Lykov <sergeyly@mellanox.com>