### PR TITLE
issue: 1062367 Fix TCP window deadlock in case of a small window

### DIFF
--- a/src/vma/lwip/tcp_out.c
+++ b/src/vma/lwip/tcp_out.c
@@ -1030,7 +1030,7 @@ tcp_output(struct tcp_pcb *pcb)
 
   while (seg){
     /* Split the segment in case of a small window */
-    if (( pcb->flags & (TF_NODELAY | TF_INFR)) && (wnd) && ((seg->len + seg->seqno - pcb->lastack) > wnd)) {
+    if (((seg->len + seg->seqno - pcb->lastack) > wnd) && (wnd) && (NULL == pcb->unacked)) {
       LWIP_ASSERT("tcp_output: no window for dummy packet", !LWIP_IS_DUMMY_SEGMENT(seg));
       tcp_split_segment(pcb, seg, wnd);
     }

--- a/src/vma/lwip/tcp_out.c
+++ b/src/vma/lwip/tcp_out.c
@@ -1030,7 +1030,7 @@ tcp_output(struct tcp_pcb *pcb)
 
   while (seg){
     /* Split the segment in case of a small window */
-    if (((seg->len + seg->seqno - pcb->lastack) > wnd) && (wnd) && (NULL == pcb->unacked)) {
+    if ((NULL == pcb->unacked) && (wnd) && ((seg->len + seg->seqno - pcb->lastack) > wnd)) {
       LWIP_ASSERT("tcp_output: no window for dummy packet", !LWIP_IS_DUMMY_SEGMENT(seg));
       tcp_split_segment(pcb, seg, wnd);
     }


### PR DESCRIPTION
The deadlock occurs when the head of TCP unsent queue packet length
is bigger than the send window combined with loss of window update
message that sent from peer side (ACK segment that contain no data).

ACK segment that contain no data are not reliably transmitted by TCP
and this is why VMA may hang when an ACK segment that update the
window is lost.

The solution is to split and fill the remaining window with part of
the unsent segment (which will engage zero-window probing upon
reception of the zero window update from the receiver).

For more details, see RFC-1122.

Signed-off-by: Daniel Libenson <danielli@mellanox.com>