### PR TITLE
issue: 928148 Change g_b_exit with g_b_exit_vma

### DIFF
--- a/src/stats/stats_printer.cpp
+++ b/src/stats/stats_printer.cpp
@@ -131,7 +131,7 @@ user_params_t user_params;
 # endif
 #endif
 
-//extern bool 		g_b_exit;
+//extern bool 		g_b_exit_vma;
 //extern struct 		sigaction g_sigact;
 //extern uint8_t* 	g_fd_mask;
 //extern uint32_t 	g_fd_map_size;

--- a/src/stats/stats_reader.cpp
+++ b/src/stats/stats_reader.cpp
@@ -130,7 +130,7 @@ typedef enum {
 # endif
 #endif
 
-bool 		g_b_exit = false;
+bool 		g_b_exit_vma = false;
 struct 		sigaction g_sigact;
 uint8_t* 	g_fd_mask;
 uint32_t 	g_fd_map_size = e_K;
@@ -886,7 +886,7 @@ void stats_reader_sig_handler(int signum)
 		log_msg("Got signal %d - exiting", signum);
 		break;
 	}
-	g_b_exit = true;
+	g_b_exit_vma = true;
 }
 
 void set_signal_action()
@@ -1015,14 +1015,14 @@ void stats_reader_handler(sh_mem_t* p_sh_mem, int pid)
 		memcpy((void*)prev_bpool_blocks,(void*)p_sh_mem->bpool_inst_arr, NUM_OF_SUPPORTED_BPOOLS * sizeof(bpool_instance_block_t));
 		prev_iomux_blocks = curr_iomux_blocks;
 		uint64_t delay_int_micro = SEC_TO_MICRO(user_params.interval);
-		if (!g_b_exit && check_if_process_running(pid)){
+		if (!g_b_exit_vma && check_if_process_running(pid)){
 			usleep(delay_int_micro);
 		}
 	}
 	
 	set_signal_action();
 	
-	while (!g_b_exit && proc_running && (user_params.cycles ? (cycles < user_params.cycles) : (true)))
+	while (!g_b_exit_vma && proc_running && (user_params.cycles ? (cycles < user_params.cycles) : (true)))
 	{
 		++cycles;
 
@@ -1088,7 +1088,7 @@ void stats_reader_handler(sh_mem_t* p_sh_mem, int pid)
 		}
 		uint64_t delay_int_micro = SEC_TO_MICRO(user_params.interval);
 		uint64_t adjasted_delay = delay_int_micro - TIME_DIFF_in_MICRO(start, end);
-		if (!g_b_exit && proc_running){
+		if (!g_b_exit_vma && proc_running){
 			usleep(adjasted_delay);
             inc_read_counter(p_sh_mem);
 		}

--- a/src/vma/dev/ring_simple.cpp
+++ b/src/vma/dev/ring_simple.cpp
@@ -1227,7 +1227,7 @@ int ring_simple::vma_poll(struct vma_completion_t *vma_completions, unsigned int
 
 		m_vma_poll_completion = vma_completions;
 
-		while (!g_b_exit && (i < (int)ncompletions)) {
+		while (!g_b_exit_vma && (i < (int)ncompletions)) {
 			m_vma_poll_completion->events = 0;
 			/* Check list size to avoid locking */
 			if (!list_empty(&m_ec_list)) {

--- a/src/vma/iomux/io_mux_call.cpp
+++ b/src/vma/iomux/io_mux_call.cpp
@@ -367,7 +367,7 @@ void io_mux_call::polling_loops()
 		//check_timer_countdown -= m_num_offloaded_wfds; //TODO: consider the appropriate factor
 		poll_counter++;
 
-		if (g_b_exit || is_sig_pending()) {
+		if (g_b_exit_vma || is_sig_pending()) {
 			errno = EINTR;
 			vma_throw_object(io_mux_call::io_error);
 		}
@@ -413,7 +413,7 @@ void io_mux_call::blocking_loops()
 	 * If wait() returns without cq ready - timeout expired.
 	 */
 	do {
-		if (g_b_exit || is_sig_pending()) {
+		if (g_b_exit_vma || is_sig_pending()) {
 			errno = EINTR;
 			vma_throw_object(io_mux_call::io_error);
 		}
@@ -482,7 +482,7 @@ int io_mux_call::call()
 		// 1st scenario
 		timer_update();
 		wait_os(false);
-		if (g_b_exit || is_sig_pending()) {
+		if (g_b_exit_vma || is_sig_pending()) {
 			errno = EINTR;
 			vma_throw_object(io_mux_call::io_error);
 		}

--- a/src/vma/main.cpp
+++ b/src/vma/main.cpp
@@ -111,7 +111,7 @@ const char *vma_version_str = "VMA_VERSION: " PACKAGE_VERSION "-" STR(VMA_LIBRAR
 			      ;	// End of vma_version_str - used in "$ strings libvma.so | grep VMA_VERSION"
 
 
-bool g_b_exit = false;
+bool g_b_exit_vma = false;
 bool g_init_ibv_fork_done = false;
 bool g_is_forked_child = false;
 bool g_init_global_ctors_done = true;
@@ -122,7 +122,7 @@ static int free_libvma_resources()
 {
 	vlog_printf(VLOG_DEBUG, "%s: Closing libvma resources\n", __FUNCTION__);
 
-	g_b_exit = true;
+	g_b_exit_vma = true;
 
 	//Triggers connection close, relevant for TCP which may need some time to terminate the connection.
 	//and for any socket that may wait from another thread

--- a/src/vma/sock/sock-redirect.cpp
+++ b/src/vma/sock/sock-redirect.cpp
@@ -2227,7 +2227,7 @@ static void handler_intr(int sig)
 {
 	switch (sig) {
 	case SIGINT:
-		g_b_exit = true;
+		g_b_exit_vma = true;
 		srdr_logdbg("Catch Signal: SIGINT (%d)\n", sig);
 		break;
 	default:

--- a/src/vma/sock/sockinfo.cpp
+++ b/src/vma/sock/sockinfo.cpp
@@ -356,7 +356,7 @@ int sockinfo::rx_wait_helper(int &poll_count, bool is_blocking)
 
 	// if we polling too much - go to sleep
 	si_logfunc("too many polls without data blocking=%d", is_blocking);
-	if (g_b_exit)
+	if (g_b_exit_vma)
 		return -1;
 
 	if (!is_blocking) {

--- a/src/vma/sock/sockinfo_udp.cpp
+++ b/src/vma/sock/sockinfo_udp.cpp
@@ -183,7 +183,7 @@ inline int sockinfo_udp::rx_wait(bool blocking)
 			si_udp_logdbg("returning with: EBADFD");
 			return -1;
 		}
-		else if (unlikely(g_b_exit)) {
+		else if (unlikely(g_b_exit_vma)) {
 			errno = EINTR;
 			si_udp_logdbg("returning with: EINTR");
 			return -1;
@@ -197,7 +197,7 @@ inline int sockinfo_udp::rx_wait(bool blocking)
 			si_udp_logdbg("returning with: EBADFD");
 			return -1;
 		}
-		else if (unlikely(g_b_exit)) {
+		else if (unlikely(g_b_exit_vma)) {
 			errno = EINTR;
 			si_udp_logdbg("returning with: EINTR");
 			return -1;
@@ -487,7 +487,7 @@ int sockinfo_udp::bind(const struct sockaddr *__addr, socklen_t __addrlen)
 		// TODO: Should we set errno again (maybe log write modified the orig.bind() errno)?
 		return ret;
 	}
-	if (unlikely(m_b_closed) || unlikely(g_b_exit)) {
+	if (unlikely(m_b_closed) || unlikely(g_b_exit_vma)) {
 		errno = EBUSY;
 		return -1; // zero returned from orig_bind()
 	}
@@ -531,7 +531,7 @@ int sockinfo_udp::connect(const struct sockaddr *__to, socklen_t __tolen)
 		si_udp_logdbg("orig connect failed (ret=%d, errno=%d %m)", ret, errno);
 		return ret;
 	}
-	if (unlikely(m_b_closed) || unlikely(g_b_exit)) {
+	if (unlikely(m_b_closed) || unlikely(g_b_exit_vma)) {
 		errno = EBUSY;
 		return -1; // zero returned from orig_connect()
 	}
@@ -645,7 +645,7 @@ int sockinfo_udp::getsockname(struct sockaddr *__name, socklen_t *__namelen)
 {
 	si_udp_logdbg("");
 
-	if (unlikely(m_b_closed) || unlikely(g_b_exit)) {
+	if (unlikely(m_b_closed) || unlikely(g_b_exit_vma)) {
 		errno = EINTR;
 		return -1;
 	}
@@ -761,7 +761,7 @@ int sockinfo_udp::setsockopt(int __level, int __optname, __const void *__optval,
 {
 	si_udp_logfunc("level=%d, optname=%d", __level, __optname);
 
-	if (unlikely(m_b_closed) || unlikely(g_b_exit))
+	if (unlikely(m_b_closed) || unlikely(g_b_exit_vma))
 		return orig_os_api.setsockopt(m_fd, __level, __optname, __optval, __optlen);
 
 #ifdef DEFINED_VMAPOLL
@@ -1278,7 +1278,7 @@ int sockinfo_udp::getsockopt(int __level, int __optname, void *__optval, socklen
 
 	int ret = orig_os_api.getsockopt(m_fd, __level, __optname, __optval, __optlen);
 
-	if (unlikely(m_b_closed) || unlikely(g_b_exit))
+	if (unlikely(m_b_closed) || unlikely(g_b_exit_vma))
 		return ret;
 
 #ifdef DEFINED_VMAPOLL
@@ -1400,7 +1400,7 @@ ssize_t sockinfo_udp::rx(const rx_call_t call_type, iovec* p_iov,ssize_t sz_iov,
 		ret = -1;
 		goto out;
 	}
-	else if (unlikely(g_b_exit)) {
+	else if (unlikely(g_b_exit_vma)) {
 		errno = EINTR;
 		ret = -1;
 		goto out;
@@ -1764,7 +1764,7 @@ ssize_t sockinfo_udp::tx(const tx_call_t call_type, const iovec* p_iov, const ss
 	 * the underlying IPv4 protocol, is 65,507 bytes
 	 * (65,535 - 8 byte UDP header - 20 byte IP header).
 	 */
-	if (unlikely((m_b_closed) || (g_b_exit) ||
+	if (unlikely((m_b_closed) || (g_b_exit_vma) ||
 			(NULL == p_iov) ||
 			(0 >= sz_iov) ||
 			(NULL == p_iov[0].iov_base) ||
@@ -1987,7 +1987,7 @@ inline bool sockinfo_udp::inspect_uc_packet(mem_buf_desc_t* p_desc)
 		return false;
 	}
 
-	if (unlikely(m_b_closed) || unlikely(g_b_exit)) {
+	if (unlikely(m_b_closed) || unlikely(g_b_exit_vma)) {
 		si_udp_logfunc("rx packet discarded - fd closed");
 		return false;
 	}

--- a/src/vma/util/sys_vars.h
+++ b/src/vma/util/sys_vars.h
@@ -700,7 +700,7 @@ extern mce_sys_var & safe_mce_sys();
 
 #define VIRTUALIZATION_FLAG				"hypervisor"
 
-extern bool g_b_exit;
+extern bool g_b_exit_vma;
 extern bool g_is_forked_child;
 extern bool g_init_global_ctors_done;
 


### PR DESCRIPTION
This change resolves issue with symbol name conflict in sockperf
and libvma.
In final solution libvma should export just API symbols.

Signed-off-by: Igor Ivanov <igor.ivanov.va@gmail.com>