### PR TITLE
issue: 1190561 detect change route dynamiclly

### DIFF
--- a/src/vma/proto/dst_entry.h
+++ b/src/vma/proto/dst_entry.h
@@ -80,7 +80,7 @@ public:
 		return m_pkt_src_ip;
 	}
 	int		modify_ratelimit(const uint32_t ratelimit_kbps);
-
+	bool		is_valid() { return cache_observer::is_valid() && m_p_rt_entry->is_valid(); };
 #if _BullseyeCoverage
     #pragma BullseyeCoverage off
 #endif

--- a/src/vma/proto/route_table_mgr.cpp
+++ b/src/vma/proto/route_table_mgr.cpp
@@ -519,17 +519,18 @@ void route_table_mgr::update_invalid_entries()
 #endif
 
 //code coverage
-#if 0
 void route_table_mgr::del_route_event(route_val &netlink_route_val)
 {
 	in_addr_t del_dst_addr = netlink_route_val.get_dst_addr();
 	in_addr_t del_dst_mask = netlink_route_val.get_dst_mask();
 	char *del_if_name = (char *) netlink_route_val.get_if_name();
 
-	rt_mgr_logdbg("netlink event- route deleted: dst '%d.%d.%d.%d', netmask '%d.%d.%d.%d', interface '%s'", NIPQUAD(del_dst_addr), NIPQUAD(del_dst_mask), del_if_name);
+	rt_mgr_logdbg("netlink event- route deleted: dst '%d.%d.%d.%d', "
+			"netmask '%d.%d.%d.%d', interface '%s'",
+			NIPQUAD(del_dst_addr), NIPQUAD(del_dst_mask), del_if_name);
 
 	route_val* p_val_from_tbl = find_route_val(netlink_route_val);
-	if(p_val_from_tbl) {
+	if (p_val_from_tbl) {
 		rt_mgr_logdbg("found deleted route val[%p]: %s", p_val_from_tbl, p_val_from_tbl->to_str());
 		p_val_from_tbl->set_deleted();
 		p_val_from_tbl->set_state(false);
@@ -537,12 +538,15 @@ void route_table_mgr::del_route_event(route_val &netlink_route_val)
 	}
 	rt_mgr_logdbg("route does not exist!");
 
-	if (g_vlogger_level >= VLOG_FUNC) {
-		print_route_tbl();
+	if (unlikely(g_vlogger_level >= VLOG_FUNC)) {
+		route_val *p_rtv;
+		for (int i = 0; i < m_tab.entries_num; i++) {
+			p_rtv = &m_tab.value[i];
+			p_rtv->print_val();
+		}
 	}
 	update_invalid_entries();
 }
-#endif
 
 void route_table_mgr::new_route_event(route_val* netlink_route_val)
 {
@@ -601,11 +605,9 @@ void route_table_mgr::notify_cb(event *ev)
 		case RTM_NEWROUTE:
 			new_route_event(p_netlink_route_info->get_route_val());
 			break;
-#if 0
 		case RTM_DELROUTE:
-			del_route_event(p_netlink_route_info->get_route_val());
+			del_route_event(*p_netlink_route_info->get_route_val());
 			break;
-#endif
 		default:
 			rt_mgr_logdbg("Route event (%u) is not handled", route_netlink_ev->nl_type);
 			break;


### PR DESCRIPTION
This commit adds support for detection of routing changes
detected by libnl.
Perior to this commmit:
1. There was no seperatin between new route and change rotue
2. Route invalidatioin was not discovered by the dst_entry.
This commit fixes both issues.

note: route delete is still not detected in libvma, so libvma
      will search the route table from the end. This will
      solve some of the issues (e.g. del route and adding new one),
      but this will not solve cases of just deleting routes and
      fallback to default\existing rule.

Signed-off-by: Rafi Wiener <rafiw@mellanox.com>