### PR TITLE
issue: 1134718 Fix lack of interface reinitialization (Tx PRM)

### DIFF
--- a/src/vma/dev/qp_mgr_eth_mlx5.cpp
+++ b/src/vma/dev/qp_mgr_eth_mlx5.cpp
@@ -90,6 +90,7 @@ void qp_mgr_eth_mlx5::init_sq()
 	m_sq_wqes	 = (struct mlx5_wqe64 (*)[])(uintptr_t)m_hw_qp->gen_data.sqstart;
 	m_sq_wqe_hot	 = &(*m_sq_wqes)[0];
 	m_sq_wqes_end	 = (uint8_t*)m_hw_qp->gen_data.sqend;
+	m_sq_wqe_counter = 0;
 
 	m_sq_db		 = &m_hw_qp->gen_data.db[MLX5_SND_DBR];
 	m_sq_bf_reg	 = m_hw_qp->gen_data.bf->reg;
@@ -153,10 +154,13 @@ qp_mgr_eth_mlx5::qp_mgr_eth_mlx5(const ring_simple* p_ring, const ib_ctx_handler
 		throw_vma_exception("failed creating qp_mgr_eth");
 	}
 
-	init_sq();
-
 	qp_logfunc("m_p_cq_mgr_tx= %p", m_p_cq_mgr_tx);
+}
 
+void qp_mgr_eth_mlx5::up()
+{
+	init_sq();
+	qp_mgr::up();
 }
 
 //! Cleanup resources QP itself will be freed by base class DTOR

--- a/src/vma/dev/qp_mgr_eth_mlx5.h
+++ b/src/vma/dev/qp_mgr_eth_mlx5.h
@@ -48,6 +48,7 @@ public:
 	qp_mgr_eth_mlx5(const ring_simple* p_ring, const ib_ctx_handler* p_context, const uint8_t port_num,
 			struct ibv_comp_channel* p_rx_comp_event_channel, const uint32_t tx_num_wr, const uint16_t vlan) throw (vma_error);
 	virtual ~qp_mgr_eth_mlx5();
+	virtual void up();
 
 protected:
 	void			trigger_completion_for_all_sent_packets();

--- a/src/vma/util/agent.cpp
+++ b/src/vma/util/agent.cpp
@@ -91,7 +91,7 @@ agent::agent() :
 	m_msg_num = 0;
 	while (i--) {
 		/* coverity[overwrite_var] */
-		msg = (agent_msg_t *)malloc(sizeof(*msg));
+		msg = (agent_msg_t *)calloc(1, sizeof(*msg));
 		if (NULL == msg) {
 			rc = -ENOMEM;
 			__log_dbg("failed queue creation (rc = %d)\n", rc);

--- a/src/vma/util/agent.h
+++ b/src/vma/util/agent.h
@@ -78,7 +78,7 @@ public:
 		if (list_empty(&m_free_queue)) {
 			for (i = 0; i < m_msg_grow; i++) {
 				/* coverity[overwrite_var] */
-				msg = (agent_msg_t *)malloc(sizeof(*msg));
+				msg = (agent_msg_t *)calloc(1, sizeof(*msg));
 				if (NULL == msg) {
 					break;
 				}


### PR DESCRIPTION
PRM Tx post send queue initialization function move from constructor
to qp::up(), to support interface bring up after being down.

Signed-off-by: Daniel Libenson <danielli@mellanox.com>