### PR TITLE
issue: 1207424 Send quickack depending on the payload size

### DIFF
--- a/src/vma/lwip/opt.h
+++ b/src/vma/lwip/opt.h
@@ -388,6 +388,14 @@
 #define LWIP_TCP                        1
 
 /**
+ * TCP_QUICKACK_THRESHOLD: TCP quickack threshold (bytes)
+ * Quickack will be sent for payload <= TCP_QUICKACK_THRESHOLD.
+ * if TCP_QUICKACK_THRESHOLD = 0, quickack threshold is disabled.
+ * The threshold is effective only when TCP_QUICKACK is enabled.
+ */
+#define TCP_QUICKACK_THRESHOLD          0
+
+/**
  * TCP_WND: The size of a TCP window.  This must be at least
  * (2 * TCP_MSS) for things to work well
  */

--- a/src/vma/lwip/tcp_in.c
+++ b/src/vma/lwip/tcp_in.c
@@ -69,7 +69,7 @@ static void tcp_parseopt(struct tcp_pcb *pcb, tcp_in_data* in_data);
 
 static err_t tcp_listen_input(struct tcp_pcb_listen *pcb, tcp_in_data* in_data);
 static err_t tcp_timewait_input(struct tcp_pcb *pcb, tcp_in_data* in_data);
-static s8_t tcp_quickack(struct tcp_pcb *pcb, u32_t tcplen);
+static s8_t tcp_quickack(struct tcp_pcb *pcb, tcp_in_data* in_data);
 
 #define LWIP_TCP_QUICKACK_BYTES_THRESHOLD 0
 /**
@@ -78,12 +78,12 @@ static s8_t tcp_quickack(struct tcp_pcb *pcb, u32_t tcplen);
  * depending on the payload size.
  */
 s8_t
-tcp_quickack(struct tcp_pcb *pcb, u32_t tcplen)
+tcp_quickack(struct tcp_pcb *pcb, tcp_in_data* in_data)
 {
 #if LWIP_TCP_QUICKACK_BYTES_THRESHOLD
-	return pcb->quickack && tcplen <= LWIP_TCP_QUICKACK_BYTES_THRESHOLD;
+	return pcb->quickack && in_data->tcplen <= LWIP_TCP_QUICKACK_BYTES_THRESHOLD;
 #else
-	LWIP_UNUSED_ARG(tcplen);
+	LWIP_UNUSED_ARG(in_data);
 	return pcb->quickack;
 #endif
 }
@@ -1281,7 +1281,7 @@ tcp_receive(struct tcp_pcb *pcb, tcp_in_data* in_data)
 
 
         /* Acknowledge the segment(s). */
-        if ((in_data->recv_data && in_data->recv_data->next) || tcp_quickack(pcb, in_data->tcplen)) {
+        if ((in_data->recv_data && in_data->recv_data->next) || tcp_quickack(pcb, in_data)) {
         	tcp_ack_now(pcb);
         } else {
         	tcp_ack(pcb);

--- a/src/vma/lwip/tcp_in.c
+++ b/src/vma/lwip/tcp_in.c
@@ -72,7 +72,7 @@ static err_t tcp_timewait_input(struct tcp_pcb *pcb, tcp_in_data* in_data);
 static s8_t tcp_quickack(struct tcp_pcb *pcb, tcp_in_data* in_data);
 
 /**
- * Send quickack if TCP_QUICKACK was enabled
+ * Send quickack if TCP_QUICKACK is enabled
  * Change LWIP_TCP_QUICKACK_THRESHOLD value in order to send quickacks
  * depending on the payload size.
  */

--- a/src/vma/lwip/tcp_in.c
+++ b/src/vma/lwip/tcp_in.c
@@ -71,7 +71,6 @@ static err_t tcp_listen_input(struct tcp_pcb_listen *pcb, tcp_in_data* in_data);
 static err_t tcp_timewait_input(struct tcp_pcb *pcb, tcp_in_data* in_data);
 static s8_t tcp_quickack(struct tcp_pcb *pcb, tcp_in_data* in_data);
 
-#define LWIP_TCP_QUICKACK_BYTES_THRESHOLD 0
 /**
  * Send quickack if TCP_QUICKACK was enabled
  * Change LWIP_TCP_QUICKACK_THRESHOLD value in order to send quickacks
@@ -80,8 +79,8 @@ static s8_t tcp_quickack(struct tcp_pcb *pcb, tcp_in_data* in_data);
 s8_t
 tcp_quickack(struct tcp_pcb *pcb, tcp_in_data* in_data)
 {
-#if LWIP_TCP_QUICKACK_BYTES_THRESHOLD
-	return pcb->quickack && in_data->tcplen <= LWIP_TCP_QUICKACK_BYTES_THRESHOLD;
+#if TCP_QUICKACK_THRESHOLD
+	return pcb->quickack && in_data->tcplen <= TCP_QUICKACK_THRESHOLD;
 #else
 	LWIP_UNUSED_ARG(in_data);
 	return pcb->quickack;

--- a/src/vma/lwip/tcp_in.c
+++ b/src/vma/lwip/tcp_in.c
@@ -69,6 +69,17 @@ static void tcp_parseopt(struct tcp_pcb *pcb, tcp_in_data* in_data);
 
 static err_t tcp_listen_input(struct tcp_pcb_listen *pcb, tcp_in_data* in_data);
 static err_t tcp_timewait_input(struct tcp_pcb *pcb, tcp_in_data* in_data);
+static s32_t tcp_quickack(struct tcp_pcb *pcb, u32_t tcplen);
+
+/**
+ * Send quickack only if quickack is enabled
+ * TODO - Send quickack depending on the payload size
+ */
+s32_t
+tcp_quickack(struct tcp_pcb *pcb, u32_t tcplen)
+{
+	return pcb->quickack && tcplen;
+}
 
 #if LWIP_3RD_PARTY_L3
 void
@@ -1263,7 +1274,7 @@ tcp_receive(struct tcp_pcb *pcb, tcp_in_data* in_data)
 
 
         /* Acknowledge the segment(s). */
-        if ((0 != pcb->quickack) || (in_data->recv_data && in_data->recv_data->next)) {
+        if (tcp_quickack(pcb, in_data->tcplen) || (in_data->recv_data && in_data->recv_data->next)) {
         	tcp_ack_now(pcb);
         } else {
         	tcp_ack(pcb);


### PR DESCRIPTION
TCP_QUICKACK_THRESHOLD parameter was added to lwip/opt.h
Change TCP_QUICKACK_THRESHOLD value in order to disable quickack for payloads
that are larger than the threshold.
By default, quickack threshold is disabled.
The threshold is effective only when TCP_QUICKACK is enabled.

Signed-off-by: Liran Oz <lirano@mellanox.com>