### PR TITLE
issue: 1213984 use dst_enty to find the route MTU

### DIFF
--- a/src/vma/dev/rfs_uc_tcp_gro.cpp
+++ b/src/vma/dev/rfs_uc_tcp_gro.cpp
@@ -48,17 +48,10 @@ rfs_uc_tcp_gro::rfs_uc_tcp_gro(flow_tuple *flow_spec_5t, ring_simple *p_ring, rf
 	rfs_uc(flow_spec_5t, p_ring, rule_filter, flow_tag_id),
 	m_p_gro_mgr(&(p_ring->m_gro_mgr)), m_b_active(false), m_b_reserved(false)
 {
-	int mtu;
 	m_n_buf_max = m_p_gro_mgr->get_buf_max();
-	route_result res;
-	// m_tos is always 0 in VMA
-	g_p_route_table_mgr->route_resolve(route_rule_table_key(flow_spec_5t->get_dst_ip(),
-					flow_spec_5t->get_src_ip(), 0), res);
-	if (res.mtu) {
-		mtu = res.mtu;
-	} else {
-		mtu = p_ring->get_mtu();
-	}
+	uint32_t mtu = p_ring->get_mtu(
+			route_rule_table_key(flow_spec_5t->get_dst_ip(),
+					     flow_spec_5t->get_src_ip(), 0));
 	m_n_byte_max = m_p_gro_mgr->get_byte_max() - mtu;
 	memset(&m_gro_desc, 0, sizeof(m_gro_desc));
 }

--- a/src/vma/dev/ring.cpp
+++ b/src/vma/dev/ring.cpp
@@ -32,6 +32,7 @@
 
 
 #include "ring.h"
+#include "vma/proto/route_table_mgr.h"
 
 #undef  MODULE_NAME
 #define MODULE_NAME     "ring"
@@ -47,6 +48,17 @@ ring::ring(int count, uint32_t mtu) :
 	INIT_LIST_HEAD(&m_ec_list);
 	m_vma_poll_completion = NULL;
 #endif // DEFINED_VMAPOLL	
+}
+
+uint32_t ring::get_mtu(const route_rule_table_key &key)
+{
+	route_result res;
+
+	g_p_route_table_mgr->route_resolve(key, res);
+	if (res.mtu) {
+		return res.mtu;
+	}
+	return m_mtu;
 }
 
 int ring::get_rx_channel_fds_index(uint32_t index) const {

--- a/src/vma/dev/ring.h
+++ b/src/vma/dev/ring.h
@@ -53,6 +53,7 @@ class rfs;
 class cq_mgr;
 class L2_address;
 class buffer_pool;
+class route_rule_table_key;
 
 #define RING_LOCK_AND_RUN(__lock__, __func_and_params__) 	\
 		__lock__.lock(); __func_and_params__; __lock__.unlock();
@@ -321,7 +322,7 @@ public:
 	ring*			get_parent() { return m_parent; };
 	virtual ring_user_id_t	generate_id() = 0;
 	virtual ring_user_id_t	generate_id(const address_t src_mac, const address_t dst_mac, uint16_t eth_proto, uint16_t encap_proto, uint32_t src_ip, uint32_t dst_ip, uint16_t src_port, uint16_t dst_port) = 0;
-	uint32_t		get_mtu() {return m_mtu;};
+	uint32_t		get_mtu(const route_rule_table_key &key);
 	bool			is_mp_ring() {return m_is_mp_ring;};
 	virtual int		modify_ratelimit(const uint32_t ratelimit_kbps) = 0;
 	virtual bool		is_ratelimit_supported(uint32_t rate) = 0;
@@ -375,7 +376,7 @@ protected:
 	int*			m_p_n_rx_channel_fds;
 	ring*			m_parent;
 	bool			m_is_mp_ring;
-
+	uint32_t		m_mtu;
 #ifdef DEFINED_VMAPOLL	
 	/* queue of event completion elements
 	 * this queue is stored events related different sockinfo (sockets)
@@ -391,14 +392,10 @@ protected:
 	 * storing them in the queue of event completion elements
 	 */
 	struct vma_completion_t* m_vma_poll_completion;
-#endif // DEFINED_VMAPOLL	
-
 private:
-#ifdef DEFINED_VMAPOLL	
 	/* This flag is enabled in case vma_poll() call is done */
 	bool                     m_vma_active;
-#endif // DEFINED_VMAPOLL	
-	uint32_t		m_mtu;
+#endif // DEFINED_VMAPOLL
 };
 
 #endif /* RING_H */

--- a/src/vma/dev/ring_bond.cpp
+++ b/src/vma/dev/ring_bond.cpp
@@ -510,7 +510,7 @@ void ring_bond::mem_buf_desc_return_to_owner_tx(mem_buf_desc_t* p_mem_buf_desc)
 void ring_bond_eth::create_slave_list(in_addr_t local_if, ring_resource_creation_info_t* p_ring_info, bool active_slaves[], uint16_t vlan)
 {
 	for (uint32_t i = 0; i < m_n_num_resources; i++) {
-		m_bond_rings[i] = new ring_eth(local_if, &p_ring_info[i], 1, active_slaves[i], vlan, get_mtu(), this);
+		m_bond_rings[i] = new ring_eth(local_if, &p_ring_info[i], 1, active_slaves[i], vlan, m_mtu, this);
 		if (m_min_devices_tx_inline < 0)
 			m_min_devices_tx_inline = m_bond_rings[i]->get_max_tx_inline();
 		else
@@ -527,7 +527,7 @@ void ring_bond_eth::create_slave_list(in_addr_t local_if, ring_resource_creation
 void ring_bond_ib::create_slave_list(in_addr_t local_if, ring_resource_creation_info_t* p_ring_info, bool active_slaves[], uint16_t pkey)
 {
 	for (uint32_t i = 0; i < m_n_num_resources; i++) {
-		m_bond_rings[i] = new ring_ib(local_if, &p_ring_info[i], 1, active_slaves[i], pkey, get_mtu(), this); // get_mtu() reads the MTU from ifconfig when created. Now passing it to its slaves. could have sent 0 here, as the MTU of the bond is already on the bond
+		m_bond_rings[i] = new ring_ib(local_if, &p_ring_info[i], 1, active_slaves[i], pkey, m_mtu, this); // m_mtu is the value from ifconfig when ring created. Now passing it to its slaves. could have sent 0 here, as the MTU of the bond is already on the bond
 		if (m_min_devices_tx_inline < 0)
 			m_min_devices_tx_inline = m_bond_rings[i]->get_max_tx_inline();
 		else

--- a/src/vma/lwip/tcp.c
+++ b/src/vma/lwip/tcp.c
@@ -662,12 +662,12 @@ tcp_connect(struct tcp_pcb *pcb, ip_addr_t *ipaddr, u16_t port,
    * If LWIP_TCP_MSS>0 use it as MSS 
    * If LWIP_TCP_MSS==0 set advertized MSS value to default 536
    */
-  pcb->advtsd_mss = (LWIP_TCP_MSS > 0) ? tcp_eff_send_mss(LWIP_TCP_MSS, ipaddr) : tcp_mss_follow_mtu_with_default(536, ipaddr); 
+  pcb->advtsd_mss = (LWIP_TCP_MSS > 0) ? tcp_eff_send_mss(LWIP_TCP_MSS, pcb) : tcp_mss_follow_mtu_with_default(536, pcb);
   /* 
    * For effective MSS with MTU knowledge - get the minimum between pcb->mss and the MSS derived from the 
    * MTU towards the remote IP address 
    * */
-  u16_t eff_mss = tcp_eff_send_mss(pcb->mss, ipaddr); 
+  u16_t eff_mss = tcp_eff_send_mss(pcb->mss, pcb);
   UPDATE_PCB_BY_MSS(pcb, eff_mss);
 #endif /* TCP_CALCULATE_EFF_SEND_MSS */
   pcb->cwnd = 1;
@@ -1448,11 +1448,11 @@ tcp_next_iss(void)
  * calculating the minimum of TCP_MSS and that netif's mtu (if set).
  */
 u16_t
-tcp_eff_send_mss(u16_t sendmss, ip_addr_t *addr)
+tcp_eff_send_mss(u16_t sendmss, struct tcp_pcb *pcb)
 {
   u16_t mtu;
 
-  mtu = external_ip_route_mtu(addr);
+  mtu = external_ip_route_mtu(pcb);
   if (mtu != 0) {
     sendmss = LWIP_MIN(sendmss, mtu - IP_HLEN - TCP_HLEN);
   }
@@ -1465,11 +1465,11 @@ tcp_eff_send_mss(u16_t sendmss, ip_addr_t *addr)
  * In case MTU is unkonw - return the default MSS 
  */
 u16_t
-tcp_mss_follow_mtu_with_default(u16_t defsendmss, ip_addr_t *addr)
+tcp_mss_follow_mtu_with_default(u16_t defsendmss, struct tcp_pcb *pcb)
 {
   u16_t mtu;
 
-  mtu = external_ip_route_mtu(addr);
+  mtu = external_ip_route_mtu(pcb);
   if (mtu != 0) {
     defsendmss = mtu - IP_HLEN - TCP_HLEN;
     defsendmss = LWIP_MAX(defsendmss, 1); /* MSS must be a positive number */

--- a/src/vma/lwip/tcp.h
+++ b/src/vma/lwip/tcp.h
@@ -55,9 +55,6 @@ typedef err_t (*ip_output_fn)(struct pbuf *p, void* p_conn, int is_rexmit, u8_t 
           
 void register_ip_output(ip_output_fn fn);
 
-typedef u16_t (*ip_route_mtu_fn)(ip_addr_t *dest);
-void register_ip_route_mtu(ip_route_mtu_fn fn);
-
 #endif
 
 #if LWIP_3RD_PARTY_BUFS
@@ -422,6 +419,9 @@ struct tcp_pcb {
   /* Delayed ACK control: number of quick acks */
   u8_t quickack;
 };
+
+typedef u16_t (*ip_route_mtu_fn)(struct tcp_pcb *pcb);
+void register_ip_route_mtu(ip_route_mtu_fn fn);
 
 #ifdef VMA_NO_TCP_PCB_LISTEN_STRUCT
 #define tcp_pcb_listen tcp_pcb

--- a/src/vma/lwip/tcp_impl.h
+++ b/src/vma/lwip/tcp_impl.h
@@ -464,9 +464,9 @@ void tcp_keepalive(struct tcp_pcb *pcb);
 void tcp_zero_window_probe(struct tcp_pcb *pcb);
 
 #if TCP_CALCULATE_EFF_SEND_MSS
-u16_t tcp_eff_send_mss(u16_t sendmss, ip_addr_t *addr);
+u16_t tcp_eff_send_mss(u16_t sendmss, struct tcp_pcb *pcb);
 #endif /* TCP_CALCULATE_EFF_SEND_MSS */
-u16_t tcp_mss_follow_mtu_with_default(u16_t sendmss, ip_addr_t *addr);
+u16_t tcp_mss_follow_mtu_with_default(u16_t sendmss, struct tcp_pcb *pcb);
 
 #if LWIP_CALLBACK_API
 err_t tcp_recv_null(void *arg, struct tcp_pcb *pcb, struct pbuf *p, err_t err);

--- a/src/vma/lwip/tcp_in.c
+++ b/src/vma/lwip/tcp_in.c
@@ -370,7 +370,7 @@ tcp_listen_input(struct tcp_pcb_listen *pcb, tcp_in_data* in_data)
     npcb->rcv_scale = 0;
 
     /* calculate advtsd_mss before parsing MSS option such that the resulting mss will take into account the updated advertized MSS */
-    npcb->advtsd_mss = (LWIP_TCP_MSS > 0) ? tcp_eff_send_mss(LWIP_TCP_MSS, &(npcb->remote_ip)) : tcp_mss_follow_mtu_with_default(536, &(npcb->remote_ip));
+    npcb->advtsd_mss = (LWIP_TCP_MSS > 0) ? tcp_eff_send_mss(LWIP_TCP_MSS, npcb) : tcp_mss_follow_mtu_with_default(536, npcb);
 
     /* Parse any options in the SYN. */
     tcp_parseopt(npcb, in_data);
@@ -384,7 +384,7 @@ tcp_listen_input(struct tcp_pcb_listen *pcb, tcp_in_data* in_data)
   	npcb->snd_wnd_max = npcb->snd_wnd;
   	npcb->ssthresh = npcb->snd_wnd;
 #if TCP_CALCULATE_EFF_SEND_MSS
-    u16_t snd_mss = tcp_eff_send_mss(npcb->mss, &(npcb->remote_ip));
+    u16_t snd_mss = tcp_eff_send_mss(npcb->mss, npcb);
     UPDATE_PCB_BY_MSS(npcb, snd_mss); 
 #endif /* TCP_CALCULATE_EFF_SEND_MSS */
 
@@ -529,7 +529,7 @@ tcp_process(struct tcp_pcb *pcb, tcp_in_data* in_data)
       set_tcp_state(pcb, ESTABLISHED);
 
 #if TCP_CALCULATE_EFF_SEND_MSS
-      u16_t eff_mss = tcp_eff_send_mss(pcb->mss, &(pcb->remote_ip));
+      u16_t eff_mss = tcp_eff_send_mss(pcb->mss, pcb);
       UPDATE_PCB_BY_MSS(pcb, eff_mss);
 #endif /* TCP_CALCULATE_EFF_SEND_MSS */
 

--- a/src/vma/proto/dst_entry.h
+++ b/src/vma/proto/dst_entry.h
@@ -96,7 +96,7 @@ public:
 	virtual flow_tuple get_flow_tuple() const;
 
 	void	return_buffers_pool();
-
+	int	get_route_mtu();
 protected:
 	ip_address 		m_dst_ip;
 	uint16_t 		m_dst_port;
@@ -182,9 +182,6 @@ protected:
 			m_p_ring->send_ring_buffer(id, p_send_wqe, attr);
 		}
 	}
-private:
-	int get_route_mtu();
-
 };
 
 

--- a/src/vma/proto/neighbour.cpp
+++ b/src/vma/proto/neighbour.cpp
@@ -407,17 +407,10 @@ bool neigh_entry::post_send_udp(iovec * iov, header *h)
 #endif
 	mem_buf_desc_t* p_mem_buf_desc, *tmp = NULL;
 	tx_packet_template_t *p_pkt;
-	route_result res;
 	size_t sz_data_payload = iov->iov_len;
 	iphdr* p_hdr = &h->m_header.hdr.m_ip_hdr;
 
-	g_p_route_table_mgr->route_resolve(route_rule_table_key(p_hdr->daddr, p_hdr->saddr, 0), res);
-	int mtu;
-	if (res.mtu) {
-		mtu = res.mtu;
-	} else {
-		mtu = m_p_ring->get_mtu();
-	}
+	int mtu = m_p_ring->get_mtu(route_rule_table_key(p_hdr->daddr, p_hdr->saddr, 0));
 	size_t max_ip_payload_size = ((mtu - sizeof(struct iphdr)) & ~0x7);
 
 	if (sz_data_payload > 65536) {

--- a/src/vma/proto/route_table_mgr.h
+++ b/src/vma/proto/route_table_mgr.h
@@ -52,6 +52,7 @@ struct route_result {
 	in_addr_t	p_src;
 	in_addr_t	p_gw;
 	uint32_t	mtu;
+	route_result(): p_src(0),p_gw(0),mtu(0){}
 };
 
 class route_table_mgr : public netlink_socket_mgr<route_val>, public cache_table_mgr<route_rule_table_key, route_val*>, public observer

--- a/src/vma/proto/route_table_mgr.h
+++ b/src/vma/proto/route_table_mgr.h
@@ -52,7 +52,7 @@ struct route_result {
 	in_addr_t	p_src;
 	in_addr_t	p_gw;
 	uint32_t	mtu;
-	route_result(): p_src(0),p_gw(0),mtu(0){}
+	route_result(): p_src(0),p_gw(0),mtu(0){ }
 };
 
 class route_table_mgr : public netlink_socket_mgr<route_val>, public cache_table_mgr<route_rule_table_key, route_val*>, public observer

--- a/src/vma/proto/vma_lwip.h
+++ b/src/vma/proto/vma_lwip.h
@@ -86,8 +86,6 @@ public:
 	static int sockaddr2ipaddr(const sockaddr *__to, socklen_t __tolen, ip_addr_t & ip, uint16_t & port);
 	void do_timers();
 
-	static u16_t vma_ip_route_mtu(ip_addr_t *dest);
-
 	//RX: feed packet to the LWIP stack
 	static int  vma_tcp_input(mem_buf_desc_t* p_rx_wc_buf_desc, tcp_pcb* p_conn, void* pv_fd_ready_array);
 

--- a/src/vma/sock/sockinfo_tcp.h
+++ b/src/vma/sock/sockinfo_tcp.h
@@ -146,7 +146,7 @@ public:
 	static err_t ip_output(struct pbuf *p, void* v_p_conn, int is_rexmit, uint8_t is_dummy);
 	static err_t ip_output_syn_ack(struct pbuf *p, void* v_p_conn, int is_rexmit, uint8_t is_dummy);
 	static void tcp_state_observer(void* pcb_container, enum tcp_state new_state);
-
+	static uint16_t get_route_mtu(struct tcp_pcb *pcb);
 	virtual bool rx_input_cb(mem_buf_desc_t* p_rx_pkt_mem_buf_desc_info, void* pv_fd_ready_array);
 	virtual void set_rx_packet_processor(void) { }
 


### PR DESCRIPTION
VMA used only the IP destination address to find the MTU route.
This caused VMA not to consider source based rules.
This commit removes this logic and uses the dst_entry
in the socket to get the route and the MTU.

* 1c981ad issue: 1213984 use dst_enty to find the route MTU

Signed-off-by: Rafi Wiener <rafiw@mellanox.com>