### PR TITLE
issue: 1222660 Correct warning check for flow steering

### DIFF
--- a/src/vma/main.cpp
+++ b/src/vma/main.cpp
@@ -310,7 +310,7 @@ void check_flow_steering_log_num_mgm_entry_size()
 {
 	char flow_steering_val[4] = {0};
 	if (priv_safe_try_read_file((const char*)FLOW_STEERING_MGM_ENTRY_SIZE_PARAM_FILE, flow_steering_val, sizeof(flow_steering_val)) == -1) {
-		vlog_printf(VLOG_DEBUG, "Flow steering option for mlx4 driver does not exist in current OFED version");
+		vlog_printf(VLOG_DEBUG, "Flow steering option for mlx4 driver does not exist in current OFED version\n");
 	}
 	else if (flow_steering_val[0] != '-' || (strtol(&flow_steering_val[1], NULL, 0) % 2) == 0) {
 		vlog_printf(VLOG_WARNING, "***************************************************************************************\n");

--- a/src/vma/main.cpp
+++ b/src/vma/main.cpp
@@ -312,7 +312,7 @@ void check_flow_steering_log_num_mgm_entry_size()
 	if (priv_safe_try_read_file((const char*)FLOW_STEERING_MGM_ENTRY_SIZE_PARAM_FILE, flow_steering_val, sizeof(flow_steering_val)) == -1) {
 		vlog_printf(VLOG_DEBUG, "Flow steering option for mlx4 driver does not exist in current OFED version");
 	}
-	else if (flow_steering_val[0] != '-' || flow_steering_val[1] != '1') {
+	else if (flow_steering_val[0] != '-' || (strtol(&flow_steering_val[1], NULL, 0) % 2) == 0) {
 		vlog_printf(VLOG_WARNING, "***************************************************************************************\n");
 		vlog_printf(VLOG_WARNING, "* VMA will not operate properly while flow steering option is disabled                *\n");
 		vlog_printf(VLOG_WARNING, "* In order to enable flow steering please restart your VMA applications after running *\n");


### PR DESCRIPTION
VMA should display warning just in case flow steering is disabled
in configuration.
As far as this capability is controlled by bits 0..5 and
b0 is responsible to flow steering force it is enough to check
single b0 bit.

Signed-off-by: Igor Ivanov <igor.ivanov.va@gmail.com>