### PR TITLE
issue: 1156840 Add TCP Tx window availability

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -125,6 +125,15 @@ AS_IF([test "x$with_valgrind" == xno],
 )
 
 #
+# Enable tcp tx window availability
+#
+AC_ARG_ENABLE([tcp_tx_wnd_availability],
+    AC_HELP_STRING([--enable-tcp-tx-wnd-availability],
+                   [Enable TCP Tx window availability (TCP packets will only be sent if their size (hdrs + data) is less than or equal to the window size. Otherwise -1 is returned and errno is set to EAGAIN.)]),
+    [AC_DEFINE(DEFINED_TCP_TX_WND_AVAILABILITY, 1, [Define to 1 to enable TCP Tx window availability])],
+    [])
+
+#
 # Experimental Verbs CQ
 #
 AC_ARG_ENABLE([exp-cq],

--- a/configure.ac
+++ b/configure.ac
@@ -127,7 +127,7 @@ AS_IF([test "x$with_valgrind" == xno],
 #
 # Enable tcp tx window availability
 #
-AC_ARG_ENABLE([tcp_tx_wnd_availability],
+AC_ARG_ENABLE([tcp-tx-wnd-availability],
     AC_HELP_STRING([--enable-tcp-tx-wnd-availability],
                    [Enable TCP Tx window availability (TCP packets will only be sent if their size (hdrs + data) is less than or equal to the window size. Otherwise -1 is returned and errno is set to EAGAIN.)]),
     [AC_DEFINE(DEFINED_TCP_TX_WND_AVAILABILITY, 1, [Define to 1 to enable TCP Tx window availability])],

--- a/src/vma/lwip/tcp.h
+++ b/src/vma/lwip/tcp.h
@@ -518,6 +518,7 @@ void             tcp_setprio (struct tcp_pcb *pcb, u8_t prio);
 
 err_t            tcp_output  (struct tcp_pcb *pcb);
 
+int            is_window_available(struct tcp_pcb *pcb, unsigned int data_len);
 
 #define get_tcp_state(pcb) ((pcb)->private_state)
 #define set_tcp_state(pcb, state) external_tcp_state_observer((pcb)->my_container, (pcb)->private_state = state)

--- a/src/vma/lwip/tcp.h
+++ b/src/vma/lwip/tcp.h
@@ -518,7 +518,7 @@ void             tcp_setprio (struct tcp_pcb *pcb, u8_t prio);
 
 err_t            tcp_output  (struct tcp_pcb *pcb);
 
-int            is_window_available(struct tcp_pcb *pcb, unsigned int data_len);
+s32_t            tcp_is_wnd_available(struct tcp_pcb *pcb, u32_t data_len);
 
 #define get_tcp_state(pcb) ((pcb)->private_state)
 #define set_tcp_state(pcb, state) external_tcp_state_observer((pcb)->my_container, (pcb)->private_state = state)

--- a/src/vma/lwip/tcp_out.c
+++ b/src/vma/lwip/tcp_out.c
@@ -964,12 +964,22 @@ tcp_split_segment(struct tcp_pcb *pcb, struct tcp_seg *seg, u32_t wnd)
   return;
 }
 
-int
-is_window_available(struct tcp_pcb *pcb, unsigned int data_len)
+s32_t
+tcp_is_wnd_available(struct tcp_pcb *pcb, u32_t data_len)
 {
 	s32_t tot_unacked_len = 0;
 	s32_t tot_unsent_len = 0;
 	s32_t wnd = (s32_t)(LWIP_MIN(pcb->snd_wnd, pcb->cwnd));
+	s32_t tot_opts_hdrs_len = 0;
+
+	#if LWIP_TCP_TIMESTAMPS
+	  if (pcb->flags & TF_TIMESTAMP) {
+		u16_t mss = pcb->mss ? pcb->mss : 536;/* The default TCP Maximum Segment Size is 536 - RFC879 */
+		u16_t mss_local = LWIP_MIN(pcb->mss, pcb->snd_wnd_max/2);
+		mss_local = mss_local ? mss_local : mss;
+		tot_opts_hdrs_len = ((LWIP_TCP_OPT_LENGTH(TF_SEG_OPTS_TS)) * ( 1 + ((data_len-1)/(mss_local))));
+	  }
+	#endif
 
 	if (pcb->unacked) {
 		tot_unacked_len = pcb->last_unacked->seqno - pcb->unacked->seqno + pcb->last_unacked->len;
@@ -979,7 +989,7 @@ is_window_available(struct tcp_pcb *pcb, unsigned int data_len)
 		tot_unsent_len = pcb->last_unsent->seqno - pcb->unsent->seqno + pcb->last_unsent->len;
 	}
 
-	return ((wnd - tot_unacked_len) >= (tot_unsent_len + (signed int)(TCP_HLEN + data_len)));
+	return ((wnd - tot_unacked_len) >= (tot_unsent_len + (tot_opts_hdrs_len + (s32_t)data_len)));
 }
 
 /**

--- a/src/vma/lwip/tcp_out.c
+++ b/src/vma/lwip/tcp_out.c
@@ -972,14 +972,14 @@ tcp_is_wnd_available(struct tcp_pcb *pcb, u32_t data_len)
 	s32_t wnd = (s32_t)(LWIP_MIN(pcb->snd_wnd, pcb->cwnd));
 	s32_t tot_opts_hdrs_len = 0;
 
-	#if LWIP_TCP_TIMESTAMPS
-	  if (pcb->flags & TF_TIMESTAMP) {
-		u16_t mss = pcb->mss ? pcb->mss : 536;/* The default TCP Maximum Segment Size is 536 - RFC879 */
-		u16_t mss_local = LWIP_MIN(pcb->mss, pcb->snd_wnd_max/2);
+#if LWIP_TCP_TIMESTAMPS
+	if (pcb->flags & TF_TIMESTAMP) {
+		u16_t mss = pcb->mss ? pcb->mss : LWIP_TCP_MSS; /* The default TCP Maximum Segment Size is 536 (LWIP_TCP_MSS) - RFC-879 */
+		u16_t mss_local = LWIP_MIN(pcb->mss, pcb->snd_wnd_max / 2);
 		mss_local = mss_local ? mss_local : mss;
-		tot_opts_hdrs_len = ((LWIP_TCP_OPT_LENGTH(TF_SEG_OPTS_TS)) * ( 1 + ((data_len-1)/(mss_local))));
-	  }
-	#endif
+		tot_opts_hdrs_len = ((LWIP_TCP_OPT_LENGTH(TF_SEG_OPTS_TS)) * (1 + ((data_len - 1) / (mss_local))));
+	}
+#endif
 
 	if (pcb->unacked) {
 		tot_unacked_len = pcb->last_unacked->seqno - pcb->unacked->seqno + pcb->last_unacked->len;

--- a/src/vma/lwip/tcp_out.c
+++ b/src/vma/lwip/tcp_out.c
@@ -964,6 +964,24 @@ tcp_split_segment(struct tcp_pcb *pcb, struct tcp_seg *seg, u32_t wnd)
   return;
 }
 
+int
+is_window_available(struct tcp_pcb *pcb, unsigned int data_len)
+{
+	s32_t tot_unacked_len = 0;
+	s32_t tot_unsent_len = 0;
+	s32_t wnd = (s32_t)(LWIP_MIN(pcb->snd_wnd, pcb->cwnd));
+
+	if (pcb->unacked) {
+		tot_unacked_len = pcb->last_unacked->seqno - pcb->unacked->seqno + pcb->last_unacked->len;
+	}
+
+	if (pcb->unsent) {
+		tot_unsent_len = pcb->last_unsent->seqno - pcb->unsent->seqno + pcb->last_unsent->len;
+	}
+
+	return ((wnd - tot_unacked_len) >= (tot_unsent_len + (signed int)(TCP_HLEN + data_len)));
+}
+
 /**
  * Find out what we can send and send it
  *

--- a/src/vma/sock/sockinfo_tcp.cpp
+++ b/src/vma/sock/sockinfo_tcp.cpp
@@ -736,6 +736,14 @@ retry_is_ready:
 		return -1;
 	}
 
+#ifdef DEFINED_TCP_TX_WND_AVAILABILITY
+	if (!is_window_available(&m_pcb, p_iov[0].iov_len)) {
+		unlock_tcp_con();
+		errno = EAGAIN;
+		return -1;
+	}
+#endif
+
 	for (int i = 0; i < sz_iov; i++) {
 		si_tcp_logfunc("iov:%d base=%p len=%d", i, p_iov[i].iov_base, p_iov[i].iov_len);
 

--- a/src/vma/sock/sockinfo_tcp.cpp
+++ b/src/vma/sock/sockinfo_tcp.cpp
@@ -737,7 +737,7 @@ retry_is_ready:
 	}
 
 #ifdef DEFINED_TCP_TX_WND_AVAILABILITY
-	if (!is_window_available(&m_pcb, p_iov[0].iov_len)) {
+	if (!tcp_is_wnd_available(&m_pcb, p_iov[0].iov_len)) {
 		unlock_tcp_con();
 		errno = EAGAIN;
 		return -1;


### PR DESCRIPTION
If DEFINED_TCP_TX_WND_AVAILABILITY is enabled, TCP packet will
only be sent if it less than or equal to window size, otherwise -1
error will be return with EAGAIN errno.

(./configure --enable-tcp-tx-wnd-availability)

Signed-off-by: Daniel Libenson <danielli@mellanox.com>