### PR TITLE
issue: 1168028 Add support for static ARP entries

### DIFF
--- a/src/vma/proto/neighbour.cpp
+++ b/src/vma/proto/neighbour.cpp
@@ -356,13 +356,13 @@ void neigh_entry::handle_timer_expired(void* ctx)
 		}
 	}
 
-	if (state != NUD_REACHABLE) {
-		neigh_logdbg("State is different from NUD_REACHABLE and L2 address wasn't changed. Sending ARP");
+	if (!priv_is_reachable(state)) {
+		neigh_logdbg("State is different from NUD_REACHABLE or NUD_PERMANENT and L2 address wasn't changed. Sending ARP");
 		send_arp();
 		m_timer_handle = priv_register_timer_event(m_n_sysvar_neigh_wait_till_send_arp_msec, this, ONE_SHOT_TIMER, NULL);
 	}
 	else {
-		neigh_logdbg("State is NUD_REACHABLE and L2 address wasn't changed. Stop sending ARP");
+		neigh_logdbg("State is NUD_REACHABLE or NUD_PERMANENT and L2 address wasn't changed. Stop sending ARP");
 	}
 }
 
@@ -713,6 +713,7 @@ void neigh_entry::handle_neigh_event(neigh_nl_event* nl_ev)
 		break;
 	}
 	case NUD_REACHABLE:
+	case NUD_PERMANENT:
 	{
 		BULLSEYE_EXCLUDE_BLOCK_START
 		if(m_state_machine == NULL) {
@@ -1036,7 +1037,7 @@ int neigh_entry::priv_enter_addr_resolved()
 
 	int state;
 
-	if (!priv_get_neigh_state(state) || state != NUD_REACHABLE) {
+	if (!priv_get_neigh_state(state) || !priv_is_reachable(state)) {
 		neigh_logdbg("got addr_resolved but state=%d", state);
 		send_arp();
 		m_timer_handle = priv_register_timer_event(m_n_sysvar_neigh_wait_till_send_arp_msec, this, ONE_SHOT_TIMER, NULL);
@@ -1138,7 +1139,7 @@ int neigh_entry::priv_enter_ready()
 	// This is the case when VMA was started with neigh in STALE state and
 	// rdma_adress_resolve() in this case will not initiate ARP
 	if (m_type == UC && ! m_is_loopback) {
-		if (priv_get_neigh_state(state) && (state != NUD_REACHABLE)) {
+		if (priv_get_neigh_state(state) && !priv_is_reachable(state)) {
 			send_arp();
 			m_timer_handle = priv_register_timer_event(m_n_sysvar_neigh_wait_till_send_arp_msec, this, ONE_SHOT_TIMER, NULL);
 		}

--- a/src/vma/proto/neighbour.cpp
+++ b/src/vma/proto/neighbour.cpp
@@ -357,12 +357,12 @@ void neigh_entry::handle_timer_expired(void* ctx)
 	}
 
 	if (!priv_is_reachable(state)) {
-		neigh_logdbg("State is different from NUD_REACHABLE or NUD_PERMANENT and L2 address wasn't changed. Sending ARP");
+		neigh_logdbg("State (%d) is not reachable and L2 address wasn't changed. Sending ARP", state);
 		send_arp();
 		m_timer_handle = priv_register_timer_event(m_n_sysvar_neigh_wait_till_send_arp_msec, this, ONE_SHOT_TIMER, NULL);
 	}
 	else {
-		neigh_logdbg("State is NUD_REACHABLE or NUD_PERMANENT and L2 address wasn't changed. Stop sending ARP");
+		neigh_logdbg("State is reachable (%s %d) and L2 address wasn't changed. Stop sending ARP", (state == NUD_REACHABLE) ? "NUD_REACHABLE" : "NUD_PERMANENT", state);
 	}
 }
 

--- a/src/vma/proto/neighbour.h
+++ b/src/vma/proto/neighbour.h
@@ -325,6 +325,7 @@ protected:
 
 	bool 			priv_get_neigh_state(int & state);
 	bool 			priv_get_neigh_l2(address_t & l2_addr);
+	bool 			priv_is_reachable(int state) { return state & (NUD_REACHABLE | NUD_PERMANENT); }
 
 	void			event_handler(event_t event, void* p_event_info = NULL);
 	void			priv_event_handler_no_locks(event_t event, void* p_event_info = NULL);


### PR DESCRIPTION
ARP (short for "Address Resolution Protocol") is a network protocol used
to map an IP network address to a corresponding hardware MAC address.
When static ARP entries are added manually on locally cached ARP table,
there is no need to send out ARP requests.

Signed-off-by: Liran Oz <lirano@mellanox.com>