### PR TITLE
issue: 1192017 Fix ibv_destroy_cq() failure while VMA_TCP_3T_RULES=1

### DIFF
--- a/src/vma/dev/rfs.cpp
+++ b/src/vma/dev/rfs.cpp
@@ -49,7 +49,7 @@ inline void rfs::prepare_filter_attach(int& filter_counter, rule_filter_map_t::i
 
 	filter_iter = m_p_rule_filter->m_map.find(m_p_rule_filter->m_key);
 	if (filter_iter == m_p_rule_filter->m_map.end()) {
-		rfs_logdbg("No matching counter for filter!!!");
+		rfs_logdbg("No matching counter for filter");
 		return;
 	}
 
@@ -131,10 +131,8 @@ rfs::~rfs()
 			destroy_ibv_flow();
 			m_p_rule_filter->m_map.erase(m_p_rule_filter->m_key);
 		}
-	} else {
-		if (m_b_tmp_is_attached) {
-			destroy_ibv_flow();
-		}
+	} else if (m_b_tmp_is_attached) {
+		destroy_ibv_flow();
 	}
 
 	if (m_p_rule_filter) {

--- a/src/vma/dev/rfs.h
+++ b/src/vma/dev/rfs.h
@@ -262,7 +262,7 @@ private:
 	rfs();		// I don't want anyone to use the default constructor
 	inline void 		prepare_filter_attach(int& filter_counter, rule_filter_map_t::iterator& filter_iter);
 	inline void 		filter_keep_attached(rule_filter_map_t::iterator& filter_iter);
-	inline void 		prepare_filter_detach(int& filter_counter);
+	inline void 		prepare_filter_detach(int& filter_counter, bool decrease_counter);
 
 };
 


### PR DESCRIPTION
When unexpected closing occurs while there is an established TCP connection,
VMA can try to destroy ibv_flow from the RFS which did not create it.
Hence, during RFS destructor we need to update m_p_rule_filter's map in order
the destroy the correct flow.

Signed-off-by: Liran Oz <lirano@mellanox.com>