### PR TITLE
issue: 1069965 Remove ldconfig from installation

### DIFF
--- a/src/vma/Makefile.am
+++ b/src/vma/Makefile.am
@@ -42,7 +42,6 @@ install-exec-hook:
 	rm -f $(DESTDIR)$(libdir)/libvma.a
 	rm -f $(DESTDIR)$(bindir)/state_machine_test
 	rm -f $(DESTDIR)$(bindir)/vlogger_test
-	if [[ `id -u` -eq 0 ]];then /sbin/ldconfig || true;fi
 
 uninstall-hook:
 	rm -f $(DESTDIR)$(libdir)/libvma.so*


### PR DESCRIPTION
User who installs any application/library should be responsible
for library cache area update. Using this explicitly
during make install does not allow a user to control/manage
installation process.
At the same time there are different restricted environments,
such as Gentoo sandbox, that consider such call as violation.

Signed-off-by: Igor Ivanov <igor.ivanov.va@gmail.com>