### PR TITLE
issue: 1150011 Fix ioctl() FIONREAD return value while no data is ava…

### DIFF
--- a/src/vma/sock/sockinfo_tcp.cpp
+++ b/src/vma/sock/sockinfo_tcp.cpp
@@ -2423,9 +2423,16 @@ int sockinfo_tcp::listen(int backlog)
 int sockinfo_tcp::rx_verify_available_data()
 {
 	int poll_count = 0;
+
+	// Poll cq to verify the latest amount of ready bytes
 	int ret = rx_wait_helper(poll_count, false);
 
-	return (ret == -1 ? ret : m_p_socket_stats->n_rx_ready_byte_count);
+	if (ret >= 0 || errno == EAGAIN) {
+		errno = 0;
+		ret = m_p_socket_stats->n_rx_ready_byte_count;
+	}
+
+	return ret;
 }
 
 int sockinfo_tcp::accept_helper(struct sockaddr *__addr, socklen_t *__addrlen, int __flags /* = 0 */)


### PR DESCRIPTION
…ilable

During ioctl() with FIONREAD call, In order to verify if there is data
available for reading, VMA calls non blocking rx_wait().
When no data was available, we would return an error (EAGAIN).

Signed-off-by: Liran Oz <lirano@mellanox.com>