### PR TITLE
issue: 1094542 Fix hardware-timestamp after software-timestamp

### DIFF
--- a/src/vma/dev/time_converter_ib_ctx.cpp
+++ b/src/vma/dev/time_converter_ib_ctx.cpp
@@ -46,8 +46,9 @@
 #define ibchtc_logdbg __log_dbg
 
 
-#define UPDATE_HW_TIMER_PERIOD_MS 10000
-#define UPDATE_HW_TIMER_INIT_MS 1000
+#define UPDATE_HW_TIMER_PERIOD_MS 1000
+#define UPDATE_HW_TIMER_INIT_MS 100
+#define UPDATE_HW_TIMER_SECONDARY_MS 200
 
 #define IB_CTX_TC_DEVIATION_THRESHOLD 10
 
@@ -69,6 +70,7 @@ time_converter_ib_ctx::time_converter_ib_ctx(struct ibv_context* ctx, ts_convers
 				m_converter_status = TS_CONVERSION_MODE_SYNC;
 
 				g_p_event_handler_manager->register_timer_event(UPDATE_HW_TIMER_INIT_MS, this, ONE_SHOT_TIMER, 0);
+				g_p_event_handler_manager->register_timer_event(UPDATE_HW_TIMER_SECONDARY_MS, this, ONE_SHOT_TIMER, 0);
 				m_timer_handle = g_p_event_handler_manager->register_timer_event(UPDATE_HW_TIMER_PERIOD_MS, this, PERIODIC_TIMER, 0);
 			}
 		}

--- a/src/vma/dev/time_converter_ib_ctx.cpp
+++ b/src/vma/dev/time_converter_ib_ctx.cpp
@@ -47,8 +47,8 @@
 
 
 #define UPDATE_HW_TIMER_PERIOD_MS 1000
-#define UPDATE_HW_TIMER_INIT_MS 100
-#define UPDATE_HW_TIMER_SECONDARY_MS 200
+#define UPDATE_HW_TIMER_FIRST_ONESHOT_MS 100
+#define UPDATE_HW_TIMER_SECOND_ONESHOT_MS 200
 
 #define IB_CTX_TC_DEVIATION_THRESHOLD 10
 
@@ -69,8 +69,8 @@ time_converter_ib_ctx::time_converter_ib_ctx(struct ibv_context* ctx, ts_convers
 			if (sync_clocks(&current_parameters_set->sync_systime, &current_parameters_set->sync_hw_clock)) {
 				m_converter_status = TS_CONVERSION_MODE_SYNC;
 
-				g_p_event_handler_manager->register_timer_event(UPDATE_HW_TIMER_INIT_MS, this, ONE_SHOT_TIMER, 0);
-				g_p_event_handler_manager->register_timer_event(UPDATE_HW_TIMER_SECONDARY_MS, this, ONE_SHOT_TIMER, 0);
+				g_p_event_handler_manager->register_timer_event(UPDATE_HW_TIMER_FIRST_ONESHOT_MS, this, ONE_SHOT_TIMER, 0);
+				g_p_event_handler_manager->register_timer_event(UPDATE_HW_TIMER_SECOND_ONESHOT_MS, this, ONE_SHOT_TIMER, 0);
 				m_timer_handle = g_p_event_handler_manager->register_timer_event(UPDATE_HW_TIMER_PERIOD_MS, this, PERIODIC_TIMER, 0);
 			}
 		}


### PR DESCRIPTION
1. Run two timers (instead of 1) at startup for sync-ing VMA's
   inner clock parameters.
2. Reduce interval between sync timers

* This should solve all cases of race conditions between sw and hw.
* It may still happen for high bursts of packets - if so, consider
* using VMA parameter VMA_HW_TS_CONVERSION=4 for PTP sync and higher
* accuracy.

Signed-off-by: Or Shalev <orsh@mellanox.com>