### PR TITLE
issue: 1176937 Add delayed ack control

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -1,4 +1,4 @@
-Update: 13 Sep 2017
+Update: 07 Nov 2017
 
 Introduction
 ============
@@ -165,7 +165,8 @@ Example:
  VMA DETAILS: TCP Timer Resolution (msec)    100                        [VMA_TCP_TIMER_RESOLUTION_MSEC]
  VMA DETAILS: TCP control thread             0 (Disabled)               [VMA_TCP_CTL_THREAD]
  VMA DETAILS: TCP timestamp option           0                          [VMA_TCP_TIMESTAMP_OPTION]
- VMA DETAILS: TCP nodelay                    0                          [VMA_TCP_NODELAY]
+ VMA DETAILS: TCP nodelay mode               0                          [VMA_TCP_NODELAY]
+ VMA DETAILS: TCP quickack mode              0                          [VMA_TCP_QUICKACK]
  VMA DETAILS: Exception handling mode        -1(just log debug message) [VMA_EXCEPTION_HANDLING]
  VMA DETAILS: Avoid sys-calls on tcp fd      Disabled                   [VMA_AVOID_SYS_CALLS_ON_TCP_FD]
  VMA DETAILS: Allow privileged sock opt      Enabled                    [VMA_ALLOW_PRIVILEGED_SOCK_OPT]
@@ -735,6 +736,15 @@ If set, disable the Nagle algorithm option for each TCP socket during initializa
 This means that TCP segments are always sent as soon as possible, even if there is
 only a small amount of data.
 For more information on TCP_NODELAY flag refer to tcp manual page.
+Valid Values are:
+Use value of 0 to disable.
+Use value of 1 for enable.
+Default value is Disabled.
+
+VMA_TCP_QUICKACK
+If set, disable delayed ack ability.
+This means that TCP responds after every packet.
+For more information on TCP_QUICKACK flag refer to tcp manual page.
 Valid Values are:
 Use value of 0 to disable.
 Use value of 1 for enable.

--- a/src/vma/lwip/tcp.c
+++ b/src/vma/lwip/tcp.c
@@ -1133,6 +1133,7 @@ void tcp_pcb_init (struct tcp_pcb* pcb, u8_t prio)
 #endif /* LWIP_TCP_KEEPALIVE */
 
 	pcb->keep_cnt_sent = 0;
+	pcb->ack_quick = 0;
 	pcb->enable_ts_opt = enable_ts_option;
 	pcb->seg_alloc = NULL;
 	pcb->pbuf_alloc = NULL;

--- a/src/vma/lwip/tcp.h
+++ b/src/vma/lwip/tcp.h
@@ -418,6 +418,9 @@ struct tcp_pcb {
   u8_t accepts_pending;
 #endif /* TCP_LISTEN_BACKLOG */
 #endif /* VMA_NO_TCP_PCB_LISTEN_STRUCT */
+
+  /* Delayed ACK control: number of quick acks */
+  u8_t ack_quick;
 };
 
 #ifdef VMA_NO_TCP_PCB_LISTEN_STRUCT

--- a/src/vma/lwip/tcp_in.c
+++ b/src/vma/lwip/tcp_in.c
@@ -1263,7 +1263,7 @@ tcp_receive(struct tcp_pcb *pcb, tcp_in_data* in_data)
 
 
         /* Acknowledge the segment(s). */
-        if (in_data->recv_data && in_data->recv_data->next) {
+        if ((0 != pcb->ack_quick) || (in_data->recv_data && in_data->recv_data->next)) {
         	tcp_ack_now(pcb);
         } else {
         	tcp_ack(pcb);

--- a/src/vma/main.cpp
+++ b/src/vma/main.cpp
@@ -572,7 +572,8 @@ void print_vma_global_settings()
 	VLOG_PARAM_NUMBER("TCP Timer Resolution (msec)", safe_mce_sys().tcp_timer_resolution_msec, MCE_DEFAULT_TCP_TIMER_RESOLUTION_MSEC, SYS_VAR_TCP_TIMER_RESOLUTION_MSEC);
 	VLOG_PARAM_NUMSTR("TCP control thread", safe_mce_sys().tcp_ctl_thread, MCE_DEFAULT_TCP_CTL_THREAD, SYS_VAR_TCP_CTL_THREAD, ctl_thread_str(safe_mce_sys().tcp_ctl_thread));
 	VLOG_PARAM_NUMBER("TCP timestamp option", safe_mce_sys().tcp_ts_opt, MCE_DEFAULT_TCP_TIMESTAMP_OPTION, SYS_VAR_TCP_TIMESTAMP_OPTION);
-	VLOG_PARAM_NUMBER("TCP nodelay", safe_mce_sys().tcp_nodelay, MCE_DEFAULT_TCP_NODELAY, SYS_VAR_TCP_NODELAY);
+	VLOG_PARAM_NUMBER("TCP nodelay mode", safe_mce_sys().tcp_nodelay, MCE_DEFAULT_TCP_NODELAY, SYS_VAR_TCP_NODELAY);
+	VLOG_PARAM_NUMBER("TCP quickack mode", safe_mce_sys().tcp_quickack, MCE_DEFAULT_TCP_QUICKACK, SYS_VAR_TCP_QUICKACK);
 	VLOG_PARAM_NUMSTR(vma_exception_handling::getName(), (int)safe_mce_sys().exception_handling, vma_exception_handling::MODE_DEFAULT, vma_exception_handling::getSysVar(), safe_mce_sys().exception_handling.to_str());
 	VLOG_PARAM_STRING("Avoid sys-calls on tcp fd", safe_mce_sys().avoid_sys_calls_on_tcp_fd, MCE_DEFAULT_AVOID_SYS_CALLS_ON_TCP_FD, SYS_VAR_AVOID_SYS_CALLS_ON_TCP_FD, safe_mce_sys().avoid_sys_calls_on_tcp_fd ? "Enabled" : "Disabled");
 	VLOG_PARAM_STRING("Allow privileged sock opt", safe_mce_sys().allow_privileged_sock_opt, MCE_DEFAULT_ALLOW_PRIVILEGED_SOCK_OPT, SYS_VAR_ALLOW_PRIVILEGED_SOCK_OPT, safe_mce_sys().allow_privileged_sock_opt ? "Enabled" : "Disabled");

--- a/src/vma/sock/sockinfo_tcp.cpp
+++ b/src/vma/sock/sockinfo_tcp.cpp
@@ -288,6 +288,15 @@ sockinfo_tcp::sockinfo_tcp(int fd):
 		}
 	}
 
+	if (safe_mce_sys().tcp_quickack) {
+		try {
+			int value = 1;
+			setsockopt(IPPROTO_TCP, TCP_QUICKACK, &value, sizeof(value));
+		} catch (vma_error&) {
+			// We should not be here
+		}
+	}
+
 	si_tcp_logdbg("TCP PCB FLAGS: 0x%x", m_pcb.flags);
 	si_tcp_logfunc("done");
 }

--- a/src/vma/sock/sockinfo_tcp.cpp
+++ b/src/vma/sock/sockinfo_tcp.cpp
@@ -3304,7 +3304,7 @@ bad_state:
 #define TCP_DEFER_ACCEPT 9      /* Wake up listener only when data arrive */
 #define TCP_WINDOW_CLAMP 10     /* Bound advertised window */
 #define TCP_INFO         11     /* Information about this connection. */
-#define TCP_QUICKACK     12     /* Bock/reenable quick ACKs.  */
+#define TCP_QUICKACK     12     /* Block/reenable quick ACKs.  */
 
 int sockinfo_tcp::fcntl(int __cmd, unsigned long int __arg)
 {
@@ -3453,6 +3453,13 @@ int sockinfo_tcp::setsockopt(int __level, int __optname,
 			unlock_tcp_con();
 			si_tcp_logdbg("(TCP_NODELAY) nagle: %d", val);
 			break;	
+		case TCP_QUICKACK:
+			val = *(int *)__optval;
+			lock_tcp_con();
+			m_pcb.ack_quick = (uint8_t)(val > 0 ? val : 0);
+			unlock_tcp_con();
+			si_tcp_logdbg("(TCP_QUICKACK) value: %d", val);
+			break;
 		default:
 			ret = SOCKOPT_HANDLE_BY_OS;
 			supported = false;
@@ -3659,6 +3666,15 @@ int sockinfo_tcp::getsockopt_offload(int __level, int __optname, void *__optval,
         		if (*__optlen >= sizeof(int)) {
         			*(int *)__optval = tcp_nagle_disabled(&m_pcb);
         			si_tcp_logdbg("(TCP_NODELAY) nagle: %d", *(int *)__optval);
+        			ret = 0;
+        		} else {
+        			errno = EINVAL;
+        		}
+        		break;
+		case TCP_QUICKACK:
+        		if (*__optlen >= sizeof(int)) {
+        			*(int *)__optval = m_pcb.ack_quick;
+        			si_tcp_logdbg("(TCP_QUICKACK) value: %d", *(int *)__optval);
         			ret = 0;
         		} else {
         			errno = EINVAL;

--- a/src/vma/util/sys_vars.cpp
+++ b/src/vma/util/sys_vars.cpp
@@ -515,6 +515,7 @@ void mce_sys_var::get_env_params()
 	tcp_ctl_thread		= MCE_DEFAULT_TCP_CTL_THREAD;
 	tcp_ts_opt		= MCE_DEFAULT_TCP_TIMESTAMP_OPTION;
 	tcp_nodelay		= MCE_DEFAULT_TCP_NODELAY;
+	tcp_quickack		= MCE_DEFAULT_TCP_QUICKACK;
 //	exception_handling is handled by its CTOR
 	avoid_sys_calls_on_tcp_fd = MCE_DEFAULT_AVOID_SYS_CALLS_ON_TCP_FD;
 	allow_privileged_sock_opt = MCE_DEFAULT_ALLOW_PRIVILEGED_SOCK_OPT;
@@ -1023,6 +1024,10 @@ void mce_sys_var::get_env_params()
 
 	if ((env_ptr = getenv(SYS_VAR_TCP_NODELAY)) != NULL) {
 		tcp_nodelay = atoi(env_ptr) ? true : false;
+	}
+
+	if ((env_ptr = getenv(SYS_VAR_TCP_QUICKACK)) != NULL) {
+		tcp_quickack = atoi(env_ptr) ? true : false;
 	}
 
 	// TODO: this should be replaced by calling "exception_handling.init()" that will be called from init()

--- a/src/vma/util/sys_vars.h
+++ b/src/vma/util/sys_vars.h
@@ -372,6 +372,7 @@ struct mce_sys_var {
 	tcp_ctl_thread_t tcp_ctl_thread;
 	tcp_ts_opt_t	tcp_ts_opt;
 	bool		tcp_nodelay;
+	bool		tcp_quickack;
 	vma_exception_handling exception_handling;
 	bool		avoid_sys_calls_on_tcp_fd;
 	bool		allow_privileged_sock_opt;
@@ -501,6 +502,7 @@ extern mce_sys_var & safe_mce_sys();
 #define SYS_VAR_TCP_CTL_THREAD				"VMA_TCP_CTL_THREAD"
 #define SYS_VAR_TCP_TIMESTAMP_OPTION			"VMA_TCP_TIMESTAMP_OPTION"
 #define SYS_VAR_TCP_NODELAY				"VMA_TCP_NODELAY"
+#define SYS_VAR_TCP_QUICKACK				"VMA_TCP_QUICKACK"
 #define SYS_VAR_VMA_EXCEPTION_HANDLING			(vma_exception_handling::getSysVar())
 #define SYS_VAR_AVOID_SYS_CALLS_ON_TCP_FD		"VMA_AVOID_SYS_CALLS_ON_TCP_FD"
 #define SYS_VAR_ALLOW_PRIVILEGED_SOCK_OPT		"VMA_ALLOW_PRIVILEGED_SOCK_OPT"
@@ -624,6 +626,7 @@ extern mce_sys_var & safe_mce_sys();
 #define MCE_DEFAULT_TCP_CTL_THREAD			(CTL_THREAD_DISABLE)
 #define MCE_DEFAULT_TCP_TIMESTAMP_OPTION		(TCP_TS_OPTION_DISABLE)
 #define MCE_DEFAULT_TCP_NODELAY				(false)
+#define MCE_DEFAULT_TCP_QUICKACK			(false)
 #define MCE_DEFAULT_VMA_EXCEPTION_HANDLING	(vma_exception_handling::MODE_DEFAULT)
 #define MCE_DEFAULT_AVOID_SYS_CALLS_ON_TCP_FD		(false)
 #define MCE_DEFAULT_ALLOW_PRIVILEGED_SOCK_OPT		(true)


### PR DESCRIPTION
Added possibility to control a logic of sending ACK on received data.
In current implementation ack.quick field operates as on/off only and might be extended to be used in a manner as Linux TCP kernel stack does.
