### PR TITLE
issue: 1122824 fix lock usage when migrating

### DIFF
--- a/src/vma/dev/ring.cpp
+++ b/src/vma/dev/ring.cpp
@@ -39,6 +39,7 @@
 #define MODULE_HDR      MODULE_NAME "%d:%s() "
 
 ring::ring(int count, uint32_t mtu) :
+	m_lock_ring_rx("ring:lock_rx"),
 	m_n_num_resources(count), m_p_n_rx_channel_fds(NULL), m_parent(NULL),
 	m_is_mp_ring(false), m_mtu(mtu)
 {

--- a/src/vma/dev/ring.h
+++ b/src/vma/dev/ring.h
@@ -325,6 +325,8 @@ public:
 	bool			is_mp_ring() {return m_is_mp_ring;};
 	virtual int		modify_ratelimit(const uint32_t ratelimit_kbps) = 0;
 	virtual bool		is_ratelimit_supported(uint32_t rate) = 0;
+	void			lock_ring_rx() {m_lock_ring_rx.lock();};
+	void			unlock_ring_rx() {m_lock_ring_rx.unlock();};
 
 #ifdef DEFINED_VMAPOLL		
 	virtual int		vma_poll(struct vma_completion_t *vma_completions, unsigned int ncompletions, int flags) = 0;
@@ -371,6 +373,7 @@ public:
 #endif // DEFINED_VMAPOLL	
 
 protected:
+	lock_spin_recursive	m_lock_ring_rx;
 	uint32_t		m_n_num_resources;
 	int*			m_p_n_rx_channel_fds;
 	ring*			m_parent;

--- a/src/vma/dev/ring_bond.cpp
+++ b/src/vma/dev/ring_bond.cpp
@@ -58,7 +58,7 @@
 
 
 ring_bond::ring_bond(int count, net_device_val::bond_type type, net_device_val::bond_xmit_hash_policy bond_xmit_hash_policy, uint32_t mtu) :
-ring(count, mtu), m_lock_ring_rx("ring_bond:lock_rx"), m_lock_ring_tx("ring_bond:lock_tx") {
+ring(count, mtu), m_lock_ring_tx("ring_bond:lock_tx") {
 	if (m_n_num_resources > MAX_NUM_RING_RESOURCES) {
 		ring_logpanic("Error creating bond ring with more than %d resource", MAX_NUM_RING_RESOURCES);
 	}

--- a/src/vma/dev/ring_bond.h
+++ b/src/vma/dev/ring_bond.h
@@ -87,7 +87,6 @@ private:
 
 	net_device_val::bond_type m_type;
 	net_device_val::bond_xmit_hash_policy m_xmit_hash_policy;
-	lock_mutex_recursive	m_lock_ring_rx;
 	lock_mutex_recursive	m_lock_ring_tx;
 };
 

--- a/src/vma/dev/ring_simple.cpp
+++ b/src/vma/dev/ring_simple.cpp
@@ -118,7 +118,6 @@ bool ring_ib::is_ratelimit_supported(uint32_t rate)
 
 ring_simple::ring_simple(ring_resource_creation_info_t* p_ring_info, in_addr_t local_if, uint16_t partition_sn, int count, transport_type_t transport_type, uint32_t mtu, ring* parent /*=NULL*/) throw (vma_error):
 	ring(count, mtu), m_p_qp_mgr(NULL), m_p_cq_mgr_rx(NULL),
-	m_lock_ring_rx("ring_simple:lock_rx"),
 	m_b_is_hypervisor(safe_mce_sys().is_hypervisor),
 	m_p_ring_stat(NULL),
 	m_lock_ring_tx("ring_simple:lock_tx"), m_p_cq_mgr_tx(NULL),

--- a/src/vma/dev/ring_simple.h
+++ b/src/vma/dev/ring_simple.h
@@ -118,7 +118,6 @@ protected:
 	qp_mgr*			m_p_qp_mgr;
 	struct cq_moderation_info m_cq_moderation_info;
 	cq_mgr*			m_p_cq_mgr_rx;
-	lock_spin_recursive	m_lock_ring_rx;
 	bool			m_b_is_hypervisor;
 	ring_stats_t*		m_p_ring_stat;
 private:


### PR DESCRIPTION
This commit fixes releasing the socket lock during migration.
This bad lock usage caused duplicaton\out of order messages arrival
and could cause VMA to stuck when migrating.

Signed-off-by: Rafi Wiener <rafiw@mellanox.com>