### PR TITLE
issue: 1150366 Align memory barrier to verbs's one

### DIFF
--- a/src/utils/asm-arm64.h
+++ b/src/utils/asm-arm64.h
@@ -47,7 +47,9 @@
 	*dst++ = *src++;	\
 	*dst++ = *src++
 
-#define wmb()	 asm volatile("" ::: "memory")
+#define mb()	asm volatile("dsb sy" ::: "memory")
+#define rmb()	asm volatile("dsb ld" ::: "memory")
+#define wmb()	asm volatile("dsb st" ::: "memory")
 #define wc_wmb() wmb()
 
 /**

--- a/src/utils/asm-ppc64.h
+++ b/src/utils/asm-ppc64.h
@@ -47,8 +47,10 @@
 	*dst++ = *src++;	\
 	*dst++ = *src++
 
-#define wmb()	 asm volatile("sync" ::: "memory")
-#define wc_wmb() wmb()
+#define mb()	 asm volatile("sync" ::: "memory")
+#define rmb()	 asm volatile("lwsync" ::: "memory")
+#define wmb()	 rmb()
+#define wc_wmb() mb()
 
 /**
  * Add to the atomic variable.

--- a/src/utils/asm-x86.h
+++ b/src/utils/asm-x86.h
@@ -40,6 +40,8 @@
 
 #define __xg(x) ((volatile long *)(x))
 
+#define mb()	 asm volatile("" ::: "memory")
+#define rmb()	 mb()
 #define wmb()	 asm volatile("" ::: "memory")
 #define wc_wmb() asm volatile("sfence" ::: "memory")
 

--- a/src/utils/asm.h
+++ b/src/utils/asm.h
@@ -38,8 +38,10 @@
 #include "asm-arm64.h"
 #elif defined(__powerpc64__)
 #include "asm-ppc64.h"
-#else
+#elif defined(__x86_64__)
 #include "asm-x86.h"
+#else
+#error No architecture specific memory barrier defenitions found!
 #endif
 
 #endif

--- a/src/vma/dev/cq_mgr.cpp
+++ b/src/vma/dev/cq_mgr.cpp
@@ -1010,7 +1010,7 @@ volatile struct mlx5_cqe64 *cq_mgr::mlx5_check_error_completion(volatile struct 
 		case MLX5_CQE_REQ_ERR:
 		case MLX5_CQE_RESP_ERR:
 			++(*ci);
-			wmb();
+			rmb();
 			*m_cq_db = htonl(m_cq_ci);
 			return cqe;
 		default:
@@ -1035,7 +1035,7 @@ inline volatile struct mlx5_cqe64 *cq_mgr::mlx5_get_cqe64(void)
 	}
 
 	++m_cq_ci;
-	wmb();
+	rmb();
 	*m_cq_db = htonl(m_cq_ci);
 
 	return cqe;
@@ -1060,7 +1060,7 @@ inline volatile struct mlx5_cqe64 *cq_mgr::mlx5_get_cqe64(volatile struct mlx5_c
 	}
 
 	++m_cq_ci;
-	wmb();
+	rmb();
 	*m_cq_db = htonl(m_cq_ci);
 
 	return cqe;

--- a/src/vma/dev/cq_mgr_mlx5.cpp
+++ b/src/vma/dev/cq_mgr_mlx5.cpp
@@ -459,7 +459,7 @@ inline volatile struct mlx5_cqe64* cq_mgr_mlx5::check_error_completion(volatile 
 	case MLX5_CQE_REQ_ERR:
 	case MLX5_CQE_RESP_ERR:
 		++(*ci);
-		wmb();
+		rmb();
 		*m_cq_dbell = htonl(m_cq_cons_index);
 		return cqe;
 

--- a/src/vma/dev/cq_mgr_mlx5.cpp
+++ b/src/vma/dev/cq_mgr_mlx5.cpp
@@ -145,7 +145,7 @@ mem_buf_desc_t* cq_mgr_mlx5::poll(enum buff_status_e& status)
 	if (likely(cqe)) {
 		/* Update the consumer index */
 		++m_cq_cons_index;
-		wmb();
+		rmb();
 		cqe64_to_mem_buff_desc(cqe, m_rx_hot_buffer, status);
 		++m_rq->tail;
 		*m_cq_dbell = htonl(m_cq_cons_index & 0xffffff);
@@ -485,7 +485,7 @@ inline volatile struct mlx5_cqe64 *cq_mgr_mlx5::get_cqe64(volatile struct mlx5_c
 	}
 
 	++m_cq_cons_index;
-	wmb();
+	rmb();
 	*m_cq_dbell = htonl(m_cq_cons_index);
 
 	return cqe;


### PR DESCRIPTION
This commit aligns the memory barrier used in vma
to the one used in verbs and the driver.
This fixes issues in ARM64 cpu

Signed-off-by: Rafi Wiener <rafiw@mellanox.com>