### PR TITLE
issue: 1149532 Fix Deadlock on blocking TCP send

### DIFF
--- a/src/vma/sock/sockinfo_tcp.cpp
+++ b/src/vma/sock/sockinfo_tcp.cpp
@@ -639,15 +639,20 @@ unsigned sockinfo_tcp::tx_wait(int & err, bool is_blocking)
 		//AlexV:Avoid from going to sleep, for the blocked socket of course, since
 		// progress engine may consume an arrived credit and it will not wakeup the
 		//transmit thread.
+		if (unlikely(err < 0)) {
+			return 0;
+		}
+		if (unlikely(g_b_exit)) {
+			errno = EINTR;
+			return 0;
+		}
 		if (is_blocking) {
+			/* force out TCP data to avoid spinning in this loop
+			 * in case data is not seen on rx
+			 */
+			tcp_output(&m_pcb);
 			poll_count = 0;
 		}
-		if (err < 0)
-			return 0;
-                if (unlikely(g_b_exit)) {
-                        errno = EINTR;
-                        return 0;
-                }
 	}
 	si_tcp_logfunc("end sz=%d rx_count=%d", sz, m_n_rx_pkt_ready_list_count);
 	return sz;


### PR DESCRIPTION
There is a scenario when VMA sndbuf=0 and application
attempts to send data and no RX data on the wire

Signed-off-by: Igor Ivanov <igor.ivanov.va@gmail.com>