### PR TITLE
issue: 1182826 check if the module parameters exists

### DIFF
--- a/contrib/jenkins_tests/globals.sh
+++ b/contrib/jenkins_tests/globals.sh
@@ -118,7 +118,7 @@ function do_github_status()
 function do_module()
 {
     echo "Checking module $1"
-    if [[ $(module avail 2>&1 | grep $1 -q > /dev/null || echo $?) ]]; then
+    if [[ $(module avail 2>&1 | grep "$1" -q > /dev/null || echo $?) ]]; then
 	    echo "[SKIP] module tool does not exist"
 	    exit 0
 	else

--- a/contrib/jenkins_tests/globals.sh
+++ b/contrib/jenkins_tests/globals.sh
@@ -118,7 +118,7 @@ function do_github_status()
 function do_module()
 {
     echo "Checking module $1"
-    if [ $(command -v module >/dev/null 2>&1 || echo $?) ]; then
+    if [[ $(module avail 2>&1 | grep $1 -q > /dev/null || echo $?) ]]; then
 	    echo "[SKIP] module tool does not exist"
 	    exit 0
 	else


### PR DESCRIPTION
This change verifies modules parameters exists instead of module application
and by this fixes compilation if icc compiler is not available in the machine.

Signed-off-by: Rafi Wiener <rafiw@mellanox.com>