### PR TITLE
issue: 1181379 Fix a TCP zero-wnd probe when there is data in-flight

### DIFF
--- a/contrib/jenkins_tests/cov.sh
+++ b/contrib/jenkins_tests/cov.sh
@@ -33,6 +33,7 @@ done
 eval "cov-analyze --config $cov_dir/coverity_config.xml \
 	--all --aggressiveness-level low \
 	--enable-fnptr --fnptr-models --paths 20000 \
+	--disable-parse-warnings \
 	--dir $cov_build"
 rc=$(($rc+$?))
 

--- a/contrib/jenkins_tests/globals.sh
+++ b/contrib/jenkins_tests/globals.sh
@@ -118,7 +118,7 @@ function do_github_status()
 function do_module()
 {
     echo "Checking module $1"
-    if [ $(command -v module >/dev/null 2>&1 || echo $?) ]; then
+    if [[ $(module avail 2>&1 | grep $1 -q > /dev/null || echo $?) ]]; then
 	    echo "[SKIP] module tool does not exist"
 	    exit 0
 	else

--- a/src/vma/lwip/tcp.c
+++ b/src/vma/lwip/tcp.c
@@ -728,7 +728,7 @@ tcp_slowtmr(struct tcp_pcb* pcb)
 	  LWIP_DEBUGF(TCP_DEBUG, ("tcp_slowtmr: max DATA retries reached\n"));
 	} else {
 	  if (pcb->persist_backoff > 0) {
-		/* If snd_wnd is zero, use persist timer to send 1 byte probes
+		/* If snd_wnd is zero and pcb->unacked is NULL , use persist timer to send 1 byte probes
 		 * instead of using the standard retransmission mechanism. */
 		pcb->persist_cnt++;
 		if (pcb->persist_cnt >= tcp_persist_backoff[pcb->persist_backoff-1]) {

--- a/src/vma/lwip/tcp_in.c
+++ b/src/vma/lwip/tcp_in.c
@@ -763,7 +763,7 @@ tcp_receive(struct tcp_pcb *pcb, tcp_in_data* in_data)
       pcb->snd_wl1 = in_data->seqno;
       pcb->snd_wl2 = in_data->ackno;
       if (pcb->snd_wnd == 0) {
-        if (pcb->persist_backoff == 0) {
+        if (pcb->persist_backoff == 0 && pcb->unacked == NULL) {
           /* start persist timer */
           pcb->persist_cnt = 0;
           pcb->persist_backoff = 1;

--- a/src/vma/lwip/tcp_out.c
+++ b/src/vma/lwip/tcp_out.c
@@ -1552,6 +1552,7 @@ tcp_zero_window_probe(struct tcp_pcb *pcb)
   struct tcp_seg *seg;
   u16_t len;
   u8_t is_fin;
+  u32_t snd_nxt;
 
   LWIP_DEBUGF(TCP_DEBUG,
               ("tcp_zero_window_probe: sending ZERO WINDOW probe to %"
@@ -1589,6 +1590,12 @@ tcp_zero_window_probe(struct tcp_pcb *pcb)
     /* Data segment, copy in one byte from the head of the unacked queue */
     *((char *)p->payload + TCP_HLEN) = *(char *)seg->dataptr;
   }
+
+   /* The byte may be acknowledged without the window being opened. */
+   snd_nxt = lwip_ntohl(seg->tcphdr->seqno) + 1;
+   if (TCP_SEQ_LT(pcb->snd_nxt, snd_nxt)) {
+     pcb->snd_nxt = snd_nxt;
+   }
 
 #if CHECKSUM_GEN_TCP
   tcphdr->chksum = inet_chksum_pseudo(p, &pcb->local_ip, &pcb->remote_ip,

--- a/src/vma/lwip/tcp_out.c
+++ b/src/vma/lwip/tcp_out.c
@@ -1564,12 +1564,10 @@ tcp_zero_window_probe(struct tcp_pcb *pcb)
                "   pcb->tmr %"U32_F" pcb->keep_cnt_sent %"U16_F"\n",
                tcp_ticks, pcb->tmr, pcb->keep_cnt_sent));
 
-  seg = pcb->unacked;
-
+  /* Only consider unsent, persist timer should be off when there data is in-flight */
+  seg = pcb->unsent;
   if(seg == NULL) {
-    seg = pcb->unsent;
-  }
-  if(seg == NULL) {
+    /* Not expected, persist timer should be off when the send buffer is empty */
     return;
   }
 


### PR DESCRIPTION
TCP zero-window probe message should not be sent when there
is data in-flight(unacked packets, pcb->unacked != NULL).

Signed-off-by: Daniel Libenson <danielli@mellanox.com>