### PR TITLE
issue: 1172255 Disable parser warning coverity checker

### DIFF
--- a/contrib/jenkins_tests/cov.sh
+++ b/contrib/jenkins_tests/cov.sh
@@ -33,6 +33,7 @@ done
 eval "cov-analyze --config $cov_dir/coverity_config.xml \
 	--all --aggressiveness-level low \
 	--enable-fnptr --fnptr-models --paths 20000 \
+	--disable-parse-warnings \
 	--dir $cov_build"
 rc=$(($rc+$?))
 


### PR DESCRIPTION
This change is done to suppress PW.INCLUDE_RECURSION
issue in third-party source as netlink/netlink.h
The issue is observed in libnl3 (not in libnl)
Event include_recursion:
includes itself: netlink.h -> object.h -> netlink.h

Signed-off-by: Igor Ivanov <igor.ivanov.va@gmail.com>