### PR TITLE
issue: 1175096 VMA failed to detect FILLER in MP_RQ

### DIFF
--- a/src/vma/dev/cq_mgr_mp.cpp
+++ b/src/vma/dev/cq_mgr_mp.cpp
@@ -122,15 +122,17 @@ int cq_mgr_mp::poll_mp_cq(uint16_t &size, uint32_t &strides_used,
 		uint32_t stride_byte_cnt = ntohl(cqe->byte_cnt);
 		strides_used += (stride_byte_cnt & MP_RQ_NUM_STRIDES_FIELD_MASK) >>
 				MP_RQ_NUM_STRIDES_FIELD_SHIFT;
-		flags = (!!(cqe->hds_ip_ext & MLX5_CQE_L4_OK) * IBV_EXP_CQ_RX_TCP_UDP_CSUM_OK) |
-			(!!(cqe->hds_ip_ext & MLX5_CQE_L3_OK) * IBV_EXP_CQ_RX_IP_CSUM_OK);
-		if (likely(flags == UDP_OK_FLAGS)) {
-			size = stride_byte_cnt & MP_RQ_BYTE_CNT_FIELD_MASK;
-		} else {
-			// if CSUM is bad it can be either filler or bad packet
+		if (unlikely(stride_byte_cnt & MP_RQ_FILLER_FIELD_MASK)) {
 			flags = VMA_MP_RQ_BAD_PACKET;
 			size = 1;
-			if (stride_byte_cnt & MP_RQ_FILLER_FIELD_MASK) {
+		} else {
+			flags = (!!(cqe->hds_ip_ext & MLX5_CQE_L4_OK) * IBV_EXP_CQ_RX_TCP_UDP_CSUM_OK) |
+				(!!(cqe->hds_ip_ext & MLX5_CQE_L3_OK) * IBV_EXP_CQ_RX_IP_CSUM_OK);
+			if (likely(flags == UDP_OK_FLAGS)) {
+				size = stride_byte_cnt & MP_RQ_BYTE_CNT_FIELD_MASK;
+			} else {
+				flags = VMA_MP_RQ_BAD_PACKET;
+				size = 1;
 				m_p_cq_stat->n_rx_pkt_drop++;
 			}
 		}


### PR DESCRIPTION
VMA assumed that in filler messages the IP CSUM bit is off
this assumption is not correct.

Signed-off-by: Rafi Wiener <rafiw@mellanox.com>