### PR TITLE
issue: 1097641 Add a dummy packet send from getsockname()

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -1,4 +1,4 @@
-Update: 10 Jul 2017
+Update: 06 Aug 2017
 
 Introduction
 ============
@@ -184,6 +184,7 @@ Example:
  VMA DETAILS: MTU                            0 (follow actual MTU)      [VMA_MTU]
  VMA DETAILS: MSS                            0 (follow VMA_MTU)         [VMA_MSS]
  VMA DETAILS: TCP CC Algorithm               0 (LWIP)                   [VMA_TCP_CC_ALGO]
+ VMA_DETAILS: Trig dummy send getsockname()  Disabled                   [VMA_TRIGGER_DUMMY_SEND_GETSOCKNAME]
  VMA INFO: ---------------------------------------------------------------------------
 
 
@@ -286,14 +287,15 @@ multi_ring_latency
      Optimized for use cases that are keen on latency where two applications communicate using send-only and receive-only TCP sockets
           
     Multi ring latency SPEC changes the following default configuration
-     VMA_MEM_ALLOC_TYPE = 2                   (default: 1 (Contig Pages))
-     VMA_SELECT_POLL = -1                     (default: 100000)
-     VMA_RX_POLL = -1                         (default: 100000)
-     VMA_RING_ALLOCATION_LOGIC_TX = 20        (default: Ring per interface)
-     VMA_RING_ALLOCATION_LOGIC_RX = 20        (default: Ring per interface)
-     VMA_SELECT_POLL_OS_RATIO = 0             (default: 10)
-     VMA_SELECT_SKIP_OS = 0                   (default: 4)
-     VMA_RX_POLL_ON_TX_TCP = true             (dafault: false)
+     VMA_MEM_ALLOC_TYPE = 2                    (default: 1 (Contig Pages))
+     VMA_SELECT_POLL = -1                      (default: 100000)
+     VMA_RX_POLL = -1                          (default: 100000)
+     VMA_RING_ALLOCATION_LOGIC_TX = 20         (default: Ring per interface)
+     VMA_RING_ALLOCATION_LOGIC_RX = 20         (default: Ring per interface)
+     VMA_SELECT_POLL_OS_RATIO = 0              (default: 10)
+     VMA_SELECT_SKIP_OS = 0                    (default: 4)
+     VMA_RX_POLL_ON_TX_TCP = true              (dafault: false)
+     VMA_TRIGGER_DUMMY_SEND_GETSOCKNAME = true (dafault: false)
 
     Example: VMA_SPEC=multi_ring_latency
 
@@ -547,6 +549,12 @@ Default value is 0 (Disable)
 VMA_RX_POLL_ON_TX_TCP
 This parameter enables/disables TCP RX polling during TCP TX operation for faster 
 TCP ACK reception. 
+Default: 0 (Disable)
+
+VMA_TRIGGER_DUMMY_SEND_GETSOCKNAME
+This parameter triggers dummy packet send from getsockname(), this
+will warm up the caches. 
+For more information regarding dummy send, see VMA user manual document.
 Default: 0 (Disable)
 
 VMA_GRO_STREAMS_MAX

--- a/src/vma/main.cpp
+++ b/src/vma/main.cpp
@@ -610,6 +610,7 @@ void print_vma_global_settings()
 	}
 	VLOG_PARAM_NUMSTR("TCP CC Algorithm", safe_mce_sys().lwip_cc_algo_mod, MCE_DEFAULT_LWIP_CC_ALGO_MOD, SYS_VAR_TCP_CC_ALGO, lwip_cc_algo_str(safe_mce_sys().lwip_cc_algo_mod));
 	VLOG_PARAM_STRING("Polling Rx on Tx TCP", safe_mce_sys().rx_poll_on_tx_tcp, MCE_DEFAULT_RX_POLL_ON_TX_TCP, SYS_VAR_VMA_RX_POLL_ON_TX_TCP, safe_mce_sys().rx_poll_on_tx_tcp ? "Enabled " : "Disabled");
+	VLOG_PARAM_STRING("Trig dummy send getsockname()", safe_mce_sys().trigger_dummy_send_getsockname, MCE_DEFAULT_TRIGGER_DUMMY_SEND_GETSOCKNAME, SYS_VAR_VMA_TRIGGER_DUMMY_SEND_GETSOCKNAME, safe_mce_sys().trigger_dummy_send_getsockname ? "Enabled " : "Disabled");
 
 #ifdef VMA_TIME_MEASURE
 	VLOG_PARAM_NUMBER("Time Measure Num Samples", safe_mce_sys().vma_time_measure_num_samples, MCE_DEFAULT_TIME_MEASURE_NUM_SAMPLES, SYS_VAR_VMA_TIME_MEASURE_NUM_SAMPLES);

--- a/src/vma/sock/sock-redirect.cpp
+++ b/src/vma/sock/sock-redirect.cpp
@@ -1025,6 +1025,14 @@ int getsockname(int __fd, struct sockaddr *__name, socklen_t *__namelen)
 	p_socket_object = fd_collection_get_sockfd(__fd);
 	if (p_socket_object) {
 		ret = p_socket_object->getsockname(__name, __namelen);
+
+		if (safe_mce_sys().trigger_dummy_send_getsockname) {
+			char buf[264] = {0};
+			struct iovec msg_iov = {&buf, sizeof(buf)};
+			struct msghdr msg = {NULL, 0, &msg_iov, 1, NULL, 0, 0};
+			int ret_send = sendmsg(__fd, &msg, VMA_SND_FLAGS_DUMMY);
+			srdr_logdbg("Triggered dummy message for socket fd=%d (ret_send=%d)", __fd, ret_send);
+		}
 	}
 	else {
 		BULLSEYE_EXCLUDE_BLOCK_START

--- a/src/vma/util/sys_vars.cpp
+++ b/src/vma/util/sys_vars.cpp
@@ -530,14 +530,14 @@ void mce_sys_var::get_env_params()
 	mce_spec		= MCE_SPEC_NONE;
 	mce_spec_param1		= 1;
 	mce_spec_param2		= 1;
-	
+
 	neigh_num_err_retries	= MCE_DEFAULT_NEIGH_NUM_ERR_RETRIES;
 	neigh_uc_arp_quata	= MCE_DEFAULT_NEIGH_UC_ARP_QUATA;
 	neigh_wait_till_send_arp_msec = MCE_DEFAULT_NEIGH_UC_ARP_DELAY_MSEC;
-
 	timer_netlink_update_msec = MCE_DEFAULT_NETLINK_TIMER_MSEC;
 
 	rx_poll_on_tx_tcp	= MCE_DEFAULT_RX_POLL_ON_TX_TCP;
+	trigger_dummy_send_getsockname = MCE_DEFAULT_TRIGGER_DUMMY_SEND_GETSOCKNAME;
 
 #ifdef VMA_TIME_MEASURE
 	vma_time_measure_num_samples = MCE_DEFAULT_TIME_MEASURE_NUM_SAMPLES;
@@ -662,7 +662,8 @@ void mce_sys_var::get_env_params()
 		ring_allocation_logic_rx = RING_LOGIC_PER_THREAD; //MCE_DEFAULT_RING_ALLOCATION_LOGIC_RX(RING_LOGIC_PER_INTERFACE) VMA_RING_ALLOCATION_LOGIC_RX
 		select_poll_os_ratio     = 0; //MCE_DEFAULT_SELECT_POLL_OS_RATIO(10) VMA_SELECT_POLL_OS_RATIO
 		select_skip_os_fd_check  = 0; //MCE_DEFAULT_SELECT_SKIP_OS(4) VMA_SELECT_SKIP_OS
-		rx_poll_on_tx_tcp	 = true;
+		rx_poll_on_tx_tcp        = true; //MCE_DEFAULT_RX_POLL_ON_TX_TCP (false)
+		trigger_dummy_send_getsockname = true; //MCE_DEFAULT_TRIGGER_DUMMY_SEND_GETSOCKNAME (false)
 		break;
 
 	case MCE_SPEC_NONE:
@@ -1125,6 +1126,9 @@ void mce_sys_var::get_env_params()
 
 	if ((env_ptr = getenv(SYS_VAR_VMA_RX_POLL_ON_TX_TCP)) != NULL)
 		rx_poll_on_tx_tcp = atoi(env_ptr) ? true : false;
+
+	if ((env_ptr = getenv(SYS_VAR_VMA_TRIGGER_DUMMY_SEND_GETSOCKNAME)) != NULL)
+		trigger_dummy_send_getsockname = atoi(env_ptr) ? true : false;
 
 #ifdef VMA_TIME_MEASURE
 	if ((env_ptr = getenv(SYS_VAR_VMA_TIME_MEASURE_NUM_SAMPLES)) != NULL) {

--- a/src/vma/util/sys_vars.h
+++ b/src/vma/util/sys_vars.h
@@ -403,6 +403,7 @@ struct mce_sys_var {
 	sysctl_reader_t & sysctl_reader;
 	bool		rx_poll_on_tx_tcp;
 	bool		is_hypervisor;
+	bool		trigger_dummy_send_getsockname;
 
 private:
 	void print_vma_load_failure_msg();
@@ -533,6 +534,7 @@ extern mce_sys_var & safe_mce_sys();
 #define SYS_VAR_VMA_TIME_MEASURE_NUM_SAMPLES		"VMA_TIME_MEASURE_NUM_SAMPLES"
 #define SYS_VAR_VMA_TIME_MEASURE_DUMP_FILE		"VMA_TIME_MEASURE_DUMP_FILE"
 #define SYS_VAR_VMA_RX_POLL_ON_TX_TCP			"VMA_RX_POLL_ON_TX_TCP"
+#define SYS_VAR_VMA_TRIGGER_DUMMY_SEND_GETSOCKNAME	"VMA_TRIGGER_DUMMY_SEND_GETSOCKNAME"
 
 #define MCE_DEFAULT_LOG_FILE				("")
 #define MCE_DEFAULT_CONF_FILE				("/etc/libvma.conf")
@@ -662,6 +664,7 @@ extern mce_sys_var & safe_mce_sys();
 #define MCE_MAX_CQ_POLL_BATCH				(128)
 #define MCE_DEFAULT_IPOIB_FLAG				(1)
 #define MCE_DEFAULT_RX_POLL_ON_TX_TCP			(false)
+#define MCE_DEFAULT_TRIGGER_DUMMY_SEND_GETSOCKNAME	(false)
 
 #define MCE_ALIGNMENT					((unsigned long)63)
 #define RX_BUF_SIZE(mtu)				(mtu + IPOIB_HDR_LEN + GRH_HDR_LEN) // RX buffers are larger in IB


### PR DESCRIPTION
in order to warm up the caches.
This change will take effect in case of
VMA_TRIGGER_DUMMY_SEND_GET_SOCK_NAME=true.

Signed-off-by: Daniel Libenson <danielli@mellanox.com>