### PR TITLE
issue: 1091563 MP_RQ - consume bad WQE in VMA

### DIFF
--- a/src/vma/dev/ring_eth_cb.h
+++ b/src/vma/dev/ring_eth_cb.h
@@ -97,8 +97,10 @@ private:
 	void*				m_curr_h_ptr;
 	size_t				m_curr_packets;
 	struct timespec			m_curr_hw_timestamp;
+	bool				m_first_call;
 	inline mp_loop_result		mp_loop(size_t limit);
 	inline bool			reload_wq();
+	void 				consume_first_wqe();
 };
 
 #endif /* HAVE_MP_RQ */

--- a/src/vma/dev/ring_eth_cb.h
+++ b/src/vma/dev/ring_eth_cb.h
@@ -97,6 +97,7 @@ private:
 	void*				m_curr_h_ptr;
 	size_t				m_curr_packets;
 	struct timespec			m_curr_hw_timestamp;
+	// workaround for bug #1070678 consume all first WQE in VMA
 	bool				m_first_call;
 	inline mp_loop_result		mp_loop(size_t limit);
 	inline bool			reload_wq();


### PR DESCRIPTION
until FW fix issue #1070678 VMA will consume
the bad WQE and not give it to the application

Signed-off-by: Rafi Wiener <rafiw@mellanox.com>