### PR TITLE
issue: 1154650 Fix IP fragmentation threshold

### DIFF
--- a/src/vma/proto/dst_entry.cpp
+++ b/src/vma/proto/dst_entry.cpp
@@ -125,6 +125,7 @@ void dst_entry::init_members()
 	m_p_send_wqe = NULL;
 	m_max_inline = 0;
 	m_max_ip_payload_size = 0;
+	m_max_udp_payload_size = 0;
 	m_b_force_os = false;
 }
 
@@ -546,7 +547,8 @@ bool dst_entry::prepare_to_send(const int ratelimit_kbps, bool skip_rules, bool 
 		set_state(true);
 		if (resolve_net_dev(is_connect)) {
 			set_src_addr();
-			m_max_ip_payload_size = ((m_p_net_dev_val->get_mtu()-sizeof(struct iphdr)) & ~0x7);
+			m_max_udp_payload_size = m_p_net_dev_val->get_mtu() - sizeof(struct iphdr);
+			m_max_ip_payload_size = m_max_udp_payload_size & ~0x7;
 			if (resolve_ring()) {
 				is_ofloaded = true;
 				if (ratelimit_kbps) {

--- a/src/vma/proto/dst_entry.h
+++ b/src/vma/proto/dst_entry.h
@@ -134,8 +134,8 @@ protected:
 	vma_ibv_send_wr* 	m_p_send_wqe;
 	uint32_t 		m_max_inline;
 	ring_user_id_t		m_id;
-	size_t			m_max_ip_payload_size;
-	size_t			m_max_udp_payload_size;
+	uint16_t		m_max_ip_payload_size;
+	uint16_t		m_max_udp_payload_size;
 
 	virtual transport_t 	get_transport(sockaddr_in to) = 0;
 	virtual uint8_t 	get_protocol_type() const = 0;

--- a/src/vma/proto/dst_entry.h
+++ b/src/vma/proto/dst_entry.h
@@ -133,8 +133,9 @@ protected:
 
 	vma_ibv_send_wr* 	m_p_send_wqe;
 	uint32_t 		m_max_inline;
-	ring_user_id_t 	m_id;
+	ring_user_id_t		m_id;
 	size_t			m_max_ip_payload_size;
+	size_t			m_max_udp_payload_size;
 
 	virtual transport_t 	get_transport(sockaddr_in to) = 0;
 	virtual uint8_t 	get_protocol_type() const = 0;

--- a/src/vma/proto/dst_entry_udp.cpp
+++ b/src/vma/proto/dst_entry_udp.cpp
@@ -212,7 +212,7 @@ ssize_t dst_entry_udp::fast_send_fragmented(const iovec* p_iov, const ssize_t sz
 
 	while (n_num_frags--) {
 		// Calc this ip datagram fragment size (include any udp header)
-		size_t sz_ip_frag = min(m_max_ip_payload_size, (sz_udp_payload - n_ip_frag_offset));
+		size_t sz_ip_frag = min((size_t)m_max_ip_payload_size, (sz_udp_payload - n_ip_frag_offset));
 		size_t sz_user_data_to_copy = sz_ip_frag;
 		size_t hdr_len = m_header.m_transport_header_len + m_header.m_ip_header_len; // Add count of L2 (ipoib or mac) header length
 
@@ -315,7 +315,7 @@ ssize_t dst_entry_udp::fast_send(const iovec* p_iov, const ssize_t sz_iov,
 	// Calc udp payload size
 	size_t sz_udp_payload = sz_data_payload + sizeof(struct udphdr);
 	vma_wr_tx_packet_attr attr = (vma_wr_tx_packet_attr)((VMA_TX_PACKET_BLOCK * b_blocked) | (VMA_TX_PACKET_DUMMY * is_dummy));
-	if (sz_udp_payload <= m_max_udp_payload_size) {
+	if (sz_udp_payload <= (size_t)m_max_udp_payload_size) {
 		return fast_send_not_fragmented(p_iov, sz_iov, attr, sz_udp_payload, sz_data_payload);
 	} else {
 		return fast_send_fragmented(p_iov, sz_iov, attr, sz_udp_payload, sz_data_payload);

--- a/src/vma/proto/dst_entry_udp.cpp
+++ b/src/vma/proto/dst_entry_udp.cpp
@@ -314,8 +314,8 @@ ssize_t dst_entry_udp::fast_send(const iovec* p_iov, const ssize_t sz_iov,
 
 	// Calc udp payload size
 	size_t sz_udp_payload = sz_data_payload + sizeof(struct udphdr);
-        vma_wr_tx_packet_attr attr = (vma_wr_tx_packet_attr)((VMA_TX_PACKET_BLOCK*b_blocked) | (VMA_TX_PACKET_DUMMY*is_dummy));
-	if (sz_udp_payload <= m_max_ip_payload_size) {
+	vma_wr_tx_packet_attr attr = (vma_wr_tx_packet_attr)((VMA_TX_PACKET_BLOCK * b_blocked) | (VMA_TX_PACKET_DUMMY * is_dummy));
+	if (sz_udp_payload <= m_max_udp_payload_size) {
 		return fast_send_not_fragmented(p_iov, sz_iov, attr, sz_udp_payload, sz_data_payload);
 	} else {
 		return fast_send_fragmented(p_iov, sz_iov, attr, sz_udp_payload, sz_data_payload);


### PR DESCRIPTION
The decision on the maximum size to be fragmented should be based on
the MTU, IP header (20 bytes) and UDP header (8 bytes) without any
alignment.
When fragmentation is performed, the size of each fragment should be
aligned to 8 bytes because of the limits of the offset field.

Signed-off-by: Liran Oz <lirano@mellanox.com>