### PR TITLE
issue: 1190592 add support for more route metrics

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -1,4 +1,4 @@
-Update: 23 Nov 2017
+Update: 14 Dec 2017
 
 Introduction
 ============
@@ -921,7 +921,8 @@ TCP congestion control algorithm.
 The default algorithm coming with LWIP is a variation of Reno/New-Reno.
 The new Cubic algorithm was adapted from FreeBsd implementation.
 Use value of 0 for LWIP algorithm.
-Use value of 1 for the Cubic algorithm.
+Use value of 1 for Cubic algorithm.
+Use vlaue of 2 for disabling the congestion algorithm.
 Default value is 0 (LWIP).
 
 VMA_TCP_MAX_SYN_RATE

--- a/src/vma/Makefile.am
+++ b/src/vma/Makefile.am
@@ -119,6 +119,7 @@ libvma_la_SOURCES := \
 	lwip/cc.c \
 	lwip/cc_lwip.c \
 	lwip/cc_cubic.c \
+	lwip/cc_none.c \
 	lwip/init.c \
 	\
 	proto/ip_frag.cpp \

--- a/src/vma/lwip/cc.h
+++ b/src/vma/lwip/cc.h
@@ -89,13 +89,6 @@ struct tcp_pcb;
 
 #include <stdint.h>
 
-/* types of different cc algorithms */
-enum cc_algo_mod {
-	CC_MOD_LWIP,
-	CC_MOD_CUBIC,
-	CC_MOD_NONE
-};
-
 /* ACK types passed to the ack_received() hook. */
 #define	CC_ACK		0x0001	/* Regular in sequence ACK. */
 #define	CC_DUPACK	0x0002	/* Duplicate ACK. */

--- a/src/vma/lwip/cc.h
+++ b/src/vma/lwip/cc.h
@@ -92,7 +92,8 @@ struct tcp_pcb;
 /* types of different cc algorithms */
 enum cc_algo_mod {
 	CC_MOD_LWIP,
-	CC_MOD_CUBIC
+	CC_MOD_CUBIC,
+	CC_MOD_NONE
 };
 
 /* ACK types passed to the ack_received() hook. */
@@ -148,6 +149,7 @@ struct cc_algo {
 
 extern struct cc_algo lwip_cc_algo;
 extern struct cc_algo cubic_cc_algo;
+extern struct cc_algo none_cc_algo;
 
 void cc_init(struct tcp_pcb *pcb);
 void cc_destroy(struct tcp_pcb *pcb);

--- a/src/vma/lwip/cc_none.c
+++ b/src/vma/lwip/cc_none.c
@@ -1,0 +1,51 @@
+/*
+ * Copyright (c) 2001-2017 Mellanox Technologies, Ltd. All rights reserved.
+ *
+ * This software is available to you under a choice of one of two
+ * licenses.  You may choose to be licensed under the terms of the GNU
+ * General Public License (GPL) Version 2, available from the file
+ * COPYING in the main directory of this source tree, or the
+ * BSD license below:
+ *
+ *     Redistribution and use in source and binary forms, with or
+ *     without modification, are permitted provided that the following
+ *     conditions are met:
+ *
+ *      - Redistributions of source code must retain the above
+ *        copyright notice, this list of conditions and the following
+ *        disclaimer.
+ *
+ *      - Redistributions in binary form must reproduce the above
+ *        copyright notice, this list of conditions and the following
+ *        disclaimer in the documentation and/or other materials
+ *        provided with the distribution.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+ * BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ * ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#include "vma/lwip/cc.h"
+#include "vma/lwip/tcp.h"
+
+#if TCP_CC_ALGO_MOD
+
+static void	none_cc_conn_init(struct tcp_pcb *pcb);
+
+struct cc_algo none_cc_algo = {
+		.name = "none_cc",
+		.conn_init = none_cc_conn_init,
+};
+
+static void
+none_cc_conn_init(struct tcp_pcb *pcb)
+{
+	pcb->cwnd = UINT32_MAX;
+}
+
+#endif //TCP_CC_ALGO_MOD

--- a/src/vma/lwip/opt.h
+++ b/src/vma/lwip/opt.h
@@ -1456,8 +1456,8 @@
  * when opening a connection. For the transmit size, this MSS sets
  * an upper limit on the MSS advertised by the remote host.
  */
-#ifndef LWIP_TCP_MSS
-#define LWIP_TCP_MSS                         536
+#ifndef LWIP_MIN_TCP_MSS
+#define LWIP_MIN_TCP_MSS                (536)
 #endif
 
 /**

--- a/src/vma/lwip/tcp.c
+++ b/src/vma/lwip/tcp.c
@@ -1101,6 +1101,9 @@ void tcp_pcb_init (struct tcp_pcb* pcb, u8_t prio)
 	case CC_MOD_CUBIC:
 		pcb->cc_algo = &cubic_cc_algo;
 		break;
+	case CC_MOD_NONE:
+		pcb->cc_algo = &none_cc_algo;
+		break;
 	case CC_MOD_LWIP:
 	default:
 		pcb->cc_algo = &lwip_cc_algo;

--- a/src/vma/lwip/tcp.h
+++ b/src/vma/lwip/tcp.h
@@ -54,7 +54,6 @@ extern u16_t lwip_tcp_mss;
 typedef err_t (*ip_output_fn)(struct pbuf *p, void* p_conn, int is_rexmit, u8_t is_dummy);
           
 void register_ip_output(ip_output_fn fn);
-
 #endif
 
 #if LWIP_3RD_PARTY_BUFS
@@ -85,8 +84,6 @@ extern tcp_seg_free_fn external_tcp_seg_free;
 struct tcp_pcb;
 
 #include "vma/lwip/cc.h"
-
-extern enum cc_algo_mod lwip_cc_algo_module;
 
 /** Function prototype for tcp accept callback functions. Called when a new
  * connection can be accepted on a listening pcb.

--- a/src/vma/lwip/tcp_impl.h
+++ b/src/vma/lwip/tcp_impl.h
@@ -335,7 +335,7 @@ extern int32_t enable_wnd_scale;
 extern u32_t rcv_wnd_scale;
 extern u8_t enable_ts_option;
 extern u32_t tcp_ticks;
-extern ip_route_mtu_fn external_ip_route_mtu;
+extern ip_route_mtu_fn external_ip_route_mtu_mss;
 
 
 /* The TCP PCB lists. */

--- a/src/vma/lwip/tcp_out.c
+++ b/src/vma/lwip/tcp_out.c
@@ -81,11 +81,11 @@ void register_ip_output(ip_output_fn fn)
     external_ip_output = fn;
 }
 
-ip_route_mtu_fn external_ip_route_mtu;
+ip_route_mtu_fn external_ip_route_mtu_mss;
 
 void register_ip_route_mtu(ip_route_mtu_fn fn)
 {
-    external_ip_route_mtu = fn;
+    external_ip_route_mtu_mss = fn;
 }
 #endif
 

--- a/src/vma/netlink/route_info.cpp
+++ b/src/vma/netlink/route_info.cpp
@@ -73,9 +73,11 @@ void netlink_route_info::fill(struct rtnl_route* nl_route_obj)
 	if (scope > 0) {
 		m_route_val->set_scope(scope);
 	}
-	int mtu = nl_object_get_compatible_metric(nl_route_obj, RTAX_MTU);
-	if (mtu > 0) {
-		m_route_val->set_mtu(mtu);
+	for (int i = 0; i < VMA_RT_METRIC_MAX; i++) {
+		uint32_t val = nl_object_get_compatible_metric(nl_route_obj, i);
+		if (val > 0) {
+			m_route_val->set_metric(i, val);
+		}
 	}
 	int protocol = rtnl_route_get_protocol(nl_route_obj);
 	if (protocol > 0) {

--- a/src/vma/proto/dst_entry.h
+++ b/src/vma/proto/dst_entry.h
@@ -80,7 +80,7 @@ public:
 		return m_pkt_src_ip;
 	}
 	int		modify_ratelimit(const uint32_t ratelimit_kbps);
-
+	const route_val* get_route_val() { return m_p_rt_val;};
 #if _BullseyeCoverage
     #pragma BullseyeCoverage off
 #endif
@@ -96,7 +96,7 @@ public:
 	virtual flow_tuple get_flow_tuple() const;
 
 	void	return_buffers_pool();
-	int	get_route_mtu();
+	virtual int	get_route_mtu();
 
 protected:
 	ip_address 		m_dst_ip;

--- a/src/vma/proto/dst_entry_tcp.cpp
+++ b/src/vma/proto/dst_entry_tcp.cpp
@@ -302,3 +302,12 @@ void dst_entry_tcp::put_buffer(mem_buf_desc_t * p_desc)
 		}
 	}
 }
+
+int dst_entry_tcp::get_route_mtu()
+{
+	// prefer advmss over mtu
+	if (m_p_rt_val && m_p_rt_val->get_advmss() > 0 ) {
+		return m_p_rt_val->get_advmss();
+	}
+	return dst_entry::get_route_mtu();
+}

--- a/src/vma/proto/dst_entry_tcp.h
+++ b/src/vma/proto/dst_entry_tcp.h
@@ -66,6 +66,7 @@ protected:
 
 	virtual void		configure_headers();
 	virtual ssize_t 	pass_buff_to_neigh(const iovec *p_iov, size_t & sz_iov, uint16_t packet_id = 0);
+	virtual int		get_route_mtu();
 
 private:
 	const uint32_t       m_n_sysvar_tx_bufs_batch_tcp;

--- a/src/vma/proto/route_table_mgr.h
+++ b/src/vma/proto/route_table_mgr.h
@@ -52,7 +52,8 @@ struct route_result {
 	in_addr_t	p_src;
 	in_addr_t	p_gw;
 	uint32_t	mtu;
-	route_result(): p_src(0), p_gw(0) ,mtu(0) {}
+	uint32_t	advmss;
+	route_result():p_src(0),p_gw(0),mtu(0),advmss(0){ }
 };
 
 class route_table_mgr : public netlink_socket_mgr<route_val>, public cache_table_mgr<route_rule_table_key, route_val*>, public observer

--- a/src/vma/proto/vma_lwip.cpp
+++ b/src/vma/proto/vma_lwip.cpp
@@ -125,8 +125,6 @@ vma_lwip::vma_lwip() : lock_spin_recursive("vma_lwip")
 
 	lwip_logdbg("");
 
-	lwip_cc_algo_module = (enum cc_algo_mod)safe_mce_sys().lwip_cc_algo_mod;
-
 	lwip_tcp_mss = get_lwip_tcp_mss(safe_mce_sys().mtu, safe_mce_sys().lwip_mss);
 	BULLSEYE_EXCLUDE_BLOCK_END
 
@@ -152,7 +150,7 @@ vma_lwip::vma_lwip() : lock_spin_recursive("vma_lwip")
 	register_tcp_seg_free(sockinfo_tcp::tcp_seg_free);
 	register_ip_output(sockinfo_tcp::ip_output);
 	register_tcp_state_observer(sockinfo_tcp::tcp_state_observer);
-	register_ip_route_mtu(sockinfo_tcp::get_route_mtu);
+	register_ip_route_mtu(sockinfo_tcp::get_route_mtu_mss);
 	register_sys_now(sys_now);
 
 	//tcp_ticks increases in the rate of tcp slow_timer

--- a/src/vma/proto/vma_lwip.h
+++ b/src/vma/proto/vma_lwip.h
@@ -66,6 +66,7 @@ static inline const char* lwip_cc_algo_str(uint32_t algo)
 {
 	switch (algo) {
 	case CC_MOD_CUBIC:	return "(CUBIC)";
+	case CC_MOD_NONE:	return "(NONE)";
 	case CC_MOD_LWIP:
 	default:		return "(LWIP)";
 	}

--- a/src/vma/proto/vma_lwip.h
+++ b/src/vma/proto/vma_lwip.h
@@ -62,16 +62,6 @@ static inline int is_bcast_mac(const uint8_t *addr)
         return (addr[0] & addr[1] & addr[2] & addr[3] & addr[4] & addr[5]) == 0xff;
 }
 
-static inline const char* lwip_cc_algo_str(uint32_t algo)
-{
-	switch (algo) {
-	case CC_MOD_CUBIC:	return "(CUBIC)";
-	case CC_MOD_NONE:	return "(NONE)";
-	case CC_MOD_LWIP:
-	default:		return "(LWIP)";
-	}
-}
-
 #if _BullseyeCoverage
     #pragma BullseyeCoverage on
 #endif

--- a/src/vma/sock/sockinfo_tcp.cpp
+++ b/src/vma/sock/sockinfo_tcp.cpp
@@ -1019,17 +1019,23 @@ err_t sockinfo_tcp::ip_output_syn_ack(struct pbuf *p, void* v_p_conn, int is_rex
 	}
 }
 
-uint16_t sockinfo_tcp::get_route_mtu(struct tcp_pcb *pcb)
+uint16_t sockinfo_tcp::get_route_mtu_mss(struct tcp_pcb *pcb)
 {
 	sockinfo_tcp *tcp_sock = (sockinfo_tcp *)pcb->my_container;
 	// in case of listen m_p_connected_dst_entry is still NULL
 	if (tcp_sock->m_p_connected_dst_entry) {
 		return tcp_sock->m_p_connected_dst_entry->get_route_mtu();
 	}
-	route_result res;
 	// m_tos is always 0 in VMA
-	g_p_route_table_mgr->route_resolve(route_rule_table_key(pcb->local_ip.addr, pcb->remote_ip.addr, 0), res);
-
+	route_result res;
+	g_p_route_table_mgr->route_resolve(
+			route_rule_table_key(pcb->local_ip.addr, pcb->remote_ip.addr, 0),
+			res);
+	// always prefer adv_mss on route over mtu in ring
+	if (res.advmss) {
+		vlog_printf(VLOG_DEBUG, "Using advmss %u\n", res.advmss);
+		return res.advmss;
+	}
 	if (res.mtu) {
 		vlog_printf(VLOG_DEBUG, "Using route mtu %u\n", res.mtu);
 		return res.mtu;
@@ -2005,6 +2011,89 @@ int sockinfo_tcp::prepareConnect(const sockaddr *, socklen_t ){
     #pragma BullseyeCoverage on
 #endif
 
+void sockinfo_tcp::set_lwip_init_metrics()
+{
+	const route_val *rt = m_p_connected_dst_entry->get_route_val();
+
+	if (rt->get_metric(RTAX_INITCWND)) {
+		m_pcb.cwnd = rt->get_metric(RTAX_INITCWND);
+	} else {
+		m_pcb.cwnd = 1;
+	}
+	if (rt->get_metric(RTAX_INITRWND)) {
+		m_pcb.rcv_wnd = rt->get_metric(RTAX_INITRWND);
+	} else {
+		m_pcb.rcv_wnd = TCP_WND_SCALED(&m_pcb);
+	}
+	if (rt->get_metric(RTAX_RTT)) {
+		m_pcb.rto = rt->get_metric(RTAX_RTT);
+	} else {
+		m_pcb.rto = 3000 / TCP_SLOW_INTERVAL;
+	}
+#if TCP_CC_ALGO_MOD
+	switch (rt->get_metric(RTAX_CC_ALGO)) {
+	case CC_MOD_CUBIC:
+		m_pcb.cc_algo = &cubic_cc_algo;
+		break;
+	case CC_MOD_NONE:
+		m_pcb.cc_algo = &none_cc_algo;
+		break;
+	case CC_MOD_LWIP:
+	default:
+		m_pcb.cc_algo = &lwip_cc_algo;
+		break;
+	}
+#endif
+	cc_init(&m_pcb);
+}
+
+void sockinfo_tcp::set_lwip_connect_metrics()
+{
+	const route_val *rt = m_p_connected_dst_entry->get_route_val();
+
+	if (rt->get_metric(RTAX_WINDOW)) {
+		m_pcb.snd_wnd = rt->get_metric(RTAX_WINDOW);
+	} else {
+		m_pcb.snd_wnd = TCP_WND;
+	}
+	  /*
+	   * For effective and advertized MSS without MTU consideration:
+	   * If MSS is configured - do not accept a higher value than 536
+	   * If MSS is not configured assume minimum value of 536
+	   * The send MSS is updated when an MSS option is received
+	   */
+	uint16_t snd_mss = m_pcb.advtsd_mss = (LWIP_TCP_MSS) ? ((LWIP_TCP_MSS > LWIP_MIN_TCP_MSS) ? LWIP_MIN_TCP_MSS : LWIP_TCP_MSS) : LWIP_MIN_TCP_MSS;
+	UPDATE_PCB_BY_MSS(&m_pcb, snd_mss);
+#if TCP_CALCULATE_EFF_SEND_MSS
+	/*
+	 * For advertized MSS with MTU knowledge - it is highly likely that it can be derived from the MTU towards the remote IP address.
+	 * Otherwise (if unlikely MTU==0)
+	 * If LWIP_TCP_MSS>0 use it as MSS
+	 * If LWIP_TCP_MSS==0 set advertized MSS value to default 536
+	 */
+	m_pcb.advtsd_mss = (LWIP_TCP_MSS > 0) ? tcp_eff_send_mss(LWIP_TCP_MSS, &m_pcb) :
+			tcp_mss_follow_mtu_with_default(LWIP_MIN_TCP_MSS, &m_pcb);
+	/*
+	 * For effective MSS with MTU knowledge - get the minimum between pcb->mss and the MSS derived from the
+	 * MTU towards the remote IP address
+	 * */
+	u16_t eff_mss = tcp_eff_send_mss(m_pcb.mss, &m_pcb);
+	UPDATE_PCB_BY_MSS(&m_pcb, eff_mss);
+#endif /* TCP_CALCULATE_EFF_SEND_MSS */
+	UPDATE_PCB_BY_MSS(&m_pcb, m_pcb.advtsd_mss);
+	if (rt->get_metric(RTAX_SSTHRESH)) {
+		m_pcb.ssthresh = rt->get_metric(RTAX_SSTHRESH);
+	} else {
+		m_pcb.ssthresh = m_pcb.mss * 10;
+	}
+	// according to ip route man this must be with lock
+	if (rt->get_metric(RTAX_CWND) && rt->is_attr_lock(RTAX_CWND)) {
+		m_pcb.cwnd = rt->get_metric(RTAX_CWND);
+	} else {
+		m_pcb.cwnd = 1;
+	}
+}
+
 /**
  *  try to connect to the dest over RDMA cm
  *  try fallback to the OS connect (TODO)
@@ -2108,7 +2197,9 @@ int sockinfo_tcp::connect(const sockaddr *__to, socklen_t __tolen)
 #endif // DEFINED_VMAPOLL
 	in_addr_t peer_ip_addr = m_connected.get_in_addr();
 	fit_rcv_wnd(true);
-
+	// inject route metrics to pcb
+	set_lwip_init_metrics();
+	set_lwip_connect_metrics();
 	int err = tcp_connect(&m_pcb, (ip_addr_t*)(&peer_ip_addr), ntohs(m_connected.get_in_port()), /*(tcp_connected_fn)*/sockinfo_tcp::connect_lwip_cb);
 	if (err != ERR_OK) {
 		//todo consider setPassthrough and go to OS
@@ -2938,7 +3029,7 @@ err_t sockinfo_tcp::syn_received_lwip_cb(void *arg, struct tcp_pcb *newpcb, err_
 		listen_sock->m_tcp_con_lock.lock();
 		return ERR_ABRT;
 	}
-
+	new_sock->set_lwip_init_metrics();
 	new_sock->register_timer();
 
 	listen_sock->m_tcp_con_lock.lock();

--- a/src/vma/sock/sockinfo_tcp.h
+++ b/src/vma/sock/sockinfo_tcp.h
@@ -146,7 +146,7 @@ public:
 	static err_t ip_output(struct pbuf *p, void* v_p_conn, int is_rexmit, uint8_t is_dummy);
 	static err_t ip_output_syn_ack(struct pbuf *p, void* v_p_conn, int is_rexmit, uint8_t is_dummy);
 	static void tcp_state_observer(void* pcb_container, enum tcp_state new_state);
-	static uint16_t get_route_mtu(struct tcp_pcb *pcb);
+	static uint16_t get_route_mtu_mss(struct tcp_pcb *pcb);
 
 	virtual bool rx_input_cb(mem_buf_desc_t* p_rx_pkt_mem_buf_desc_info, void* pv_fd_ready_array);
 	virtual void set_rx_packet_processor(void) { }
@@ -413,6 +413,8 @@ private:
 	void process_reuse_ctl_packets();
 	void process_rx_ctl_packets();
 	bool check_dummy_send_conditions(const int flags, const iovec* p_iov, const ssize_t sz_iov);
+	void set_lwip_connect_metrics();
+	void set_lwip_init_metrics();
 };
 typedef struct tcp_seg tcp_seg;
 


### PR DESCRIPTION
This commit adds support for parsing the following metrics:
aaadvmss, window, cwnd, initcwnd, initrwnd, ssthresh, rto, congctl

Signed-off-by: Rafi Wiener <rafiw@mellanox.com>