### PR TITLE
issue: 1214453 Improve selection of filesystem monitor method

### DIFF
--- a/src/vma/util/agent.cpp
+++ b/src/vma/util/agent.cpp
@@ -206,6 +206,11 @@ agent::~agent()
 
 	m_state = AGENT_CLOSED;
 
+	/* This delay is needed to allow process EXIT message
+	 * before event from system file monitor is raised
+	 */
+	usleep(1000);
+
 	while (!list_empty(&m_free_queue)) {
 		msg = list_first_entry(&m_free_queue, agent_msg_t, item);
 		list_del_init(&msg->item);

--- a/tools/daemon/hash.c
+++ b/tools/daemon/hash.c
@@ -168,6 +168,10 @@ void *hash_put(hash_t ht, hash_key_t key, void *value)
 			if (ht->free && entry->value) {
 				ht->free(entry->value);
 			}
+			if (entry->key == HASH_KEY_INVALID) {
+				ht->count++;
+			}
+			entry->key = key;
 			entry->value = value;
 			return value;
 		}
@@ -186,13 +190,23 @@ void hash_del(hash_t ht, hash_key_t key)
 			if (ht->free && entry->value) {
 				ht->free(entry->value);
 			}
+			if (entry->key != HASH_KEY_INVALID) {
+				ht->count--;
+			}
 			entry->key = HASH_KEY_INVALID;
 			entry->value = NULL;
-			ht->count--;
 		}
 	}
 }
 
+/* hash_find():
+ *
+ * Find a place (hash element) in the hash related key or
+ * new element.
+ * @param ht - point to hash object
+ * @param key - key identified data
+ * @return hash element or NULL in case there is no place.
+ */
 static struct hash_element* hash_find(hash_t ht, hash_key_t key)
 {
 	struct hash_element *entry = NULL;
@@ -209,9 +223,6 @@ static struct hash_element* hash_find(hash_t ht, hash_key_t key)
 
 		if ((ht->count < ht->size) &&
 			(entry->key == HASH_KEY_INVALID)) {
-			entry->key = key;
-			entry->value = NULL;
-			ht->count++;
 			break;
 		} else {
 			if (attempts >= (ht->size - 1)) {

--- a/tools/daemon/loop.c
+++ b/tools/daemon/loop.c
@@ -110,16 +110,16 @@ int proc_loop(void)
 			continue;
 		}
 
-		/* Check any events from fanotify */
-		if (FD_ISSET(daemon_cfg.notify_fd, &readfds)) {
-			log_debug("notification processing ...\n");
-			rc = proc_notify();
-		}
-
 		/* Check messages from processes */
 		if (FD_ISSET(daemon_cfg.sock_fd, &readfds)) {
 			log_debug("message processing ...\n");
 			rc = proc_message();
+		}
+
+		/* Check any events from file system monitor */
+		if (FD_ISSET(daemon_cfg.notify_fd, &readfds)) {
+			log_debug("notification processing ...\n");
+			rc = proc_notify();
 		}
 	}
 

--- a/tools/daemon/notify.c
+++ b/tools/daemon/notify.c
@@ -54,7 +54,7 @@
 #include "daemon.h"
 
 #ifndef KERNEL_O_LARGEFILE
-#if defined(__aarch64__)
+#if defined(__aarch64__) || defined(__powerpc__)
 /* Check architecture: if we are running on ARM,
  * omit KERNEL_O_LARGEFILE from fanotify_init invocation because
  * KERNEL_O_LARGEFILE breaks program on armv running at least kernel 4.4+


### PR DESCRIPTION
Filesystem monitor selection should be based on libc ability
to support fanotify or inotify and kernel configuration.

Signed-off-by: Igor Ivanov <igor.ivanov.va@gmail.com>