### PR TITLE
issue: 1235810 Allow to override build date

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -53,9 +53,13 @@ AC_SUBST(VMA_LIBRARY_RELEASE)
 #LIBALIC_FLAG
 LIBALIC_FLAG=""
 AC_SUBST(LIBALIC_FLAG)
-AC_SUBST([BUILD_DATE], [$(date +'%b/%d/%Y')])
-AC_SUBST([BUILD_TIME], [$(date +'%H:%M:%S')])
-AC_SUBST([BUILD_DATE_CHANGELOG], [$(date +'%a, %d %b %Y %T %z')])
+dateopt=""
+if test -n "$SOURCE_DATE_EPOCH" ; then
+    dateopt="-u -d @$SOURCE_DATE_EPOCH"
+fi
+AC_SUBST([BUILD_DATE], [$(date $dateopt +'%b/%d/%y')])
+AC_SUBST([BUILD_TIME], [$(date $dateopt +'%H:%M:%S')])
+AC_SUBST([BUILD_DATE_CHANGELOG], [$(date $dateopt +'%a, %d %b %Y %T %z')])
 
 m4_include([config/m4/opt.m4])
 


### PR DESCRIPTION
in order to make builds reproducible.
See https://reproducible-builds.org/ for why this is good
and https://reproducible-builds.org/specs/source-date-epoch/
for the definition of this variable.
This date call only works with GNU date.

Signed-off-by: Bernhard M. Wiedemann <bwiedemann@suse.de>

Without this patch, building the libvma package on openSUSE Linux would always produce differing results with a diff like

```diff
/usr/share/doc/packages/libvma-8.4.8/VMA_VERSION        2017-11-14 12:00:00.000000000 +0000
@@ -1,4 +1,4 @@
VMA VERSION: 8.4.8-0
VMA SVN-REVISION: 8
-BUILD DATE: Nov/26/2017 08:02:24
+BUILD DATE: Jan/01/2019 21:18:51
```