### PR TITLE
issue: 1088208 consider cache_line when getting CQE

### DIFF
--- a/src/vma/dev/cq_mgr_mlx5.cpp
+++ b/src/vma/dev/cq_mgr_mlx5.cpp
@@ -63,6 +63,7 @@ cq_mgr_mlx5::cq_mgr_mlx5(ring_simple* p_ring, ib_ctx_handler* p_ib_ctx_handler,
 	,m_rx_hot_buffer(NULL)
 	,m_p_rq_wqe_idx_to_wrid(NULL)
 	,m_qp(NULL)
+	,m_mlx5_cq(NULL)
 {
 	cq_logfunc("");
 }
@@ -141,7 +142,7 @@ mem_buf_desc_t* cq_mgr_mlx5::poll(enum buff_status_e& status)
 			return NULL;
 		}
 	}
-	volatile mlx5_cqe64 *cqe = check_cqe();
+	mlx5_cqe64 *cqe = check_cqe();
 	if (likely(cqe)) {
 		/* Update the consumer index */
 		++m_cq_cons_index;
@@ -177,7 +178,7 @@ mem_buf_desc_t* cq_mgr_mlx5::poll(enum buff_status_e& status)
 	return buff;
 }
 
-inline void cq_mgr_mlx5::cqe64_to_mem_buff_desc(volatile struct mlx5_cqe64 *cqe, mem_buf_desc_t* p_rx_wc_buf_desc, enum buff_status_e &status)
+inline void cq_mgr_mlx5::cqe64_to_mem_buff_desc(struct mlx5_cqe64 *cqe, mem_buf_desc_t* p_rx_wc_buf_desc, enum buff_status_e &status)
 {
 	struct mlx5_err_cqe *ecqe;
 	ecqe = (struct mlx5_err_cqe *)cqe;
@@ -420,7 +421,7 @@ int cq_mgr_mlx5::poll_and_process_element_rx(uint64_t* p_cq_poll_sn, void* pv_fd
 	return ret_rx_processed;
 }
 
-inline void cq_mgr_mlx5::cqe64_to_vma_wc(volatile struct mlx5_cqe64 *cqe, vma_ibv_wc *wc)
+inline void cq_mgr_mlx5::cqe64_to_vma_wc(struct mlx5_cqe64 *cqe, vma_ibv_wc *wc)
 {
 	struct mlx5_err_cqe* ecqe = (struct mlx5_err_cqe *)cqe;
 
@@ -452,8 +453,8 @@ inline void cq_mgr_mlx5::cqe64_to_vma_wc(volatile struct mlx5_cqe64 *cqe, vma_ib
 	wc->vendor_err = ecqe->vendor_err_synd;
 }
 
-inline volatile struct mlx5_cqe64* cq_mgr_mlx5::check_error_completion(volatile struct mlx5_cqe64 *cqe,
-								 volatile uint32_t *ci, uint8_t op_own)
+inline struct mlx5_cqe64* cq_mgr_mlx5::check_error_completion(struct mlx5_cqe64 *cqe,
+							      uint32_t *ci, uint8_t op_own)
 {
 	switch (op_own >> 4) {
 	case MLX5_CQE_REQ_ERR:
@@ -469,10 +470,10 @@ inline volatile struct mlx5_cqe64* cq_mgr_mlx5::check_error_completion(volatile 
 	}
 }
 
-inline volatile struct mlx5_cqe64 *cq_mgr_mlx5::get_cqe64(volatile struct mlx5_cqe64 **cqe_err)
+inline struct mlx5_cqe64 *cq_mgr_mlx5::get_cqe64(struct mlx5_cqe64 **cqe_err)
 {
 
-	volatile struct mlx5_cqe64 *cqe = (volatile struct mlx5_cqe64 *)(((uint8_t*)m_cqes) +
+	struct mlx5_cqe64 *cqe = (struct mlx5_cqe64 *)(((uint8_t*)m_cqes) +
 			((m_cq_cons_index & (m_cq_size - 1)) << m_cqe_log_sz));
 	uint8_t op_own = cqe->op_own;
 
@@ -491,7 +492,7 @@ inline volatile struct mlx5_cqe64 *cq_mgr_mlx5::get_cqe64(volatile struct mlx5_c
 	return cqe;
 }
 
-int cq_mgr_mlx5::poll_and_process_error_element_tx(volatile struct mlx5_cqe64 *cqe, uint64_t* p_cq_poll_sn)
+int cq_mgr_mlx5::poll_and_process_error_element_tx(struct mlx5_cqe64 *cqe, uint64_t* p_cq_poll_sn)
 {
 	uint16_t wqe_ctr = ntohs(cqe->wqe_counter);
 	int index = wqe_ctr & (m_qp->m_tx_num_wr - 1);
@@ -531,8 +532,8 @@ int cq_mgr_mlx5::poll_and_process_element_tx(uint64_t* p_cq_poll_sn)
 	cq_logfuncall("");
 
 	int ret = 0;
-	volatile mlx5_cqe64 *cqe_err = NULL;
-	volatile mlx5_cqe64 *cqe = get_cqe64(&cqe_err);
+	mlx5_cqe64 *cqe_err = NULL;
+	mlx5_cqe64 *cqe = get_cqe64(&cqe_err);
 
 	if (likely(cqe)) {
 		uint16_t wqe_ctr = ntohs(cqe->wqe_counter);
@@ -567,17 +568,17 @@ int cq_mgr_mlx5::poll_and_process_element_tx(uint64_t* p_cq_poll_sn)
 void cq_mgr_mlx5::set_qp_rq(qp_mgr* qp)
 {
 	struct ibv_cq *ibcq = m_p_ibv_cq; // ibcp is used in next macro: _to_mxxx
-	struct mlx5_cq *mlx5_cq = _to_mxxx(cq, cq);
+	m_mlx5_cq = _to_mxxx(cq, cq);
 	struct verbs_qp *vqp = (struct verbs_qp *)qp->m_qp;
 	struct mlx5_qp *mlx5_hw_qp = (struct mlx5_qp*)container_of(vqp, struct mlx5_qp, verbs_qp);
 
-	m_rq = &(mlx5_hw_qp->rq);
+	m_rq = &mlx5_hw_qp->rq;
 	m_p_rq_wqe_idx_to_wrid = qp->m_rq_wqe_idx_to_wrid;
 	qp->m_rq_wqe_counter = 0; /* In case of bonded qp, wqe_counter must be reset to zero */
 	m_rx_hot_buffer = NULL;
-	m_cq_dbell = mlx5_cq->dbrec;
-	m_cqe_log_sz = ilog_2(mlx5_cq->cqe_sz);
-	m_cqes = ((uint8_t*)mlx5_cq->active_buf->buf) + mlx5_cq->cqe_sz - sizeof(struct mlx5_cqe64);
+	m_cq_dbell = m_mlx5_cq->dbrec;
+	m_cqe_log_sz = ilog_2(m_mlx5_cq->cqe_sz);
+	m_cqes = ((uint8_t*)m_mlx5_cq->active_buf->buf) + m_mlx5_cq->cqe_sz - sizeof(struct mlx5_cqe64);
 }
 
 void cq_mgr_mlx5::add_qp_rx(qp_mgr* qp)
@@ -595,9 +596,7 @@ void cq_mgr_mlx5::del_qp_rx(qp_mgr *qp)
 
 inline void cq_mgr_mlx5::update_consumer_index()
 {
-	struct ibv_cq *ibcq = m_p_ibv_cq; // ibcp is used in next macro: _to_mxxx
-	struct mlx5_cq* mlx5_cq = _to_mxxx(cq, cq);
-	mlx5_cq->cons_index = m_cq_cons_index;
+	m_mlx5_cq->cons_index = m_cq_cons_index;
 	wmb();
 }
 
@@ -618,11 +617,11 @@ void cq_mgr_mlx5::add_qp_tx(qp_mgr* qp)
 	//Assume locked!
 	cq_mgr::add_qp_tx(qp);
 	struct ibv_cq *ibcq = m_p_ibv_cq; // ibcp is used in next macro: _to_mxxx
-	struct mlx5_cq *mlx5_cq = _to_mxxx(cq, cq);
+	m_mlx5_cq = _to_mxxx(cq, cq);
 	m_qp = static_cast<qp_mgr_eth_mlx5*> (qp);
-	m_cq_dbell = mlx5_cq->dbrec;
-	m_cqe_log_sz = ilog_2(mlx5_cq->cqe_sz);
-	m_cqes = ((uint8_t*)mlx5_cq->active_buf->buf) + mlx5_cq->cqe_sz - sizeof(struct mlx5_cqe64);
+	m_cq_dbell = m_mlx5_cq->dbrec;
+	m_cqe_log_sz = ilog_2(m_mlx5_cq->cqe_sz);
+	m_cqes = ((uint8_t *)m_mlx5_cq->active_buf->buf) + m_mlx5_cq->cqe_sz - sizeof(struct mlx5_cqe64);
 	cq_logfunc("qp_mgr=%p m_cq_dbell=%p m_cqes=%p", m_qp, m_cq_dbell, m_cqes);
 }
 

--- a/src/vma/dev/cq_mgr_mlx5.h
+++ b/src/vma/dev/cq_mgr_mlx5.h
@@ -79,9 +79,10 @@ protected:
 
 	uint32_t                    m_cq_size;
 	uint32_t                    m_cq_cons_index;
-	struct mlx5_cqe64           (*m_cqes)[];
+	void*                       m_cqes;
 	volatile uint32_t*	    m_cq_dbell;
 	struct mlx5_wq*		    m_rq;
+	int                         m_cqe_log_sz;
 
 private:
 	mem_buf_desc_t              *m_rx_hot_buffer;

--- a/src/vma/dev/cq_mgr_mlx5.h
+++ b/src/vma/dev/cq_mgr_mlx5.h
@@ -58,12 +58,12 @@ public:
 	virtual ~cq_mgr_mlx5();
 
 	virtual mem_buf_desc_t*     poll(enum buff_status_e& status);
-	inline volatile struct mlx5_cqe64* get_cqe64(volatile struct mlx5_cqe64 **cqe_err);
-	inline void                 cqe64_to_mem_buff_desc(volatile struct mlx5_cqe64 *cqe, mem_buf_desc_t* p_rx_wc_buf_desc, enum buff_status_e& status);
+	inline struct mlx5_cqe64*   get_cqe64(struct mlx5_cqe64 **cqe_err);
+	inline void                 cqe64_to_mem_buff_desc(struct mlx5_cqe64 *cqe, mem_buf_desc_t* p_rx_wc_buf_desc, enum buff_status_e& status);
 	virtual int                 drain_and_proccess(uintptr_t* p_recycle_buffers_last_wr_id = NULL);
 	virtual int                 poll_and_process_element_rx(uint64_t* p_cq_poll_sn, void* pv_fd_ready_array = NULL);
 	virtual int		    poll_and_process_element_tx(uint64_t* p_cq_poll_sn);
-	int			    poll_and_process_error_element_tx(volatile struct mlx5_cqe64 *cqe, uint64_t* p_cq_poll_sn);
+	int			    poll_and_process_error_element_tx(struct mlx5_cqe64 *cqe, uint64_t* p_cq_poll_sn);
 
 	virtual mem_buf_desc_t*     process_cq_element_rx(mem_buf_desc_t* p_mem_buf_desc, enum buff_status_e status);
 	virtual void                add_qp_rx(qp_mgr* qp);
@@ -75,7 +75,7 @@ public:
 	virtual int                 wait_for_notification_and_process_element(uint64_t* p_cq_poll_sn, void* pv_fd_ready_array = NULL);
 
 protected:
-	inline volatile struct mlx5_cqe64* check_cqe(void);
+	inline struct mlx5_cqe64*   check_cqe(void);
 
 	uint32_t                    m_cq_size;
 	uint32_t                    m_cq_cons_index;
@@ -88,9 +88,10 @@ private:
 	mem_buf_desc_t              *m_rx_hot_buffer;
 	uint64_t                    *m_p_rq_wqe_idx_to_wrid;
 	qp_mgr_eth_mlx5*            m_qp; //for tx
+	struct mlx5_cq*             m_mlx5_cq;
 
-	void cqe64_to_vma_wc(volatile struct mlx5_cqe64 *cqe, vma_ibv_wc *wc);
-	inline volatile struct mlx5_cqe64* check_error_completion(volatile struct mlx5_cqe64 *cqe,volatile uint32_t *ci, uint8_t op_own);
+	void cqe64_to_vma_wc(struct mlx5_cqe64 *cqe, vma_ibv_wc *wc);
+	inline struct mlx5_cqe64*   check_error_completion(struct mlx5_cqe64 *cqe, uint32_t *ci, uint8_t op_own);
 	inline void		    update_consumer_index();
 	inline void                 update_global_sn(uint64_t& cq_poll_sn, uint32_t rettotal);
 };

--- a/src/vma/dev/cq_mgr_mlx5.inl
+++ b/src/vma/dev/cq_mgr_mlx5.inl
@@ -43,8 +43,8 @@
 /**/
 inline volatile struct mlx5_cqe64* cq_mgr_mlx5::check_cqe(void)
 {
-	volatile struct mlx5_cqe64 *cqe = &(*m_cqes)[m_cq_cons_index & (m_cq_size - 1)];
-
+	volatile struct mlx5_cqe64* cqe = (volatile struct mlx5_cqe64 *)(((uint8_t *)m_cqes) +
+			((m_cq_cons_index & (m_cq_size - 1)) << m_cqe_log_sz));
 	/*
 	 * CQE ownership is defined by Owner bit in the CQE.
 	 * The value indicating SW ownership is flipped every

--- a/src/vma/dev/cq_mgr_mlx5.inl
+++ b/src/vma/dev/cq_mgr_mlx5.inl
@@ -41,9 +41,9 @@
 /**/
 /** inlining functions can only help if they are implemented before their usage **/
 /**/
-inline volatile struct mlx5_cqe64* cq_mgr_mlx5::check_cqe(void)
+inline struct mlx5_cqe64* cq_mgr_mlx5::check_cqe(void)
 {
-	volatile struct mlx5_cqe64* cqe = (volatile struct mlx5_cqe64 *)(((uint8_t *)m_cqes) +
+	struct mlx5_cqe64* cqe = (struct mlx5_cqe64 *)(((uint8_t *)m_cqes) +
 			((m_cq_cons_index & (m_cq_size - 1)) << m_cqe_log_sz));
 	/*
 	 * CQE ownership is defined by Owner bit in the CQE.

--- a/src/vma/dev/cq_mgr_mp.cpp
+++ b/src/vma/dev/cq_mgr_mp.cpp
@@ -135,7 +135,8 @@ int cq_mgr_mp::poll_mp_cq(uint16_t &size, uint32_t &strides_used,
 			size = stride_byte_cnt & MP_RQ_BYTE_CNT_FIELD_MASK;
 		}
 		++m_cq_cons_index;
-		prefetch((void*)&(*m_cqes)[m_cq_cons_index & (m_cq_size - 1)]);
+		prefetch((uint8_t*)m_cqes + ((m_cq_cons_index & (m_cq_size - 1)) << m_cqe_log_sz));
+
 	} else {
 		size = 0;
 		flags = 0;

--- a/src/vma/dev/cq_mgr_mp.cpp
+++ b/src/vma/dev/cq_mgr_mp.cpp
@@ -136,7 +136,6 @@ int cq_mgr_mp::poll_mp_cq(uint16_t &size, uint32_t &strides_used,
 		}
 		++m_cq_cons_index;
 		prefetch((uint8_t*)m_cqes + ((m_cq_cons_index & (m_cq_size - 1)) << m_cqe_log_sz));
-
 	} else {
 		size = 0;
 		flags = 0;


### PR DESCRIPTION
This commit adds supoprt for CPU using cahce line
different than 64. Till now cache line was assumed
to be 64, this cause failure in PPC64li.
Change was to treat CQE array as pointer instead
of array and take the cache line in to considiration
when getting CQE.

Signed-off-by: Rafi Wiener <rafiw@mellanox.com>