### PR TITLE
issue: 1185372 Traffic is not offloaded for high VMA_RX_WRE values

### DIFF
--- a/src/vma/dev/net_device_table_mgr.cpp
+++ b/src/vma/dev/net_device_table_mgr.cpp
@@ -411,9 +411,9 @@ bool net_device_table_mgr::verify_eth_qp_creation(const char* ifname, uint8_t po
 	vma_ibv_cq_init_attr attr;
 	memset(&attr, 0, sizeof(attr));
 
-	qp_init_attr.cap.max_send_wr = safe_mce_sys().tx_num_wr;
-	qp_init_attr.cap.max_recv_wr = safe_mce_sys().rx_num_wr;
-	qp_init_attr.cap.max_inline_data = safe_mce_sys().tx_max_inline;
+	qp_init_attr.cap.max_send_wr = MCE_DEFAULT_TX_NUM_WRE;
+	qp_init_attr.cap.max_recv_wr = MCE_DEFAULT_RX_NUM_WRE;
+	qp_init_attr.cap.max_inline_data = MCE_DEFAULT_TX_MAX_INLINE;
 	qp_init_attr.cap.max_send_sge = MCE_DEFAULT_TX_NUM_SGE;
 	qp_init_attr.cap.max_recv_sge = MCE_DEFAULT_RX_NUM_SGE;
 	qp_init_attr.sq_sig_all = 0;


### PR DESCRIPTION
As part of VMA's initialization process, we are trying to open QP on
each ETH device (verify_eth_qp_creation()) which fails for high
VMA_RX_WRE values.
This happens because VMA is trying to open QP using high value of
VMA_RX_WRE which is not supported.
A better way to handle this is to use a default value of VMA_RX_WRE at
verify_eth_creation().

Signed-off-by: Liran Oz <lirano@mellanox.com>