### PR TITLE
issue: 1075188 Unify Default and SocketXtreme mode in single binary

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -182,7 +182,6 @@ Example:
  VMA DETAILS: UC ARP delay (msec)            10000                      [VMA_NEIGH_UC_ARP_DELAY_MSEC]
  VMA DETAILS: Num of neigh restart retries   1                          [VMA_NEIGH_NUM_ERR_RETRIES]
  VMA DETAILS: IPOIB support                  Enabled                    [VMA_IPOIB]
- VMA DETAILS: SocketXtrme                    Disabled                   [VMA_XTREME]
  VMA DETAILS: BF (Blue Flame)                Enabled                    [VMA_BF]
  VMA DETAILS: fork() support                 Enabled                    [VMA_FORK]
  VMA DETAILS: close on dup2()                Enabled                    [VMA_CLOSE_ON_DUP2]
@@ -902,10 +901,6 @@ will forward the call to the OS.
 This is, in practice, a very rudimentary dup2 support.
 It only supports the case, where dup2 is used to close file descriptors,
 Default value is 1 (Enabled)
-
-VMA_XTREME
-When this parameter is enabled, VMA operates in SocketXtreme mode.
-Default value is 1 (Disabled)
 
 VMA_MTU
 Size of each Rx and Tx data buffer (Maximum Transfer Unit).

--- a/README.txt
+++ b/README.txt
@@ -182,6 +182,7 @@ Example:
  VMA DETAILS: UC ARP delay (msec)            10000                      [VMA_NEIGH_UC_ARP_DELAY_MSEC]
  VMA DETAILS: Num of neigh restart retries   1                          [VMA_NEIGH_NUM_ERR_RETRIES]
  VMA DETAILS: IPOIB support                  Enabled                    [VMA_IPOIB]
+ VMA DETAILS: SocketXtrme                    Disabled                   [VMA_XTREME]
  VMA DETAILS: BF (Blue Flame)                Enabled                    [VMA_BF]
  VMA DETAILS: fork() support                 Enabled                    [VMA_FORK]
  VMA DETAILS: close on dup2()                Enabled                    [VMA_CLOSE_ON_DUP2]
@@ -901,6 +902,10 @@ will forward the call to the OS.
 This is, in practice, a very rudimentary dup2 support.
 It only supports the case, where dup2 is used to close file descriptors,
 Default value is 1 (Enabled)
+
+VMA_XTREME
+When this parameter is enabled, VMA operates in SocketXtreme mode.
+Default value is 1 (Disabled)
 
 VMA_MTU
 Size of each Rx and Tx data buffer (Maximum Transfer Unit).

--- a/configure.ac
+++ b/configure.ac
@@ -290,21 +290,6 @@ PROF_IBPROF_SETUP()
 #
 #PROF_RDTSC_SETUP()
 
-# VMA Extreme configuration
-#
-AC_ARG_ENABLE([vmapoll],
-    AC_HELP_STRING([--enable-vmapoll],
-        [Enable alternative API to standard sockets API for receiving packets (default=no)]))
-if test "x$enable_vmapoll" = xyes; then
-    AC_CHECK_HEADER([infiniband/mlx5_hw.h],
-        [AC_DEFINE([DEFINED_VMAPOLL], 1, [Define to 1 if vmapoll was enabled at configure time])],
-        [AC_MSG_ERROR([vmapoll mode is not supported with the current installed OFED version])])
-else
-    enable_vmapoll=no
-fi
-AC_MSG_CHECKING([for vmapoll API support])
-AC_MSG_RESULT([$enable_vmapoll])
-
 
 # Thread locking control
 #
@@ -314,12 +299,8 @@ AC_ARG_ENABLE([thread-lock],
 AC_MSG_CHECKING(
     [for thread locking support])
 if test "x$enable_thread_lock" = "xno"; then
-    if test "x$enable_vmapoll" = xyes; then
-        AC_DEFINE([DEFINED_NO_THREAD_LOCK], 1, [Define to 1 to disable thread locking])
-        AC_MSG_RESULT([no])
-    else
-        AC_MSG_RESULT([yes (vmapoll is not enabled)])
-    fi
+    AC_DEFINE([DEFINED_NO_THREAD_LOCK], 1, [Define to 1 to disable thread locking])
+    AC_MSG_RESULT([no])
 else
     AC_MSG_RESULT([yes])
 fi

--- a/configure.ac
+++ b/configure.ac
@@ -290,6 +290,21 @@ PROF_IBPROF_SETUP()
 #
 #PROF_RDTSC_SETUP()
 
+# VMA Extreme configuration
+#
+AC_ARG_ENABLE([vmapoll],
+    AC_HELP_STRING([--enable-vmapoll],
+        [Enable alternative API to standard sockets API for receiving packets (default=no)]))
+if test "x$enable_vmapoll" = xyes; then
+    AC_CHECK_HEADER([infiniband/mlx5_hw.h],
+        [AC_DEFINE([DEFINED_VMAPOLL], 1, [Define to 1 if vmapoll was enabled at configure time])],
+        [AC_MSG_ERROR([vmapoll mode is not supported with the current installed OFED version])])
+else
+    enable_vmapoll=no
+fi
+AC_MSG_CHECKING([for vmapoll API support])
+AC_MSG_RESULT([$enable_vmapoll])
+
 
 # Thread locking control
 #
@@ -299,8 +314,12 @@ AC_ARG_ENABLE([thread-lock],
 AC_MSG_CHECKING(
     [for thread locking support])
 if test "x$enable_thread_lock" = "xno"; then
-    AC_DEFINE([DEFINED_NO_THREAD_LOCK], 1, [Define to 1 to disable thread locking])
-    AC_MSG_RESULT([no])
+    if test "x$enable_vmapoll" = xyes; then
+        AC_DEFINE([DEFINED_NO_THREAD_LOCK], 1, [Define to 1 to disable thread locking])
+        AC_MSG_RESULT([no])
+    else
+        AC_MSG_RESULT([yes (vmapoll is not enabled)])
+    fi
 else
     AC_MSG_RESULT([yes])
 fi

--- a/src/vma/dev/buffer_pool.cpp
+++ b/src/vma/dev/buffer_pool.cpp
@@ -115,9 +115,7 @@ buffer_pool::buffer_pool(size_t buffer_count, size_t buf_size, ib_ctx_handler *p
 		desc->p_desc_owner = owner;
 		desc->lwip_pbuf.custom_free_function = custom_free_function;
 		put_buffer_helper(desc);
-#ifdef DEFINED_VMAPOLL
 		desc->rx.vma_polled = false;
-#endif		
 
 		ptr_buff += sz_aligned_element;
 		ptr_desc += sizeof(mem_buf_desc_t);

--- a/src/vma/dev/cq_mgr.cpp
+++ b/src/vma/dev/cq_mgr.cpp
@@ -91,17 +91,7 @@ cq_mgr::cq_mgr(ring_simple* p_ring, ib_ctx_handler* p_ib_ctx_handler, int cq_siz
 	,m_n_sysvar_rx_prefetch_bytes_before_poll(safe_mce_sys().rx_prefetch_bytes_before_poll)
 	,m_n_sysvar_rx_prefetch_bytes(safe_mce_sys().rx_prefetch_bytes)
 	,m_sz_transport_header(0)
-#ifdef DEFINED_VMAPOLL
-	,m_rx_hot_buff(NULL)
-	,m_qp(NULL)
-	,m_mlx5_cq(NULL)
-	,m_cq_sz(cq_size)
-	,m_cq_ci(0)
-	,m_mlx5_cqes(NULL)
-	,m_cq_db(0)
-#endif
 	,m_p_ib_ctx_handler(p_ib_ctx_handler)
-	,m_n_sysvar_rx_num_wr_to_post_recv(safe_mce_sys().rx_num_wr_to_post_recv)
 	,m_b_sysvar_is_rx_sw_csum_on(safe_mce_sys().rx_sw_csum)
 	,m_comp_event_channel(p_comp_event_channel)
 	,m_b_notification_armed(false)
@@ -158,13 +148,6 @@ void cq_mgr::configure(int cq_size)
 	if (m_b_is_rx) {
 		vma_stats_instance_create_cq_block(m_p_cq_stat);
 	}
-	
-#ifdef DEFINED_VMAPOLL
-	struct ibv_cq *ibcq = m_p_ibv_cq; // ibcp is used in next macro: _to_mxxx
-	m_mlx5_cq = _to_mxxx(cq, cq);
-	m_cq_db = m_mlx5_cq->dbrec;
-	m_mlx5_cqes = (volatile struct mlx5_cqe64 (*)[])(uintptr_t)m_mlx5_cq->active_buf->buf;
-#endif
 
 	if (m_b_is_rx) {
 		m_b_is_rx_hw_csum_on = vma_is_rx_hw_csum_supported(m_p_ib_ctx_handler->get_ibv_device_attr());
@@ -183,9 +166,6 @@ void cq_mgr::prep_ibv_cq(vma_ibv_cq_init_attr& attr) const
 
 uint32_t cq_mgr::clean_cq()
 {
-#ifdef DEFINED_VMAPOLL
-	return 0;
-#else
 	uint32_t ret_total = 0;
 	int ret = 0;
 	uint64_t cq_poll_sn = 0;
@@ -206,7 +186,6 @@ uint32_t cq_mgr::clean_cq()
 	}
 
 	return ret_total;
-#endif
 }
 
 cq_mgr::~cq_mgr()
@@ -277,7 +256,7 @@ void cq_mgr::add_qp_rx(qp_mgr* qp)
 	uint32_t qp_rx_wr_num = qp->get_rx_max_wr_num();
 	cq_logdbg("Trying to push %d WRE to allocated qp (%p)", qp_rx_wr_num, qp);
 	while (qp_rx_wr_num) {
-		uint32_t n_num_mem_bufs = m_n_sysvar_rx_num_wr_to_post_recv;
+		uint32_t n_num_mem_bufs = safe_mce_sys().rx_num_wr_to_post_recv;
 		if (n_num_mem_bufs > qp_rx_wr_num)
 			n_num_mem_bufs = qp_rx_wr_num;
 		p_temp_desc_list = g_buffer_pool_rx->get_buffers_thread_safe(n_num_mem_bufs, m_rx_lkey);
@@ -305,9 +284,6 @@ void cq_mgr::add_qp_rx(qp_mgr* qp)
 	cq_logdbg("Successfully post_recv qp with %d new Rx buffers (planned=%d)", qp->get_rx_max_wr_num()-qp_rx_wr_num, qp->get_rx_max_wr_num());
 
 	// Add qp_mgr to map
-#ifdef DEFINED_VMAPOLL
-	m_qp = qp;
-#endif // DEFINED_VMAPOLL
 	m_qp_rec.qp = qp;
 	m_qp_rec.debth = 0;
 }
@@ -329,9 +305,6 @@ void cq_mgr::add_qp_tx(qp_mgr* qp)
 {
 	//Assume locked!
 	cq_logdbg("qp_mgr=%p", qp);
-#ifdef DEFINED_VMAPOLL
-	m_qp = qp;
-#endif // DEFINED_VMAPOLL
 	m_qp_rec.qp = qp;
 	m_qp_rec.debth = 0;
 }
@@ -569,12 +542,7 @@ mem_buf_desc_t* cq_mgr::process_cq_element_rx(vma_ibv_wc* p_wce)
 
 		//we use context to verify that on reclaim rx buffer path we return the buffer to the right CQ
 		p_mem_buf_desc->rx.is_vma_thr = false;
-#ifdef DEFINED_VMAPOLL
-		p_mem_buf_desc->rx.context = NULL;
-#else
 		p_mem_buf_desc->rx.context = this;
-#endif // DEFINED_VMAPOLL
-		p_mem_buf_desc->rx.vma_polled = false;
 
 		//this is not a deadcode if timestamping is defined in verbs API
 		// coverity[dead_error_condition]
@@ -698,126 +666,11 @@ void cq_mgr::mem_buf_desc_return_to_owner(mem_buf_desc_t* p_mem_buf_desc, void* 
 	reclaim_recv_buffer_helper(p_mem_buf_desc);
 }
 
-#ifdef DEFINED_VMAPOLL
-int cq_mgr::vma_poll_and_process_element_rx(mem_buf_desc_t **p_desc_lst)
-{
-	int packets_num = 0;
-
-	if (unlikely(m_rx_hot_buff == NULL)) {
-		int index = m_qp->m_mlx5_hw_qp->rq.tail & (m_qp->m_rx_num_wr - 1);
-		m_rx_hot_buff = (mem_buf_desc_t*)(uintptr_t)m_qp->m_p_rq_wqe_idx_to_wrid[index];
-		m_rx_hot_buff->rx.context = NULL;
-		m_rx_hot_buff->rx.is_vma_thr = false;
-	}
-	//prefetch_range((uint8_t*)m_rx_hot_buff->p_buffer,safe_mce_sys().rx_prefetch_bytes_before_poll);
-#ifdef RDTSC_MEASURE_RX_VERBS_READY_POLL
-	RDTSC_TAKE_START(g_rdtsc_instr_info_arr[RDTSC_FLOW_RX_VERBS_READY_POLL]);
-#endif //RDTSC_MEASURE_RX_VERBS_READY_POLL
-
-#ifdef RDTSC_MEASURE_RX_VERBS_IDLE_POLL
-	RDTSC_TAKE_START(g_rdtsc_instr_info_arr[RDTSC_FLOW_RX_VERBS_IDLE_POLL]);
-#endif //RDTSC_MEASURE_RX_VERBS_IDLE_POLL
-
-#ifdef RDTSC_MEASURE_RX_VMA_TCP_IDLE_POLL
-	RDTSC_TAKE_END(g_rdtsc_instr_info_arr[RDTSC_FLOW_RX_VMA_TCP_IDLE_POLL]);
-#endif //RDTSC_MEASURE_RX_VMA_TCP_IDLE_POLL
-	volatile mlx5_cqe64 *cqe_err = NULL;
-	volatile mlx5_cqe64 *cqe = mlx5_get_cqe64(&cqe_err);
-
-	if (likely(cqe)) {
-		++m_n_wce_counter;
-		++m_qp->m_mlx5_hw_qp->rq.tail;
-		m_rx_hot_buff->sz_data = ntohl(cqe->byte_cnt);
-		m_rx_hot_buff->rx.flow_tag_id = vma_get_flow_tag(cqe);
-
-		if (unlikely(++m_qp_rec.debth >= (int)m_n_sysvar_rx_num_wr_to_post_recv)) {
-			compensate_qp_poll_success(m_rx_hot_buff);
-		}
-		++packets_num;
-		*p_desc_lst = m_rx_hot_buff;
-		m_rx_hot_buff = NULL;
-	}
-	else if (cqe_err) {
-		/* Return nothing in case error wc
-		 * It is difference with poll_and_process_element_rx()
-		 */
-		mlx5_poll_and_process_error_element_rx(cqe_err, NULL);
-		*p_desc_lst = NULL;
-	}
-	else {
-#ifdef RDTSC_MEASURE_RX_VERBS_IDLE_POLL
-		RDTSC_TAKE_END(g_rdtsc_instr_info_arr[RDTSC_FLOW_RX_VERBS_IDLE_POLL]);
-#endif
-
-#ifdef RDTSC_MEASURE_RX_VMA_TCP_IDLE_POLL
-		RDTSC_TAKE_START(g_rdtsc_instr_info_arr[RDTSC_FLOW_RX_VMA_TCP_IDLE_POLL]);
-#endif
-
-#ifdef RDTSC_MEASURE_RX_CQE_RECEIVEFROM
-		RDTSC_TAKE_START(g_rdtsc_instr_info_arr[RDTSC_FLOW_RX_CQE_TO_RECEIVEFROM]);
-#endif
-		compensate_qp_poll_failed();
-	}
-
-	return packets_num;
-
-}
-#endif // DEFINED_VMAPOLL
-
 int cq_mgr::poll_and_process_element_rx(uint64_t* p_cq_poll_sn, void* pv_fd_ready_array)
 {
 	// Assume locked!!!
 	cq_logfuncall("");
 
-#ifdef DEFINED_VMAPOLL
-	NOT_IN_USE(p_cq_poll_sn);
-	
-	/* coverity[stack_use_local_overflow] */
-	uint32_t ret_rx_processed = process_recv_queue(pv_fd_ready_array);
-	if (unlikely(ret_rx_processed >= m_n_sysvar_cq_poll_batch_max)) {
-		m_p_ring->m_gro_mgr.flush_all(pv_fd_ready_array);
-		return ret_rx_processed;
-	}
-
-	if (m_p_next_rx_desc_poll) {
-		prefetch_range((uint8_t*)m_p_next_rx_desc_poll->p_buffer,safe_mce_sys().rx_prefetch_bytes_before_poll);
-	}
-
-	if (unlikely(m_rx_hot_buff == NULL)) {
-		int index = m_qp->m_mlx5_hw_qp->rq.tail & (m_qp->m_rx_num_wr - 1);
-		m_rx_hot_buff = (mem_buf_desc_t*)(uintptr_t)m_qp->m_p_rq_wqe_idx_to_wrid[index];
-		m_rx_hot_buff->rx.context = NULL;
-		m_rx_hot_buff->rx.is_vma_thr = false;
-		m_rx_hot_buff->rx.vma_polled = false;
-	}
-	else {
-		volatile mlx5_cqe64 *cqe_err = NULL;
-		volatile mlx5_cqe64 *cqe = mlx5_get_cqe64(&cqe_err);
-
-		if (likely(cqe)) {
-			++m_n_wce_counter;
-			++m_qp->m_mlx5_hw_qp->rq.tail;
-			m_rx_hot_buff->sz_data = ntohl(cqe->byte_cnt);
-			m_rx_hot_buff->rx.flow_tag_id = vma_get_flow_tag(cqe);
-
-			if (unlikely(++m_qp_rec.debth >= (int)m_n_sysvar_rx_num_wr_to_post_recv)) {
-				compensate_qp_poll_success(m_rx_hot_buff);
-			}
-			process_recv_buffer(m_rx_hot_buff, pv_fd_ready_array);
-			++ret_rx_processed;
-			m_rx_hot_buff = NULL;
-		}
-		else if (cqe_err) {
-			ret_rx_processed += mlx5_poll_and_process_error_element_rx(cqe_err, pv_fd_ready_array);
-		}
-		else {
-			compensate_qp_poll_failed();
-		}
-
-	}
-	
-	return ret_rx_processed;
-#else	
 	/* coverity[stack_use_local_overflow] */
 	vma_ibv_wc wce[MCE_MAX_CQ_POLL_BATCH];
 
@@ -855,7 +708,6 @@ int cq_mgr::poll_and_process_element_rx(uint64_t* p_cq_poll_sn, void* pv_fd_read
 	}
 	
 	return ret_rx_processed;
-#endif // DEFINED_VMAPOLL
 }
 
 int cq_mgr::poll_and_process_element_tx(uint64_t* p_cq_poll_sn)
@@ -882,129 +734,6 @@ int cq_mgr::poll_and_process_element_tx(uint64_t* p_cq_poll_sn)
 	return ret;
 }
 
-#ifdef DEFINED_VMAPOLL
-int cq_mgr::mlx5_poll_and_process_error_element_rx(volatile struct mlx5_cqe64 *cqe, void* pv_fd_ready_array)
-{
-	vma_ibv_wc wce;
-
-	memset(&wce, 0, sizeof(wce));
-	wce.wr_id = (uintptr_t)m_rx_hot_buff;
-	mlx5_cqe64_to_vma_wc(cqe, &wce);
-
-	++m_n_wce_counter;
-	++m_qp->m_mlx5_hw_qp->rq.tail;
-
-	m_rx_hot_buff = process_cq_element_rx(&wce);
-	if (m_rx_hot_buff) {
-		if (vma_wc_opcode(wce) & VMA_IBV_WC_RECV) {
-			if ((++m_qp_rec.debth < (int)m_n_sysvar_rx_num_wr_to_post_recv) ||
-				!compensate_qp_poll_success(m_rx_hot_buff)) {
-					process_recv_buffer(m_rx_hot_buff, pv_fd_ready_array);
-			}
-		}
-	}
-	m_rx_hot_buff = NULL;
-
-	return 1;
-}
-
-inline void cq_mgr::mlx5_cqe64_to_vma_wc(volatile struct mlx5_cqe64 *cqe, vma_ibv_wc *wc)
-{
-	struct mlx5_err_cqe *ecqe;
-	ecqe = (struct mlx5_err_cqe *)cqe;
-
-	switch (cqe->op_own >> 4) {
-	case MLX5_CQE_RESP_WR_IMM:
-		cq_logerr("IBV_WC_RECV_RDMA_WITH_IMM is not supported");
-		break;
-	case MLX5_CQE_RESP_SEND:
-	case MLX5_CQE_RESP_SEND_IMM:
-	case MLX5_CQE_RESP_SEND_INV:
-		vma_wc_opcode(*wc) = VMA_IBV_WC_RECV; 
-		wc->byte_len = ntohl(cqe->byte_cnt);
-		wc->status = IBV_WC_SUCCESS;
-		return;
-	case MLX5_CQE_REQ:
-		wc->status = IBV_WC_SUCCESS;
-		return;
-	default:
-		break;
-	}
-
-	/* Only IBV_WC_WR_FLUSH_ERR is used in code */
-	if (MLX5_CQE_SYNDROME_WR_FLUSH_ERR == ecqe->syndrome) {
-		wc->status = IBV_WC_WR_FLUSH_ERR;
-	} else {
-		wc->status = IBV_WC_GENERAL_ERR;
-	}
- 
-	wc->vendor_err = ecqe->vendor_err_synd;
-}
-
-volatile struct mlx5_cqe64 *cq_mgr::mlx5_check_error_completion(volatile struct mlx5_cqe64 *cqe, volatile uint16_t *ci, uint8_t op_own)
-{
-	switch (op_own >> 4) {
-		case MLX5_CQE_INVALID:
-			return NULL; /* No CQE */
-		case MLX5_CQE_REQ_ERR:
-		case MLX5_CQE_RESP_ERR:
-			++(*ci);
-			rmb();
-			*m_cq_db = htonl(m_cq_ci);
-			return cqe;
-		default:
-			return NULL;
-	}
-}
-
-inline volatile struct mlx5_cqe64 *cq_mgr::mlx5_get_cqe64(void)
-{
-	volatile struct mlx5_cqe64 *cqe;
-	volatile struct mlx5_cqe64 *cqes;
-	uint8_t op_own;
-
-	cqes = *m_mlx5_cqes;
-	cqe = &cqes[m_cq_ci & (m_cq_sz - 1)];
-	op_own = cqe->op_own;
-
-	if (unlikely((op_own & MLX5_CQE_OWNER_MASK) == !(m_cq_ci & m_cq_sz))) {
-		return NULL;
-	} else if (unlikely((op_own >> 4) == MLX5_CQE_INVALID)) {
-		return NULL;
-	}
-
-	++m_cq_ci;
-	rmb();
-	*m_cq_db = htonl(m_cq_ci);
-
-	return cqe;
-}
-
-inline volatile struct mlx5_cqe64 *cq_mgr::mlx5_get_cqe64(volatile struct mlx5_cqe64 **cqe_err)
-{
-	volatile struct mlx5_cqe64 *cqe;
-	volatile struct mlx5_cqe64 *cqes;
-	uint8_t op_own;
-
-	cqes = *m_mlx5_cqes;
-	cqe = &cqes[m_cq_ci & (m_cq_sz - 1)];
-	op_own = cqe->op_own;
-
-	*cqe_err = NULL;
-	if (unlikely((op_own & MLX5_CQE_OWNER_MASK) == !(m_cq_ci & m_cq_sz))) {
-		return NULL;
-	} else if (unlikely(op_own & 0x80)) {
-		*cqe_err = mlx5_check_error_completion(cqe, &m_cq_ci, op_own);
-		return NULL;
-	}
-
-	++m_cq_ci;
-	rmb();
-	*m_cq_db = htonl(m_cq_ci);
-
-	return cqe;
-}
-#endif // DEFINED_VMAPOLL
 
 #if _BullseyeCoverage
     #pragma BullseyeCoverage off
@@ -1098,130 +827,6 @@ bool cq_mgr::reclaim_recv_buffers(descq_t *rx_reuse)
 
 int cq_mgr::drain_and_proccess(uintptr_t* p_recycle_buffers_last_wr_id /*=NULL*/)
 {
-#ifdef DEFINED_VMAPOLL
-	cq_logfuncall("cq was %s drained. %d processed wce since last check. %d wce in m_rx_queue", (m_b_was_drained?"":"not "), m_n_wce_counter, m_rx_queue.size());
-
-#if 0 /* TODO: see explanation */
-	/* This function should be called during destructor only.
-	 * Intrenal thread does not launch draining RX logic for vma_poll mode 
-	 * See: net_device_table_mgr::handle_timer_expired(RING_PROGRESS_ENGINE_TIMER)
-	 */
-
-	/* Check if we are in socketXtreme usage mode */
-	if (true == m_p_ring->get_xtreme_active()) {
-		return 0;
-	}
-#endif
-	// CQ polling loop until max wce limit is reached for this interval or CQ is drained
-	uint32_t ret_total = 0;
-	//uint64_t cq_poll_sn = 0;
-
-	if (p_recycle_buffers_last_wr_id != NULL) {
-		m_b_was_drained = false;
-	}
-
-	while ((m_n_sysvar_progress_engine_wce_max && (m_n_sysvar_progress_engine_wce_max > m_n_wce_counter)) &&
-		!m_b_was_drained) {
-		int ret = 0;
-		volatile mlx5_cqe64 *cqe_arr[MCE_MAX_CQ_POLL_BATCH];
-
-		for (int i = 0; i < MCE_MAX_CQ_POLL_BATCH; ++i)
-		{
-			cqe_arr[i] = mlx5_get_cqe64();
-			if (cqe_arr[i]) {
-				++ret;
-				wmb();
-				*m_cq_db = htonl(m_cq_ci);
-				if (m_b_is_rx) {
-					++m_qp->m_mlx5_hw_qp->rq.tail;
-				}
-			}
-			else {
-				break;
-			}
-		}
-
-		if (!ret) {
-			m_b_was_drained = true;
-			return ret_total;
-		}
-
-
-		m_n_wce_counter += ret;
-		if (ret < MCE_MAX_CQ_POLL_BATCH)
-			m_b_was_drained = true;
-
-		for (int i = 0; i < ret; i++) {
-			uint32_t wqe_sz = 0;
-			volatile mlx5_cqe64 *cqe = cqe_arr[i];
-			vma_ibv_wc wce;
-
-			uint16_t wqe_ctr = ntohs(cqe->wqe_counter);
-			if (m_b_is_rx) {
-				wqe_sz = m_qp->m_rx_num_wr;
-			}
-			else {
-				wqe_sz = m_qp->m_tx_num_wr;
-			}
-
-			int index = wqe_ctr & (wqe_sz - 1);
-
-			/* We need to processes rx data in case
-			 * wce.status == IBV_WC_SUCCESS
-			 * and release buffers to rx pool
-			 * in case failure
-			 */
-			m_rx_hot_buff = (mem_buf_desc_t*)(uintptr_t)m_qp->m_p_rq_wqe_idx_to_wrid[index];
-			memset(&wce, 0, sizeof(wce));
-			wce.wr_id = (uintptr_t)m_rx_hot_buff;
-			mlx5_cqe64_to_vma_wc(cqe, &wce);
-
-			m_rx_hot_buff = process_cq_element_rx(&wce);
-			if (m_rx_hot_buff) {
-				if (p_recycle_buffers_last_wr_id) {
-					m_p_cq_stat->n_rx_pkt_drop++;
-					reclaim_recv_buffer_helper(m_rx_hot_buff);
-				} else {
-					bool procces_now = false;
-					if (m_transport_type == VMA_TRANSPORT_ETH) {
-						procces_now = is_eth_tcp_frame(m_rx_hot_buff);
-					}
-					if (m_transport_type == VMA_TRANSPORT_IB) {
-						procces_now = is_ib_tcp_frame(m_rx_hot_buff);
-					}
-					// We process immediately all non udp/ip traffic..
-					if (procces_now) {
-						m_rx_hot_buff->rx.is_vma_thr = true;
-						if ((++m_qp_rec.debth < (int)m_n_sysvar_rx_num_wr_to_post_recv) ||
-							!compensate_qp_poll_success(m_rx_hot_buff)) {
-							process_recv_buffer(m_rx_hot_buff, NULL);
-						}
-					}
-					else { //udp/ip traffic we just put in the cq's rx queue
-						m_rx_queue.push_back(m_rx_hot_buff);
-						mem_buf_desc_t* buff_cur = m_rx_queue.get_and_pop_front();
-						if ((++m_qp_rec.debth < (int)m_n_sysvar_rx_num_wr_to_post_recv) ||
-							!compensate_qp_poll_success(buff_cur)) {
-							m_rx_queue.push_front(buff_cur);
-						}
-					}
-				}
-			}
-			if (p_recycle_buffers_last_wr_id) {
-				*p_recycle_buffers_last_wr_id = (uintptr_t)wce.wr_id;
-			}
-		}
-		ret_total += ret;
-	}
-	m_n_wce_counter = 0;
-	m_b_was_drained = false;
-
-	// Update cq statistics
-	m_p_cq_stat->n_rx_sw_queue_len = m_rx_queue.size();
-	m_p_cq_stat->n_rx_drained_at_once_max = max(ret_total, m_p_cq_stat->n_rx_drained_at_once_max);
-
-	return ret_total;
-#else
 	cq_logfuncall("cq was %s drained. %d processed wce since last check. %d wce in m_rx_queue", (m_b_was_drained?"":"not "), m_n_wce_counter, m_rx_queue.size());
 
 	// CQ polling loop until max wce limit is reached for this interval or CQ is drained
@@ -1293,7 +898,6 @@ int cq_mgr::drain_and_proccess(uintptr_t* p_recycle_buffers_last_wr_id /*=NULL*/
 	m_p_cq_stat->n_rx_drained_at_once_max = max(ret_total, m_p_cq_stat->n_rx_drained_at_once_max);
 
 	return ret_total;
-#endif // DEFINED_VMAPOLL
 }
 
 

--- a/src/vma/dev/cq_mgr.cpp
+++ b/src/vma/dev/cq_mgr.cpp
@@ -705,7 +705,7 @@ int cq_mgr::vma_poll_and_process_element_rx(mem_buf_desc_t **p_desc_lst)
 
 	if (unlikely(m_rx_hot_buff == NULL)) {
 		int index = m_qp->m_mlx5_hw_qp->rq.tail & (m_qp->m_rx_num_wr - 1);
-		m_rx_hot_buff = (mem_buf_desc_t*)(uintptr_t)m_qp->m_rq_wqe_idx_to_wrid[index];
+		m_rx_hot_buff = (mem_buf_desc_t*)(uintptr_t)m_qp->m_p_rq_wqe_idx_to_wrid[index];
 		m_rx_hot_buff->rx.context = NULL;
 		m_rx_hot_buff->rx.is_vma_thr = false;
 	}
@@ -785,7 +785,7 @@ int cq_mgr::poll_and_process_element_rx(uint64_t* p_cq_poll_sn, void* pv_fd_read
 
 	if (unlikely(m_rx_hot_buff == NULL)) {
 		int index = m_qp->m_mlx5_hw_qp->rq.tail & (m_qp->m_rx_num_wr - 1);
-		m_rx_hot_buff = (mem_buf_desc_t*)(uintptr_t)m_qp->m_rq_wqe_idx_to_wrid[index];
+		m_rx_hot_buff = (mem_buf_desc_t*)(uintptr_t)m_qp->m_p_rq_wqe_idx_to_wrid[index];
 		m_rx_hot_buff->rx.context = NULL;
 		m_rx_hot_buff->rx.is_vma_thr = false;
 		m_rx_hot_buff->rx.vma_polled = false;
@@ -1171,7 +1171,7 @@ int cq_mgr::drain_and_proccess(uintptr_t* p_recycle_buffers_last_wr_id /*=NULL*/
 			 * and release buffers to rx pool
 			 * in case failure
 			 */
-			m_rx_hot_buff = (mem_buf_desc_t*)(uintptr_t)m_qp->m_rq_wqe_idx_to_wrid[index];
+			m_rx_hot_buff = (mem_buf_desc_t*)(uintptr_t)m_qp->m_p_rq_wqe_idx_to_wrid[index];
 			memset(&wce, 0, sizeof(wce));
 			wce.wr_id = (uintptr_t)m_rx_hot_buff;
 			mlx5_cqe64_to_vma_wc(cqe, &wce);

--- a/src/vma/dev/cq_mgr.cpp
+++ b/src/vma/dev/cq_mgr.cpp
@@ -726,6 +726,12 @@ int cq_mgr::poll_and_process_element_tx(uint64_t* p_cq_poll_sn)
 	return ret;
 }
 
+int	cq_mgr::poll_and_process_element_rx(mem_buf_desc_t **p_desc_lst)
+{
+	NOT_IN_USE(p_desc_lst);
+	cq_logerr("SocketXtreme mode is supported by mlx5 cq manager only");
+	return 0;
+}
 
 #if _BullseyeCoverage
     #pragma BullseyeCoverage off

--- a/src/vma/dev/cq_mgr.cpp
+++ b/src/vma/dev/cq_mgr.cpp
@@ -1107,8 +1107,8 @@ int cq_mgr::drain_and_proccess(uintptr_t* p_recycle_buffers_last_wr_id /*=NULL*/
 	 * See: net_device_table_mgr::handle_timer_expired(RING_PROGRESS_ENGINE_TIMER)
 	 */
 
-	/* Check if we are in vma_poll() usage mode */
-	if (true == m_p_ring->get_vma_active()) {
+	/* Check if we are in socketXtreme usage mode */
+	if (true == m_p_ring->get_xtreme_active()) {
 		return 0;
 	}
 #endif

--- a/src/vma/dev/cq_mgr.h
+++ b/src/vma/dev/cq_mgr.h
@@ -149,7 +149,7 @@ public:
 	virtual int	poll_and_process_element_rx(uint64_t* p_cq_poll_sn, void* pv_fd_ready_array = NULL);
 	virtual int	poll_and_process_element_tx(uint64_t* p_cq_poll_sn);
 
-	virtual int	poll_and_process_element_rx(mem_buf_desc_t **p_desc_lst) { NOT_IN_USE(p_desc_lst); return 0; }
+	virtual int	poll_and_process_element_rx(mem_buf_desc_t **p_desc_lst);
 
 	/**
 	 * This will check if the cq was drained, and if it wasn't it will drain it.

--- a/src/vma/dev/cq_mgr.h
+++ b/src/vma/dev/cq_mgr.h
@@ -194,9 +194,6 @@ public:
 	void 	modify_cq_moderation(uint32_t period, uint32_t count);
 
 	inline void convert_hw_time_to_system_time(uint64_t hwtime, struct timespec* systime) { m_p_ib_ctx_handler->convert_hw_time_to_system_time(hwtime, systime); }
-#ifdef DEFINED_VMAPOLL
-	void 	mlx5_init_cq();
-#endif // DEFINED_VMAPOLL
 
 
 protected:
@@ -282,7 +279,6 @@ private:
 	void		handle_tcp_ctl_packets(uint32_t rx_processed, void* pv_fd_ready_array);
 
 #ifdef DEFINED_VMAPOLL
-	int 		vma_poll_reclaim_single_recv_buffer_helper(mem_buf_desc_t* buff);
 	void		vma_poll_reclaim_recv_buffer_helper(mem_buf_desc_t* buff);
 #endif // DEFINED_VMAPOLL
 

--- a/src/vma/dev/cq_mgr.h
+++ b/src/vma/dev/cq_mgr.h
@@ -52,11 +52,6 @@
 #endif
 #include "vma/vma_extra.h"
 
-#ifdef DEFINED_VMAPOLL
-	#define IS_VMAPOLL true
-#else
-	#define IS_VMAPOLL false
-#endif // DEFINED_VMAPOLL
 
 class net_device_mgr;
 class ring;
@@ -248,6 +243,7 @@ protected:
 	ib_ctx_handler*		m_p_ib_ctx_handler;
 
 private:
+	const uint32_t		m_n_sysvar_rx_num_wr_to_post_recv;
 	const bool		m_b_sysvar_is_rx_sw_csum_on;
 	struct ibv_comp_channel *m_comp_event_channel;
 	bool			m_b_notification_armed;

--- a/src/vma/dev/cq_mgr.h
+++ b/src/vma/dev/cq_mgr.h
@@ -184,6 +184,8 @@ public:
 	bool	reclaim_recv_buffers(descq_t *rx_reuse);
 	bool	reclaim_recv_buffers_no_lock(descq_t *rx_reuse);
 	bool	reclaim_recv_buffers(mem_buf_desc_t *rx_reuse_lst);
+	bool	reclaim_recv_buffers_no_lock(mem_buf_desc_t *rx_reuse_lst);
+	int	reclaim_recv_single_buffer(mem_buf_desc_t* rx_reuse);
 
 	//maps between qpn and vlan id to the local interface
 	void	map_vlan_and_qpn_to_local_if(int qp_num, uint16_t vlan_id, in_addr_t local_if);
@@ -272,15 +274,18 @@ private:
 	cq_stats_t 		m_cq_stat_static;
 	static atomic_t		m_n_cq_id_counter;
 
+	/* This fields are needed to track internal memory buffers
+	 * represented as struct vma_buff_t
+	 * from user application by special VMA extended API
+	 */
+	mem_buf_desc_t*		m_rx_buffs_rdy_for_free_head;
+	mem_buf_desc_t*		m_rx_buffs_rdy_for_free_tail;
+
 #ifdef DEFINED_VMAPOLL
 	int	vma_poll_and_process_element_rx(mem_buf_desc_t **p_desc_lst);
 #endif // DEFINED_VMAPOLL
 
 	void		handle_tcp_ctl_packets(uint32_t rx_processed, void* pv_fd_ready_array);
-
-#ifdef DEFINED_VMAPOLL
-	void		vma_poll_reclaim_recv_buffer_helper(mem_buf_desc_t* buff);
-#endif // DEFINED_VMAPOLL
 
 	// requests safe_mce_sys().qp_compensation_level buffers from global pool
 	bool 		request_more_buffers() __attribute__((noinline));

--- a/src/vma/dev/cq_mgr_mlx5.cpp
+++ b/src/vma/dev/cq_mgr_mlx5.cpp
@@ -252,17 +252,6 @@ int cq_mgr_mlx5::drain_and_proccess(uintptr_t* p_recycle_buffers_last_wr_id /*=N
 #ifdef DEFINED_VMAPOLL
 	cq_logfuncall("cq was %s drained. %d processed wce since last check. %d wce in m_rx_queue", (m_b_was_drained?"":"not "), m_n_wce_counter, m_rx_queue.size());
 
-#if 0 /* TODO: see explanation */
-	/* This function should be called during destructor only.
-	 * Intrenal thread does not launch draining RX logic for vma_poll mode
-	 * See: net_device_table_mgr::handle_timer_expired(RING_PROGRESS_ENGINE_TIMER)
-	 */
-
-	/* Check if we are in socketXtreme usage mode */
-	if (true == m_p_ring->get_xtreme_active()) {
-		return 0;
-	}
-#endif
 	// CQ polling loop until max wce limit is reached for this interval or CQ is drained
 	uint32_t ret_total = 0;
 	//uint64_t cq_poll_sn = 0;

--- a/src/vma/dev/cq_mgr_mlx5.cpp
+++ b/src/vma/dev/cq_mgr_mlx5.cpp
@@ -70,9 +70,6 @@ cq_mgr_mlx5::cq_mgr_mlx5(ring_simple* p_ring, ib_ctx_handler* p_ib_ctx_handler,
 
 uint32_t cq_mgr_mlx5::clean_cq()
 {
-#ifdef DEFINED_VMAPOLL
-	return 0;
-#else
 	uint32_t ret_total = 0;
 	uint64_t cq_poll_sn = 0;
 	mem_buf_desc_t* buff;
@@ -103,7 +100,6 @@ uint32_t cq_mgr_mlx5::clean_cq()
 	}
 
 	return ret_total;
-#endif // DEFINED_VMAPOLL
 }
 
 cq_mgr_mlx5::~cq_mgr_mlx5()

--- a/src/vma/dev/cq_mgr_mlx5.cpp
+++ b/src/vma/dev/cq_mgr_mlx5.cpp
@@ -60,6 +60,14 @@ cq_mgr_mlx5::cq_mgr_mlx5(ring_simple* p_ring, ib_ctx_handler* p_ib_ctx_handler,
 	,m_cq_dbell(NULL)
 	,m_rq(NULL)
 	,m_cqe_log_sz(0)
+	,m_n_sysvar_rx_num_wr_to_post_recv(safe_mce_sys().rx_num_wr_to_post_recv)
+#ifdef DEFINED_VMAPOLL
+	,m_rx_hot_buff(NULL)
+	,m_cq_sz(cq_size)
+	,m_cq_ci(0)
+	,m_mlx5_cqes(NULL)
+	,m_cq_db(0)
+#endif
 	,m_rx_hot_buffer(NULL)
 	,m_qp(NULL)
 	,m_mlx5_cq(NULL)
@@ -69,6 +77,9 @@ cq_mgr_mlx5::cq_mgr_mlx5(ring_simple* p_ring, ib_ctx_handler* p_ib_ctx_handler,
 
 uint32_t cq_mgr_mlx5::clean_cq()
 {
+#ifdef DEFINED_VMAPOLL
+	return 0;
+#else
 	uint32_t ret_total = 0;
 	uint64_t cq_poll_sn = 0;
 	mem_buf_desc_t* buff;
@@ -99,6 +110,7 @@ uint32_t cq_mgr_mlx5::clean_cq()
 	}
 
 	return ret_total;
+#endif
 }
 
 cq_mgr_mlx5::~cq_mgr_mlx5()
@@ -244,6 +256,130 @@ inline void cq_mgr_mlx5::cqe64_to_mem_buff_desc(struct mlx5_cqe64 *cqe, mem_buf_
 
 int cq_mgr_mlx5::drain_and_proccess(uintptr_t* p_recycle_buffers_last_wr_id /*=NULL*/)
 {
+#ifdef DEFINED_VMAPOLL
+	cq_logfuncall("cq was %s drained. %d processed wce since last check. %d wce in m_rx_queue", (m_b_was_drained?"":"not "), m_n_wce_counter, m_rx_queue.size());
+
+#if 0 /* TODO: see explanation */
+	/* This function should be called during destructor only.
+	 * Intrenal thread does not launch draining RX logic for vma_poll mode
+	 * See: net_device_table_mgr::handle_timer_expired(RING_PROGRESS_ENGINE_TIMER)
+	 */
+
+	/* Check if we are in socketXtreme usage mode */
+	if (true == m_p_ring->get_xtreme_active()) {
+		return 0;
+	}
+#endif
+	// CQ polling loop until max wce limit is reached for this interval or CQ is drained
+	uint32_t ret_total = 0;
+	//uint64_t cq_poll_sn = 0;
+
+	if (p_recycle_buffers_last_wr_id != NULL) {
+		m_b_was_drained = false;
+	}
+
+	while ((m_n_sysvar_progress_engine_wce_max && (m_n_sysvar_progress_engine_wce_max > m_n_wce_counter)) &&
+		!m_b_was_drained) {
+		int ret = 0;
+		volatile mlx5_cqe64 *cqe_arr[MCE_MAX_CQ_POLL_BATCH];
+
+		for (int i = 0; i < MCE_MAX_CQ_POLL_BATCH; ++i)
+		{
+			cqe_arr[i] = mlx5_get_cqe64();
+			if (cqe_arr[i]) {
+				++ret;
+				wmb();
+				*m_cq_db = htonl(m_cq_ci);
+				if (m_b_is_rx) {
+					++m_qp->m_mlx5_hw_qp->rq.tail;
+				}
+			}
+			else {
+				break;
+			}
+		}
+
+		if (!ret) {
+			m_b_was_drained = true;
+			return ret_total;
+		}
+
+
+		m_n_wce_counter += ret;
+		if (ret < MCE_MAX_CQ_POLL_BATCH)
+			m_b_was_drained = true;
+
+		for (int i = 0; i < ret; i++) {
+			uint32_t wqe_sz = 0;
+			volatile mlx5_cqe64 *cqe = cqe_arr[i];
+			vma_ibv_wc wce;
+
+			uint16_t wqe_ctr = ntohs(cqe->wqe_counter);
+			if (m_b_is_rx) {
+				wqe_sz = m_qp->m_rx_num_wr;
+			}
+			else {
+				wqe_sz = m_qp->m_tx_num_wr;
+			}
+
+			int index = wqe_ctr & (wqe_sz - 1);
+
+			/* We need to processes rx data in case
+			 * wce.status == IBV_WC_SUCCESS
+			 * and release buffers to rx pool
+			 * in case failure
+			 */
+			m_rx_hot_buff = (mem_buf_desc_t*)(uintptr_t)m_qp->m_p_rq_wqe_idx_to_wrid[index];
+			memset(&wce, 0, sizeof(wce));
+			wce.wr_id = (uintptr_t)m_rx_hot_buff;
+			mlx5_cqe64_to_vma_wc(cqe, &wce);
+
+			m_rx_hot_buff = cq_mgr::process_cq_element_rx(&wce);
+			if (m_rx_hot_buff) {
+				if (p_recycle_buffers_last_wr_id) {
+					m_p_cq_stat->n_rx_pkt_drop++;
+					reclaim_recv_buffer_helper(m_rx_hot_buff);
+				} else {
+					bool procces_now = false;
+					if (m_transport_type == VMA_TRANSPORT_ETH) {
+						procces_now = is_eth_tcp_frame(m_rx_hot_buff);
+					}
+					if (m_transport_type == VMA_TRANSPORT_IB) {
+						procces_now = is_ib_tcp_frame(m_rx_hot_buff);
+					}
+					// We process immediately all non udp/ip traffic..
+					if (procces_now) {
+						m_rx_hot_buff->rx.is_vma_thr = true;
+						if ((++m_qp_rec.debth < (int)m_n_sysvar_rx_num_wr_to_post_recv) ||
+							!compensate_qp_poll_success(m_rx_hot_buff)) {
+							process_recv_buffer(m_rx_hot_buff, NULL);
+						}
+					}
+					else { //udp/ip traffic we just put in the cq's rx queue
+						m_rx_queue.push_back(m_rx_hot_buff);
+						mem_buf_desc_t* buff_cur = m_rx_queue.get_and_pop_front();
+						if ((++m_qp_rec.debth < (int)m_n_sysvar_rx_num_wr_to_post_recv) ||
+							!compensate_qp_poll_success(buff_cur)) {
+							m_rx_queue.push_front(buff_cur);
+						}
+					}
+				}
+			}
+			if (p_recycle_buffers_last_wr_id) {
+				*p_recycle_buffers_last_wr_id = (uintptr_t)wce.wr_id;
+			}
+		}
+		ret_total += ret;
+	}
+	m_n_wce_counter = 0;
+	m_b_was_drained = false;
+
+	// Update cq statistics
+	m_p_cq_stat->n_rx_sw_queue_len = m_rx_queue.size();
+	m_p_cq_stat->n_rx_drained_at_once_max = max(ret_total, m_p_cq_stat->n_rx_drained_at_once_max);
+
+	return ret_total;
+#else
 	cq_logfuncall("cq was %sdrained. %d processed wce since last check. %d wce in m_rx_queue", (m_b_was_drained?"":"not "), m_n_wce_counter, m_rx_queue.size());
 
 	/* CQ polling loop until max wce limit is reached for this interval or CQ is drained */
@@ -316,6 +452,7 @@ int cq_mgr_mlx5::drain_and_proccess(uintptr_t* p_recycle_buffers_last_wr_id /*=N
 	m_p_cq_stat->n_rx_drained_at_once_max = max(ret_total, m_p_cq_stat->n_rx_drained_at_once_max);
 
 	return ret_total;
+#endif // DEFINED_VMAPOLL
 }
 
 inline void cq_mgr_mlx5::update_global_sn(uint64_t& cq_poll_sn, uint32_t num_polled_cqes)
@@ -346,7 +483,12 @@ mem_buf_desc_t* cq_mgr_mlx5::process_cq_element_rx(mem_buf_desc_t* p_mem_buf_des
 
 	/* we use context to verify that on reclaim rx buffer path we return the buffer to the right CQ */
 	p_mem_buf_desc->rx.is_vma_thr = false;
+#ifdef DEFINED_VMAPOLL
+	p_mem_buf_desc->rx.context = NULL;
+#else
 	p_mem_buf_desc->rx.context = this;
+#endif // DEFINED_VMAPOLL
+	p_mem_buf_desc->rx.vma_polled = false;
 
 	if (unlikely((status != BS_OK) ||
 			     (m_b_is_rx_hw_csum_on && p_mem_buf_desc->rx.is_sw_csum_need))) {
@@ -380,6 +522,55 @@ int cq_mgr_mlx5::poll_and_process_element_rx(uint64_t* p_cq_poll_sn, void* pv_fd
 	/* Assume locked!!! */
 	cq_logfuncall("");
 
+#ifdef DEFINED_VMAPOLL
+	NOT_IN_USE(p_cq_poll_sn);
+
+	/* coverity[stack_use_local_overflow] */
+	uint32_t ret_rx_processed = process_recv_queue(pv_fd_ready_array);
+	if (unlikely(ret_rx_processed >= m_n_sysvar_cq_poll_batch_max)) {
+		m_p_ring->m_gro_mgr.flush_all(pv_fd_ready_array);
+		return ret_rx_processed;
+	}
+
+	if (m_p_next_rx_desc_poll) {
+		prefetch_range((uint8_t*)m_p_next_rx_desc_poll->p_buffer,safe_mce_sys().rx_prefetch_bytes_before_poll);
+	}
+
+	if (unlikely(m_rx_hot_buff == NULL)) {
+		int index = m_qp->m_mlx5_hw_qp->rq.tail & (m_qp->m_rx_num_wr - 1);
+		m_rx_hot_buff = (mem_buf_desc_t*)(uintptr_t)m_qp->m_p_rq_wqe_idx_to_wrid[index];
+		m_rx_hot_buff->rx.context = NULL;
+		m_rx_hot_buff->rx.is_vma_thr = false;
+		m_rx_hot_buff->rx.vma_polled = false;
+	}
+	else {
+		volatile mlx5_cqe64 *cqe_err = NULL;
+		volatile mlx5_cqe64 *cqe = mlx5_get_cqe64(&cqe_err);
+
+		if (likely(cqe)) {
+			++m_n_wce_counter;
+			++m_qp->m_mlx5_hw_qp->rq.tail;
+			m_rx_hot_buff->sz_data = ntohl(cqe->byte_cnt);
+			m_rx_hot_buff->rx.flow_tag_id = vma_get_flow_tag(cqe);
+
+			if (unlikely(++m_qp_rec.debth >= (int)m_n_sysvar_rx_num_wr_to_post_recv)) {
+				compensate_qp_poll_success(m_rx_hot_buff);
+			}
+			process_recv_buffer(m_rx_hot_buff, pv_fd_ready_array);
+			++ret_rx_processed;
+			m_rx_hot_buff = NULL;
+		}
+		else if (cqe_err) {
+			ret_rx_processed += mlx5_poll_and_process_error_element_rx(cqe_err, pv_fd_ready_array);
+		}
+		else {
+			compensate_qp_poll_failed();
+		}
+
+	}
+
+	return ret_rx_processed;
+#else
 	uint32_t ret_rx_processed = process_recv_queue(pv_fd_ready_array);
 	if (unlikely(ret_rx_processed >= m_n_sysvar_cq_poll_batch_max)) {
 		m_p_ring->m_gro_mgr.flush_all(pv_fd_ready_array);
@@ -418,7 +609,74 @@ int cq_mgr_mlx5::poll_and_process_element_rx(uint64_t* p_cq_poll_sn, void* pv_fd
 	}
 
 	return ret_rx_processed;
+#endif // DEFINED_VMAPOLL
 }
+
+#ifdef DEFINED_VMAPOLL
+int cq_mgr_mlx5::poll_and_process_element_rx(mem_buf_desc_t **p_desc_lst)
+{
+	int packets_num = 0;
+
+	if (unlikely(m_rx_hot_buff == NULL)) {
+		int index = m_qp->m_mlx5_hw_qp->rq.tail & (m_qp->m_rx_num_wr - 1);
+		m_rx_hot_buff = (mem_buf_desc_t*)(uintptr_t)m_qp->m_p_rq_wqe_idx_to_wrid[index];
+		m_rx_hot_buff->rx.context = NULL;
+		m_rx_hot_buff->rx.is_vma_thr = false;
+	}
+	//prefetch_range((uint8_t*)m_rx_hot_buff->p_buffer,safe_mce_sys().rx_prefetch_bytes_before_poll);
+#ifdef RDTSC_MEASURE_RX_VERBS_READY_POLL
+	RDTSC_TAKE_START(g_rdtsc_instr_info_arr[RDTSC_FLOW_RX_VERBS_READY_POLL]);
+#endif //RDTSC_MEASURE_RX_VERBS_READY_POLL
+
+#ifdef RDTSC_MEASURE_RX_VERBS_IDLE_POLL
+	RDTSC_TAKE_START(g_rdtsc_instr_info_arr[RDTSC_FLOW_RX_VERBS_IDLE_POLL]);
+#endif //RDTSC_MEASURE_RX_VERBS_IDLE_POLL
+
+#ifdef RDTSC_MEASURE_RX_VMA_TCP_IDLE_POLL
+	RDTSC_TAKE_END(g_rdtsc_instr_info_arr[RDTSC_FLOW_RX_VMA_TCP_IDLE_POLL]);
+#endif //RDTSC_MEASURE_RX_VMA_TCP_IDLE_POLL
+	volatile mlx5_cqe64 *cqe_err = NULL;
+	volatile mlx5_cqe64 *cqe = mlx5_get_cqe64(&cqe_err);
+
+	if (likely(cqe)) {
+		++m_n_wce_counter;
+		++m_qp->m_mlx5_hw_qp->rq.tail;
+		m_rx_hot_buff->sz_data = ntohl(cqe->byte_cnt);
+		m_rx_hot_buff->rx.flow_tag_id = vma_get_flow_tag(cqe);
+
+		if (unlikely(++m_qp_rec.debth >= (int)m_n_sysvar_rx_num_wr_to_post_recv)) {
+			compensate_qp_poll_success(m_rx_hot_buff);
+		}
+		++packets_num;
+		*p_desc_lst = m_rx_hot_buff;
+		m_rx_hot_buff = NULL;
+	}
+	else if (cqe_err) {
+		/* Return nothing in case error wc
+		 * It is difference with poll_and_process_element_rx()
+		 */
+		mlx5_poll_and_process_error_element_rx(cqe_err, NULL);
+		*p_desc_lst = NULL;
+	}
+	else {
+#ifdef RDTSC_MEASURE_RX_VERBS_IDLE_POLL
+		RDTSC_TAKE_END(g_rdtsc_instr_info_arr[RDTSC_FLOW_RX_VERBS_IDLE_POLL]);
+#endif
+
+#ifdef RDTSC_MEASURE_RX_VMA_TCP_IDLE_POLL
+		RDTSC_TAKE_START(g_rdtsc_instr_info_arr[RDTSC_FLOW_RX_VMA_TCP_IDLE_POLL]);
+#endif
+
+#ifdef RDTSC_MEASURE_RX_CQE_RECEIVEFROM
+		RDTSC_TAKE_START(g_rdtsc_instr_info_arr[RDTSC_FLOW_RX_CQE_TO_RECEIVEFROM]);
+#endif
+		compensate_qp_poll_failed();
+	}
+
+	return packets_num;
+
+}
+#endif // DEFINED_VMAPOLL
 
 inline void cq_mgr_mlx5::cqe64_to_vma_wc(struct mlx5_cqe64 *cqe, vma_ibv_wc *wc)
 {
@@ -577,6 +835,11 @@ void cq_mgr_mlx5::set_qp_rq(qp_mgr* qp)
 	m_cq_dbell = m_mlx5_cq->dbrec;
 	m_cqe_log_sz = ilog_2(m_mlx5_cq->cqe_sz);
 	m_cqes = ((uint8_t*)m_mlx5_cq->active_buf->buf) + m_mlx5_cq->cqe_sz - sizeof(struct mlx5_cqe64);
+
+#ifdef DEFINED_VMAPOLL
+	m_cq_db = m_mlx5_cq->dbrec;
+	m_mlx5_cqes = (volatile struct mlx5_cqe64 (*)[])(uintptr_t)m_mlx5_cq->active_buf->buf;
+#endif
 }
 
 void cq_mgr_mlx5::add_qp_rx(qp_mgr* qp)
@@ -621,5 +884,129 @@ void cq_mgr_mlx5::add_qp_tx(qp_mgr* qp)
 	m_cqes = ((uint8_t *)m_mlx5_cq->active_buf->buf) + m_mlx5_cq->cqe_sz - sizeof(struct mlx5_cqe64);
 	cq_logfunc("qp_mgr=%p m_cq_dbell=%p m_cqes=%p", m_qp, m_cq_dbell, m_cqes);
 }
+
+#ifdef DEFINED_VMAPOLL
+int cq_mgr_mlx5::mlx5_poll_and_process_error_element_rx(volatile struct mlx5_cqe64 *cqe, void* pv_fd_ready_array)
+{
+	vma_ibv_wc wce;
+
+	memset(&wce, 0, sizeof(wce));
+	wce.wr_id = (uintptr_t)m_rx_hot_buff;
+	mlx5_cqe64_to_vma_wc(cqe, &wce);
+
+	++m_n_wce_counter;
+	++m_qp->m_mlx5_hw_qp->rq.tail;
+
+	m_rx_hot_buff = cq_mgr::process_cq_element_rx(&wce);
+	if (m_rx_hot_buff) {
+		if (vma_wc_opcode(wce) & VMA_IBV_WC_RECV) {
+			if ((++m_qp_rec.debth < (int)m_n_sysvar_rx_num_wr_to_post_recv) ||
+				!compensate_qp_poll_success(m_rx_hot_buff)) {
+					process_recv_buffer(m_rx_hot_buff, pv_fd_ready_array);
+			}
+		}
+	}
+	m_rx_hot_buff = NULL;
+
+	return 1;
+}
+
+inline void cq_mgr_mlx5::mlx5_cqe64_to_vma_wc(volatile struct mlx5_cqe64 *cqe, vma_ibv_wc *wc)
+{
+	struct mlx5_err_cqe *ecqe;
+	ecqe = (struct mlx5_err_cqe *)cqe;
+
+	switch (cqe->op_own >> 4) {
+	case MLX5_CQE_RESP_WR_IMM:
+		cq_logerr("IBV_WC_RECV_RDMA_WITH_IMM is not supported");
+		break;
+	case MLX5_CQE_RESP_SEND:
+	case MLX5_CQE_RESP_SEND_IMM:
+	case MLX5_CQE_RESP_SEND_INV:
+		vma_wc_opcode(*wc) = VMA_IBV_WC_RECV;
+		wc->byte_len = ntohl(cqe->byte_cnt);
+		wc->status = IBV_WC_SUCCESS;
+		return;
+	case MLX5_CQE_REQ:
+		wc->status = IBV_WC_SUCCESS;
+		return;
+	default:
+		break;
+	}
+
+	/* Only IBV_WC_WR_FLUSH_ERR is used in code */
+	if (MLX5_CQE_SYNDROME_WR_FLUSH_ERR == ecqe->syndrome) {
+		wc->status = IBV_WC_WR_FLUSH_ERR;
+	} else {
+		wc->status = IBV_WC_GENERAL_ERR;
+	}
+
+	wc->vendor_err = ecqe->vendor_err_synd;
+}
+
+volatile struct mlx5_cqe64 *cq_mgr_mlx5::mlx5_check_error_completion(volatile struct mlx5_cqe64 *cqe, volatile uint16_t *ci, uint8_t op_own)
+{
+	switch (op_own >> 4) {
+		case MLX5_CQE_INVALID:
+			return NULL; /* No CQE */
+		case MLX5_CQE_REQ_ERR:
+		case MLX5_CQE_RESP_ERR:
+			++(*ci);
+			rmb();
+			*m_cq_db = htonl(m_cq_ci);
+			return cqe;
+		default:
+			return NULL;
+	}
+}
+
+inline volatile struct mlx5_cqe64 *cq_mgr_mlx5::mlx5_get_cqe64(void)
+{
+	volatile struct mlx5_cqe64 *cqe;
+	volatile struct mlx5_cqe64 *cqes;
+	uint8_t op_own;
+
+	cqes = *m_mlx5_cqes;
+	cqe = &cqes[m_cq_ci & (m_cq_sz - 1)];
+	op_own = cqe->op_own;
+
+	if (unlikely((op_own & MLX5_CQE_OWNER_MASK) == !(m_cq_ci & m_cq_sz))) {
+		return NULL;
+	} else if (unlikely((op_own >> 4) == MLX5_CQE_INVALID)) {
+		return NULL;
+	}
+
+	++m_cq_ci;
+	rmb();
+	*m_cq_db = htonl(m_cq_ci);
+
+	return cqe;
+}
+
+inline volatile struct mlx5_cqe64 *cq_mgr_mlx5::mlx5_get_cqe64(volatile struct mlx5_cqe64 **cqe_err)
+{
+	volatile struct mlx5_cqe64 *cqe;
+	volatile struct mlx5_cqe64 *cqes;
+	uint8_t op_own;
+
+	cqes = *m_mlx5_cqes;
+	cqe = &cqes[m_cq_ci & (m_cq_sz - 1)];
+	op_own = cqe->op_own;
+
+	*cqe_err = NULL;
+	if (unlikely((op_own & MLX5_CQE_OWNER_MASK) == !(m_cq_ci & m_cq_sz))) {
+		return NULL;
+	} else if (unlikely(op_own & 0x80)) {
+		*cqe_err = mlx5_check_error_completion(cqe, &m_cq_ci, op_own);
+		return NULL;
+	}
+
+	++m_cq_ci;
+	rmb();
+	*m_cq_db = htonl(m_cq_ci);
+
+	return cqe;
+}
+#endif // DEFINED_VMAPOLL
 
 #endif//HAVE_INFINIBAND_MLX5_HW_H

--- a/src/vma/dev/cq_mgr_mlx5.cpp
+++ b/src/vma/dev/cq_mgr_mlx5.cpp
@@ -61,6 +61,7 @@ cq_mgr_mlx5::cq_mgr_mlx5(ring_simple* p_ring, ib_ctx_handler* p_ib_ctx_handler,
 	,m_rq(NULL)
 	,m_cqe_log_sz(0)
 	,m_n_sysvar_rx_num_wr_to_post_recv(safe_mce_sys().rx_num_wr_to_post_recv)
+	,m_b_sysvar_enable_xtreme(safe_mce_sys().enable_xtreme)
 	,m_rx_hot_buffer(NULL)
 	,m_qp(NULL)
 	,m_mlx5_cq(NULL)
@@ -245,119 +246,6 @@ inline void cq_mgr_mlx5::cqe64_to_mem_buff_desc(struct mlx5_cqe64 *cqe, mem_buf_
 
 int cq_mgr_mlx5::drain_and_proccess(uintptr_t* p_recycle_buffers_last_wr_id /*=NULL*/)
 {
-#ifdef DEFINED_VMAPOLL
-	cq_logfuncall("cq was %s drained. %d processed wce since last check. %d wce in m_rx_queue", (m_b_was_drained?"":"not "), m_n_wce_counter, m_rx_queue.size());
-
-	// CQ polling loop until max wce limit is reached for this interval or CQ is drained
-	uint32_t ret_total = 0;
-	//uint64_t cq_poll_sn = 0;
-
-	if (p_recycle_buffers_last_wr_id != NULL) {
-		m_b_was_drained = false;
-	}
-
-	while ((m_n_sysvar_progress_engine_wce_max && (m_n_sysvar_progress_engine_wce_max > m_n_wce_counter)) &&
-		!m_b_was_drained) {
-		int ret = 0;
-		mlx5_cqe64 *cqe_arr[MCE_MAX_CQ_POLL_BATCH];
-
-		for (int i = 0; i < MCE_MAX_CQ_POLL_BATCH; ++i)
-		{
-			cqe_arr[i] = get_cqe64();
-			if (cqe_arr[i]) {
-				++ret;
-				wmb();
-				*m_cq_dbell = htonl(m_cq_cons_index);
-				if (m_b_is_rx) {
-					++m_qp->m_hw_qp->rq.tail;
-				}
-			}
-			else {
-				break;
-			}
-		}
-
-		if (!ret) {
-			m_b_was_drained = true;
-			return ret_total;
-		}
-
-
-		m_n_wce_counter += ret;
-		if (ret < MCE_MAX_CQ_POLL_BATCH)
-			m_b_was_drained = true;
-
-		for (int i = 0; i < ret; i++) {
-			uint32_t wqe_sz = 0;
-			mlx5_cqe64 *cqe = cqe_arr[i];
-			vma_ibv_wc wce;
-
-			uint16_t wqe_ctr = ntohs(cqe->wqe_counter);
-			if (m_b_is_rx) {
-				wqe_sz = m_qp->m_rx_num_wr;
-			}
-			else {
-				wqe_sz = m_qp->m_tx_num_wr;
-			}
-
-			int index = wqe_ctr & (wqe_sz - 1);
-
-			/* We need to processes rx data in case
-			 * wce.status == IBV_WC_SUCCESS
-			 * and release buffers to rx pool
-			 * in case failure
-			 */
-			m_rx_hot_buffer = (mem_buf_desc_t*)(uintptr_t)m_qp->m_p_rq_wqe_idx_to_wrid[index];
-			memset(&wce, 0, sizeof(wce));
-			wce.wr_id = (uintptr_t)m_rx_hot_buffer;
-			cqe64_to_vma_wc(cqe, &wce);
-
-			m_rx_hot_buffer = cq_mgr::process_cq_element_rx(&wce);
-			if (m_rx_hot_buffer) {
-				if (p_recycle_buffers_last_wr_id) {
-					m_p_cq_stat->n_rx_pkt_drop++;
-					reclaim_recv_buffer_helper(m_rx_hot_buffer);
-				} else {
-					bool procces_now = false;
-					if (m_transport_type == VMA_TRANSPORT_ETH) {
-						procces_now = is_eth_tcp_frame(m_rx_hot_buffer);
-					}
-					if (m_transport_type == VMA_TRANSPORT_IB) {
-						procces_now = is_ib_tcp_frame(m_rx_hot_buffer);
-					}
-					// We process immediately all non udp/ip traffic..
-					if (procces_now) {
-						m_rx_hot_buffer->rx.is_vma_thr = true;
-						if ((++m_qp_rec.debth < (int)m_n_sysvar_rx_num_wr_to_post_recv) ||
-							!compensate_qp_poll_success(m_rx_hot_buffer)) {
-							process_recv_buffer(m_rx_hot_buffer, NULL);
-						}
-					}
-					else { //udp/ip traffic we just put in the cq's rx queue
-						m_rx_queue.push_back(m_rx_hot_buffer);
-						mem_buf_desc_t* buff_cur = m_rx_queue.get_and_pop_front();
-						if ((++m_qp_rec.debth < (int)m_n_sysvar_rx_num_wr_to_post_recv) ||
-							!compensate_qp_poll_success(buff_cur)) {
-							m_rx_queue.push_front(buff_cur);
-						}
-					}
-				}
-			}
-			if (p_recycle_buffers_last_wr_id) {
-				*p_recycle_buffers_last_wr_id = (uintptr_t)wce.wr_id;
-			}
-		}
-		ret_total += ret;
-	}
-	m_n_wce_counter = 0;
-	m_b_was_drained = false;
-
-	// Update cq statistics
-	m_p_cq_stat->n_rx_sw_queue_len = m_rx_queue.size();
-	m_p_cq_stat->n_rx_drained_at_once_max = max(ret_total, m_p_cq_stat->n_rx_drained_at_once_max);
-
-	return ret_total;
-#else
 	cq_logfuncall("cq was %sdrained. %d processed wce since last check. %d wce in m_rx_queue", (m_b_was_drained?"":"not "), m_n_wce_counter, m_rx_queue.size());
 
 	/* CQ polling loop until max wce limit is reached for this interval or CQ is drained */
@@ -368,62 +256,157 @@ int cq_mgr_mlx5::drain_and_proccess(uintptr_t* p_recycle_buffers_last_wr_id /*=N
 		m_b_was_drained = false;
 	}
 
-	while ((m_n_sysvar_progress_engine_wce_max > m_n_wce_counter) &&
-		!m_b_was_drained) {
-		buff_status_e status = BS_OK;
-		mem_buf_desc_t* buff = poll(status);
-		if (NULL == buff) {
-			update_global_sn(cq_poll_sn, ret_total);
-			m_b_was_drained = true;
-			m_p_ring->m_gro_mgr.flush_all(NULL);
-			return ret_total;
-		}
+	if (m_b_sysvar_enable_xtreme) {
+		while ((m_n_sysvar_progress_engine_wce_max && (m_n_sysvar_progress_engine_wce_max > m_n_wce_counter)) &&
+			!m_b_was_drained) {
+			int ret = 0;
+			mlx5_cqe64 *cqe_arr[MCE_MAX_CQ_POLL_BATCH];
 
-		++m_n_wce_counter;
-
-		if (process_cq_element_rx(buff, status)) {
-			if (p_recycle_buffers_last_wr_id) {
-				m_p_cq_stat->n_rx_pkt_drop++;
-				reclaim_recv_buffer_helper(buff);
-			} else {
-				bool procces_now = false;
-				if (m_transport_type == VMA_TRANSPORT_ETH) {
-					procces_now = is_eth_tcp_frame(buff);
-				}
-				if (m_transport_type == VMA_TRANSPORT_IB) {
-					procces_now = is_ib_tcp_frame(buff);
-				}
-				/* We process immediately all non udp/ip traffic.. */
-				if (procces_now) {
-					buff->rx.is_vma_thr = true;
-					if ((++m_qp_rec.debth < (int)m_n_sysvar_rx_num_wr_to_post_recv) ||
-							!compensate_qp_poll_success(buff)) {
-						process_recv_buffer(buff, NULL);
+			for (int i = 0; i < MCE_MAX_CQ_POLL_BATCH; ++i)
+			{
+				cqe_arr[i] = get_cqe64();
+				if (cqe_arr[i]) {
+					++ret;
+					wmb();
+					*m_cq_dbell = htonl(m_cq_cons_index);
+					if (m_b_is_rx) {
+						++m_qp->m_hw_qp->rq.tail;
 					}
 				}
-				else { /* udp/ip traffic we just put in the cq's rx queue */
-					m_rx_queue.push_back(buff);
-					mem_buf_desc_t* buff_cur = m_rx_queue.front();
-					m_rx_queue.pop_front();
-					if ((++m_qp_rec.debth < (int)m_n_sysvar_rx_num_wr_to_post_recv) ||
-							!compensate_qp_poll_success(buff_cur)) {
-						m_rx_queue.push_front(buff_cur);
+				else {
+					break;
+				}
+			}
+
+			if (!ret) {
+				m_b_was_drained = true;
+				return ret_total;
+			}
+
+
+			m_n_wce_counter += ret;
+			if (ret < MCE_MAX_CQ_POLL_BATCH)
+				m_b_was_drained = true;
+
+			for (int i = 0; i < ret; i++) {
+				uint32_t wqe_sz = 0;
+				mlx5_cqe64 *cqe = cqe_arr[i];
+				vma_ibv_wc wce;
+
+				uint16_t wqe_ctr = ntohs(cqe->wqe_counter);
+				if (m_b_is_rx) {
+					wqe_sz = m_qp->m_rx_num_wr;
+				}
+				else {
+					wqe_sz = m_qp->m_tx_num_wr;
+				}
+
+				int index = wqe_ctr & (wqe_sz - 1);
+
+				/* We need to processes rx data in case
+				 * wce.status == IBV_WC_SUCCESS
+				 * and release buffers to rx pool
+				 * in case failure
+				 */
+				m_rx_hot_buffer = (mem_buf_desc_t*)(uintptr_t)m_qp->m_p_rq_wqe_idx_to_wrid[index];
+				memset(&wce, 0, sizeof(wce));
+				wce.wr_id = (uintptr_t)m_rx_hot_buffer;
+				cqe64_to_vma_wc(cqe, &wce);
+
+				m_rx_hot_buffer = cq_mgr::process_cq_element_rx(&wce);
+				if (m_rx_hot_buffer) {
+					if (p_recycle_buffers_last_wr_id) {
+						m_p_cq_stat->n_rx_pkt_drop++;
+						reclaim_recv_buffer_helper(m_rx_hot_buffer);
+					} else {
+						bool procces_now = false;
+						if (m_transport_type == VMA_TRANSPORT_ETH) {
+							procces_now = is_eth_tcp_frame(m_rx_hot_buffer);
+						}
+						if (m_transport_type == VMA_TRANSPORT_IB) {
+							procces_now = is_ib_tcp_frame(m_rx_hot_buffer);
+						}
+						// We process immediately all non udp/ip traffic..
+						if (procces_now) {
+							m_rx_hot_buffer->rx.is_vma_thr = true;
+							if ((++m_qp_rec.debth < (int)m_n_sysvar_rx_num_wr_to_post_recv) ||
+								!compensate_qp_poll_success(m_rx_hot_buffer)) {
+								process_recv_buffer(m_rx_hot_buffer, NULL);
+							}
+						}
+						else { //udp/ip traffic we just put in the cq's rx queue
+							m_rx_queue.push_back(m_rx_hot_buffer);
+							mem_buf_desc_t* buff_cur = m_rx_queue.get_and_pop_front();
+							if ((++m_qp_rec.debth < (int)m_n_sysvar_rx_num_wr_to_post_recv) ||
+								!compensate_qp_poll_success(buff_cur)) {
+								m_rx_queue.push_front(buff_cur);
+							}
+						}
+					}
+				}
+				if (p_recycle_buffers_last_wr_id) {
+					*p_recycle_buffers_last_wr_id = (uintptr_t)wce.wr_id;
+				}
+			}
+			ret_total += ret;
+		}
+	} else {
+		while ((m_n_sysvar_progress_engine_wce_max > m_n_wce_counter) &&
+			!m_b_was_drained) {
+			buff_status_e status = BS_OK;
+			mem_buf_desc_t* buff = poll(status);
+			if (NULL == buff) {
+				update_global_sn(cq_poll_sn, ret_total);
+				m_b_was_drained = true;
+				m_p_ring->m_gro_mgr.flush_all(NULL);
+				return ret_total;
+			}
+
+			++m_n_wce_counter;
+
+			if (process_cq_element_rx(buff, status)) {
+				if (p_recycle_buffers_last_wr_id) {
+					m_p_cq_stat->n_rx_pkt_drop++;
+					reclaim_recv_buffer_helper(buff);
+				} else {
+					bool procces_now = false;
+					if (m_transport_type == VMA_TRANSPORT_ETH) {
+						procces_now = is_eth_tcp_frame(buff);
+					}
+					if (m_transport_type == VMA_TRANSPORT_IB) {
+						procces_now = is_ib_tcp_frame(buff);
+					}
+					/* We process immediately all non udp/ip traffic.. */
+					if (procces_now) {
+						buff->rx.is_vma_thr = true;
+						if ((++m_qp_rec.debth < (int)m_n_sysvar_rx_num_wr_to_post_recv) ||
+								!compensate_qp_poll_success(buff)) {
+							process_recv_buffer(buff, NULL);
+						}
+					}
+					else { /* udp/ip traffic we just put in the cq's rx queue */
+						m_rx_queue.push_back(buff);
+						mem_buf_desc_t* buff_cur = m_rx_queue.front();
+						m_rx_queue.pop_front();
+						if ((++m_qp_rec.debth < (int)m_n_sysvar_rx_num_wr_to_post_recv) ||
+								!compensate_qp_poll_success(buff_cur)) {
+							m_rx_queue.push_front(buff_cur);
+						}
 					}
 				}
 			}
+
+			if (p_recycle_buffers_last_wr_id) {
+				*p_recycle_buffers_last_wr_id = (uintptr_t)buff;
+			}
+
+			++ret_total;
 		}
 
-		if (p_recycle_buffers_last_wr_id) {
-			*p_recycle_buffers_last_wr_id = (uintptr_t)buff;
-		}
+		update_global_sn(cq_poll_sn, ret_total);
 
-		++ret_total;
+		m_p_ring->m_gro_mgr.flush_all(NULL);
 	}
-
-	update_global_sn(cq_poll_sn, ret_total);
-
-	m_p_ring->m_gro_mgr.flush_all(NULL);
-
 	m_n_wce_counter = 0;
 	m_b_was_drained = false;
 
@@ -432,7 +415,6 @@ int cq_mgr_mlx5::drain_and_proccess(uintptr_t* p_recycle_buffers_last_wr_id /*=N
 	m_p_cq_stat->n_rx_drained_at_once_max = max(ret_total, m_p_cq_stat->n_rx_drained_at_once_max);
 
 	return ret_total;
-#endif // DEFINED_VMAPOLL
 }
 
 inline void cq_mgr_mlx5::update_global_sn(uint64_t& cq_poll_sn, uint32_t num_polled_cqes)
@@ -498,55 +480,6 @@ int cq_mgr_mlx5::poll_and_process_element_rx(uint64_t* p_cq_poll_sn, void* pv_fd
 	/* Assume locked!!! */
 	cq_logfuncall("");
 
-#ifdef DEFINED_VMAPOLL
-	NOT_IN_USE(p_cq_poll_sn);
-
-	/* coverity[stack_use_local_overflow] */
-	uint32_t ret_rx_processed = process_recv_queue(pv_fd_ready_array);
-	if (unlikely(ret_rx_processed >= m_n_sysvar_cq_poll_batch_max)) {
-		m_p_ring->m_gro_mgr.flush_all(pv_fd_ready_array);
-		return ret_rx_processed;
-	}
-
-	if (m_p_next_rx_desc_poll) {
-		prefetch_range((uint8_t*)m_p_next_rx_desc_poll->p_buffer,safe_mce_sys().rx_prefetch_bytes_before_poll);
-	}
-
-	if (unlikely(m_rx_hot_buffer == NULL)) {
-		int index = m_qp->m_hw_qp->rq.tail & (m_qp->m_rx_num_wr - 1);
-		m_rx_hot_buffer = (mem_buf_desc_t*)(uintptr_t)m_qp->m_p_rq_wqe_idx_to_wrid[index];
-		m_rx_hot_buffer->rx.context = NULL;
-		m_rx_hot_buffer->rx.is_vma_thr = false;
-		m_rx_hot_buffer->rx.vma_polled = false;
-	}
-	else {
-		mlx5_cqe64 *cqe_err = NULL;
-		mlx5_cqe64 *cqe = get_cqe64(&cqe_err);
-
-		if (likely(cqe)) {
-			++m_n_wce_counter;
-			++m_qp->m_hw_qp->rq.tail;
-			m_rx_hot_buffer->sz_data = ntohl(cqe->byte_cnt);
-			m_rx_hot_buffer->rx.flow_tag_id = vma_get_flow_tag(cqe);
-
-			if (unlikely(++m_qp_rec.debth >= (int)m_n_sysvar_rx_num_wr_to_post_recv)) {
-				compensate_qp_poll_success(m_rx_hot_buffer);
-			}
-			process_recv_buffer(m_rx_hot_buffer, pv_fd_ready_array);
-			++ret_rx_processed;
-			m_rx_hot_buffer = NULL;
-		}
-		else if (cqe_err) {
-			ret_rx_processed += poll_and_process_error_element_rx(cqe_err, pv_fd_ready_array);
-		}
-		else {
-			compensate_qp_poll_failed();
-		}
-
-	}
-
-	return ret_rx_processed;
-#else
 	uint32_t ret_rx_processed = process_recv_queue(pv_fd_ready_array);
 	if (unlikely(ret_rx_processed >= m_n_sysvar_cq_poll_batch_max)) {
 		m_p_ring->m_gro_mgr.flush_all(pv_fd_ready_array);
@@ -557,36 +490,70 @@ int cq_mgr_mlx5::poll_and_process_element_rx(uint64_t* p_cq_poll_sn, void* pv_fd
 		prefetch_range((uint8_t*)m_p_next_rx_desc_poll->p_buffer, m_n_sysvar_rx_prefetch_bytes_before_poll);
 	}
 
-	buff_status_e status = BS_OK;
-	uint32_t ret = 0;
-	while (ret < m_n_sysvar_cq_poll_batch_max) {
-		mem_buf_desc_t *buff = poll(status);
-		if (buff) {
-			++ret;
-			if (process_cq_element_rx(buff, status)) {
-				if ((++m_qp_rec.debth < (int)m_n_sysvar_rx_num_wr_to_post_recv) ||
-						!compensate_qp_poll_success(buff)) {
-					process_recv_buffer(buff, pv_fd_ready_array);
+	if (m_b_sysvar_enable_xtreme) {
+		if (unlikely(m_rx_hot_buffer == NULL)) {
+			int index = m_qp->m_hw_qp->rq.tail & (m_qp->m_rx_num_wr - 1);
+			m_rx_hot_buffer = (mem_buf_desc_t*)(uintptr_t)m_qp->m_p_rq_wqe_idx_to_wrid[index];
+			m_rx_hot_buffer->rx.context = NULL;
+			m_rx_hot_buffer->rx.is_vma_thr = false;
+			m_rx_hot_buffer->rx.vma_polled = false;
+		}
+		else {
+			mlx5_cqe64 *cqe_err = NULL;
+			mlx5_cqe64 *cqe = get_cqe64(&cqe_err);
+
+			if (likely(cqe)) {
+				++m_n_wce_counter;
+				++m_qp->m_hw_qp->rq.tail;
+				m_rx_hot_buffer->sz_data = ntohl(cqe->byte_cnt);
+				m_rx_hot_buffer->rx.flow_tag_id = vma_get_flow_tag(cqe);
+
+				if (unlikely(++m_qp_rec.debth >= (int)m_n_sysvar_rx_num_wr_to_post_recv)) {
+					(void)compensate_qp_poll_success(m_rx_hot_buffer);
 				}
+				process_recv_buffer(m_rx_hot_buffer, pv_fd_ready_array);
+				++ret_rx_processed;
+				m_rx_hot_buffer = NULL;
 			}
+			else if (cqe_err) {
+				ret_rx_processed += poll_and_process_error_element_rx(cqe_err, pv_fd_ready_array);
+			}
+			else {
+				compensate_qp_poll_failed();
+			}
+
+		}
+	} else {
+		buff_status_e status = BS_OK;
+		uint32_t ret = 0;
+		while (ret < m_n_sysvar_cq_poll_batch_max) {
+			mem_buf_desc_t *buff = poll(status);
+			if (buff) {
+				++ret;
+				if (process_cq_element_rx(buff, status)) {
+					if ((++m_qp_rec.debth < (int)m_n_sysvar_rx_num_wr_to_post_recv) ||
+							!compensate_qp_poll_success(buff)) {
+						process_recv_buffer(buff, pv_fd_ready_array);
+					}
+				}
+			} else {
+				m_b_was_drained = true;
+				break;
+			}
+		}
+
+		update_global_sn(*p_cq_poll_sn, ret);
+
+		if (likely(ret > 0)) {
+			ret_rx_processed += ret;
+			m_n_wce_counter += ret;
+			m_p_ring->m_gro_mgr.flush_all(pv_fd_ready_array);
 		} else {
-			m_b_was_drained = true;
-			break;
+			compensate_qp_poll_failed();
 		}
 	}
 
-	update_global_sn(*p_cq_poll_sn, ret);
-
-	if (likely(ret > 0)) {
-		ret_rx_processed += ret;
-		m_n_wce_counter += ret;
-		m_p_ring->m_gro_mgr.flush_all(pv_fd_ready_array);
-	} else {
-		compensate_qp_poll_failed();
-	}
-
 	return ret_rx_processed;
-#endif // DEFINED_VMAPOLL
 }
 
 int cq_mgr_mlx5::poll_and_process_element_rx(mem_buf_desc_t **p_desc_lst)
@@ -621,7 +588,7 @@ int cq_mgr_mlx5::poll_and_process_element_rx(mem_buf_desc_t **p_desc_lst)
 		m_rx_hot_buffer->rx.flow_tag_id = vma_get_flow_tag(cqe);
 
 		if (unlikely(++m_qp_rec.debth >= (int)m_n_sysvar_rx_num_wr_to_post_recv)) {
-			compensate_qp_poll_success(m_rx_hot_buffer);
+			(void)compensate_qp_poll_success(m_rx_hot_buffer);
 		}
 		++packets_num;
 		*p_desc_lst = m_rx_hot_buffer;

--- a/src/vma/dev/cq_mgr_mlx5.cpp
+++ b/src/vma/dev/cq_mgr_mlx5.cpp
@@ -418,7 +418,8 @@ int cq_mgr_mlx5::drain_and_proccess(uintptr_t* p_recycle_buffers_last_wr_id /*=N
 				/* We process immediately all non udp/ip traffic.. */
 				if (procces_now) {
 					buff->rx.is_vma_thr = true;
-					if (!compensate_qp_poll_success(buff)) {
+					if ((++m_qp_rec.debth < (int)m_n_sysvar_rx_num_wr_to_post_recv) ||
+							!compensate_qp_poll_success(buff)) {
 						process_recv_buffer(buff, NULL);
 					}
 				}
@@ -426,7 +427,8 @@ int cq_mgr_mlx5::drain_and_proccess(uintptr_t* p_recycle_buffers_last_wr_id /*=N
 					m_rx_queue.push_back(buff);
 					mem_buf_desc_t* buff_cur = m_rx_queue.front();
 					m_rx_queue.pop_front();
-					if (!compensate_qp_poll_success(buff_cur)) {
+					if ((++m_qp_rec.debth < (int)m_n_sysvar_rx_num_wr_to_post_recv) ||
+							!compensate_qp_poll_success(buff_cur)) {
 						m_rx_queue.push_front(buff_cur);
 					}
 				}
@@ -588,7 +590,8 @@ int cq_mgr_mlx5::poll_and_process_element_rx(uint64_t* p_cq_poll_sn, void* pv_fd
 		if (buff) {
 			++ret;
 			if (process_cq_element_rx(buff, status)) {
-				if (!compensate_qp_poll_success(buff)) {
+				if ((++m_qp_rec.debth < (int)m_n_sysvar_rx_num_wr_to_post_recv) ||
+						!compensate_qp_poll_success(buff)) {
 					process_recv_buffer(buff, pv_fd_ready_array);
 				}
 			}

--- a/src/vma/dev/cq_mgr_mlx5.cpp
+++ b/src/vma/dev/cq_mgr_mlx5.cpp
@@ -256,6 +256,7 @@ int cq_mgr_mlx5::drain_and_proccess(uintptr_t* p_recycle_buffers_last_wr_id /*=N
 		m_b_was_drained = false;
 	}
 
+#ifdef DEFINED_VMAPOLL
 	if (m_b_sysvar_enable_xtreme) {
 		while ((m_n_sysvar_progress_engine_wce_max && (m_n_sysvar_progress_engine_wce_max > m_n_wce_counter)) &&
 			!m_b_was_drained) {
@@ -350,7 +351,9 @@ int cq_mgr_mlx5::drain_and_proccess(uintptr_t* p_recycle_buffers_last_wr_id /*=N
 			}
 			ret_total += ret;
 		}
-	} else {
+	} else
+#endif /* DEFINED_VMAPOLL */
+	{
 		while ((m_n_sysvar_progress_engine_wce_max > m_n_wce_counter) &&
 			!m_b_was_drained) {
 			buff_status_e status = BS_OK;
@@ -490,6 +493,7 @@ int cq_mgr_mlx5::poll_and_process_element_rx(uint64_t* p_cq_poll_sn, void* pv_fd
 		prefetch_range((uint8_t*)m_p_next_rx_desc_poll->p_buffer, m_n_sysvar_rx_prefetch_bytes_before_poll);
 	}
 
+#ifdef DEFINED_VMAPOLL
 	if (m_b_sysvar_enable_xtreme) {
 		if (unlikely(m_rx_hot_buffer == NULL)) {
 			int index = m_qp->m_hw_qp->rq.tail & (m_qp->m_rx_num_wr - 1);
@@ -523,7 +527,9 @@ int cq_mgr_mlx5::poll_and_process_element_rx(uint64_t* p_cq_poll_sn, void* pv_fd
 			}
 
 		}
-	} else {
+	} else
+#endif /* DEFINED_VMAPOLL */
+	{
 		buff_status_e status = BS_OK;
 		uint32_t ret = 0;
 		while (ret < m_n_sysvar_cq_poll_batch_max) {

--- a/src/vma/dev/cq_mgr_mlx5.cpp
+++ b/src/vma/dev/cq_mgr_mlx5.cpp
@@ -478,11 +478,7 @@ mem_buf_desc_t* cq_mgr_mlx5::process_cq_element_rx(mem_buf_desc_t* p_mem_buf_des
 
 	/* we use context to verify that on reclaim rx buffer path we return the buffer to the right CQ */
 	p_mem_buf_desc->rx.is_vma_thr = false;
-#ifdef DEFINED_VMAPOLL
 	p_mem_buf_desc->rx.context = NULL;
-#else
-	p_mem_buf_desc->rx.context = this;
-#endif // DEFINED_VMAPOLL
 	p_mem_buf_desc->rx.vma_polled = false;
 
 	if (unlikely((status != BS_OK) ||

--- a/src/vma/dev/cq_mgr_mlx5.cpp
+++ b/src/vma/dev/cq_mgr_mlx5.cpp
@@ -61,13 +61,6 @@ cq_mgr_mlx5::cq_mgr_mlx5(ring_simple* p_ring, ib_ctx_handler* p_ib_ctx_handler,
 	,m_rq(NULL)
 	,m_cqe_log_sz(0)
 	,m_n_sysvar_rx_num_wr_to_post_recv(safe_mce_sys().rx_num_wr_to_post_recv)
-#ifdef DEFINED_VMAPOLL
-	,m_rx_hot_buff(NULL)
-	,m_cq_sz(cq_size)
-	,m_cq_ci(0)
-	,m_mlx5_cqes(NULL)
-	,m_cq_db(0)
-#endif
 	,m_rx_hot_buffer(NULL)
 	,m_qp(NULL)
 	,m_mlx5_cq(NULL)
@@ -281,7 +274,7 @@ int cq_mgr_mlx5::drain_and_proccess(uintptr_t* p_recycle_buffers_last_wr_id /*=N
 	while ((m_n_sysvar_progress_engine_wce_max && (m_n_sysvar_progress_engine_wce_max > m_n_wce_counter)) &&
 		!m_b_was_drained) {
 		int ret = 0;
-		volatile mlx5_cqe64 *cqe_arr[MCE_MAX_CQ_POLL_BATCH];
+		mlx5_cqe64 *cqe_arr[MCE_MAX_CQ_POLL_BATCH];
 
 		for (int i = 0; i < MCE_MAX_CQ_POLL_BATCH; ++i)
 		{
@@ -289,9 +282,9 @@ int cq_mgr_mlx5::drain_and_proccess(uintptr_t* p_recycle_buffers_last_wr_id /*=N
 			if (cqe_arr[i]) {
 				++ret;
 				wmb();
-				*m_cq_db = htonl(m_cq_ci);
+				*m_cq_dbell = htonl(m_cq_cons_index);
 				if (m_b_is_rx) {
-					++m_qp->m_mlx5_hw_qp->rq.tail;
+					++m_qp->m_hw_qp->rq.tail;
 				}
 			}
 			else {
@@ -311,7 +304,7 @@ int cq_mgr_mlx5::drain_and_proccess(uintptr_t* p_recycle_buffers_last_wr_id /*=N
 
 		for (int i = 0; i < ret; i++) {
 			uint32_t wqe_sz = 0;
-			volatile mlx5_cqe64 *cqe = cqe_arr[i];
+			mlx5_cqe64 *cqe = cqe_arr[i];
 			vma_ibv_wc wce;
 
 			uint16_t wqe_ctr = ntohs(cqe->wqe_counter);
@@ -329,34 +322,34 @@ int cq_mgr_mlx5::drain_and_proccess(uintptr_t* p_recycle_buffers_last_wr_id /*=N
 			 * and release buffers to rx pool
 			 * in case failure
 			 */
-			m_rx_hot_buff = (mem_buf_desc_t*)(uintptr_t)m_qp->m_p_rq_wqe_idx_to_wrid[index];
+			m_rx_hot_buffer = (mem_buf_desc_t*)(uintptr_t)m_qp->m_p_rq_wqe_idx_to_wrid[index];
 			memset(&wce, 0, sizeof(wce));
-			wce.wr_id = (uintptr_t)m_rx_hot_buff;
+			wce.wr_id = (uintptr_t)m_rx_hot_buffer;
 			mlx5_cqe64_to_vma_wc(cqe, &wce);
 
-			m_rx_hot_buff = cq_mgr::process_cq_element_rx(&wce);
-			if (m_rx_hot_buff) {
+			m_rx_hot_buffer = cq_mgr::process_cq_element_rx(&wce);
+			if (m_rx_hot_buffer) {
 				if (p_recycle_buffers_last_wr_id) {
 					m_p_cq_stat->n_rx_pkt_drop++;
-					reclaim_recv_buffer_helper(m_rx_hot_buff);
+					reclaim_recv_buffer_helper(m_rx_hot_buffer);
 				} else {
 					bool procces_now = false;
 					if (m_transport_type == VMA_TRANSPORT_ETH) {
-						procces_now = is_eth_tcp_frame(m_rx_hot_buff);
+						procces_now = is_eth_tcp_frame(m_rx_hot_buffer);
 					}
 					if (m_transport_type == VMA_TRANSPORT_IB) {
-						procces_now = is_ib_tcp_frame(m_rx_hot_buff);
+						procces_now = is_ib_tcp_frame(m_rx_hot_buffer);
 					}
 					// We process immediately all non udp/ip traffic..
 					if (procces_now) {
-						m_rx_hot_buff->rx.is_vma_thr = true;
+						m_rx_hot_buffer->rx.is_vma_thr = true;
 						if ((++m_qp_rec.debth < (int)m_n_sysvar_rx_num_wr_to_post_recv) ||
-							!compensate_qp_poll_success(m_rx_hot_buff)) {
-							process_recv_buffer(m_rx_hot_buff, NULL);
+							!compensate_qp_poll_success(m_rx_hot_buffer)) {
+							process_recv_buffer(m_rx_hot_buffer, NULL);
 						}
 					}
 					else { //udp/ip traffic we just put in the cq's rx queue
-						m_rx_queue.push_back(m_rx_hot_buff);
+						m_rx_queue.push_back(m_rx_hot_buffer);
 						mem_buf_desc_t* buff_cur = m_rx_queue.get_and_pop_front();
 						if ((++m_qp_rec.debth < (int)m_n_sysvar_rx_num_wr_to_post_recv) ||
 							!compensate_qp_poll_success(buff_cur)) {
@@ -538,29 +531,29 @@ int cq_mgr_mlx5::poll_and_process_element_rx(uint64_t* p_cq_poll_sn, void* pv_fd
 		prefetch_range((uint8_t*)m_p_next_rx_desc_poll->p_buffer,safe_mce_sys().rx_prefetch_bytes_before_poll);
 	}
 
-	if (unlikely(m_rx_hot_buff == NULL)) {
-		int index = m_qp->m_mlx5_hw_qp->rq.tail & (m_qp->m_rx_num_wr - 1);
-		m_rx_hot_buff = (mem_buf_desc_t*)(uintptr_t)m_qp->m_p_rq_wqe_idx_to_wrid[index];
-		m_rx_hot_buff->rx.context = NULL;
-		m_rx_hot_buff->rx.is_vma_thr = false;
-		m_rx_hot_buff->rx.vma_polled = false;
+	if (unlikely(m_rx_hot_buffer == NULL)) {
+		int index = m_qp->m_hw_qp->rq.tail & (m_qp->m_rx_num_wr - 1);
+		m_rx_hot_buffer = (mem_buf_desc_t*)(uintptr_t)m_qp->m_p_rq_wqe_idx_to_wrid[index];
+		m_rx_hot_buffer->rx.context = NULL;
+		m_rx_hot_buffer->rx.is_vma_thr = false;
+		m_rx_hot_buffer->rx.vma_polled = false;
 	}
 	else {
-		volatile mlx5_cqe64 *cqe_err = NULL;
-		volatile mlx5_cqe64 *cqe = mlx5_get_cqe64(&cqe_err);
+		mlx5_cqe64 *cqe_err = NULL;
+		mlx5_cqe64 *cqe = get_cqe64(&cqe_err);
 
 		if (likely(cqe)) {
 			++m_n_wce_counter;
-			++m_qp->m_mlx5_hw_qp->rq.tail;
-			m_rx_hot_buff->sz_data = ntohl(cqe->byte_cnt);
-			m_rx_hot_buff->rx.flow_tag_id = vma_get_flow_tag(cqe);
+			++m_qp->m_hw_qp->rq.tail;
+			m_rx_hot_buffer->sz_data = ntohl(cqe->byte_cnt);
+			m_rx_hot_buffer->rx.flow_tag_id = vma_get_flow_tag(cqe);
 
 			if (unlikely(++m_qp_rec.debth >= (int)m_n_sysvar_rx_num_wr_to_post_recv)) {
-				compensate_qp_poll_success(m_rx_hot_buff);
+				compensate_qp_poll_success(m_rx_hot_buffer);
 			}
-			process_recv_buffer(m_rx_hot_buff, pv_fd_ready_array);
+			process_recv_buffer(m_rx_hot_buffer, pv_fd_ready_array);
 			++ret_rx_processed;
-			m_rx_hot_buff = NULL;
+			m_rx_hot_buffer = NULL;
 		}
 		else if (cqe_err) {
 			ret_rx_processed += mlx5_poll_and_process_error_element_rx(cqe_err, pv_fd_ready_array);
@@ -620,13 +613,13 @@ int cq_mgr_mlx5::poll_and_process_element_rx(mem_buf_desc_t **p_desc_lst)
 {
 	int packets_num = 0;
 
-	if (unlikely(m_rx_hot_buff == NULL)) {
-		int index = m_qp->m_mlx5_hw_qp->rq.tail & (m_qp->m_rx_num_wr - 1);
-		m_rx_hot_buff = (mem_buf_desc_t*)(uintptr_t)m_qp->m_p_rq_wqe_idx_to_wrid[index];
-		m_rx_hot_buff->rx.context = NULL;
-		m_rx_hot_buff->rx.is_vma_thr = false;
+	if (unlikely(m_rx_hot_buffer == NULL)) {
+		int index = m_qp->m_hw_qp->rq.tail & (m_qp->m_rx_num_wr - 1);
+		m_rx_hot_buffer = (mem_buf_desc_t*)(uintptr_t)m_qp->m_p_rq_wqe_idx_to_wrid[index];
+		m_rx_hot_buffer->rx.context = NULL;
+		m_rx_hot_buffer->rx.is_vma_thr = false;
 	}
-	//prefetch_range((uint8_t*)m_rx_hot_buff->p_buffer,safe_mce_sys().rx_prefetch_bytes_before_poll);
+	//prefetch_range((uint8_t*)m_rx_hot_buffer->p_buffer,safe_mce_sys().rx_prefetch_bytes_before_poll);
 #ifdef RDTSC_MEASURE_RX_VERBS_READY_POLL
 	RDTSC_TAKE_START(g_rdtsc_instr_info_arr[RDTSC_FLOW_RX_VERBS_READY_POLL]);
 #endif //RDTSC_MEASURE_RX_VERBS_READY_POLL
@@ -638,21 +631,21 @@ int cq_mgr_mlx5::poll_and_process_element_rx(mem_buf_desc_t **p_desc_lst)
 #ifdef RDTSC_MEASURE_RX_VMA_TCP_IDLE_POLL
 	RDTSC_TAKE_END(g_rdtsc_instr_info_arr[RDTSC_FLOW_RX_VMA_TCP_IDLE_POLL]);
 #endif //RDTSC_MEASURE_RX_VMA_TCP_IDLE_POLL
-	volatile mlx5_cqe64 *cqe_err = NULL;
-	volatile mlx5_cqe64 *cqe = mlx5_get_cqe64(&cqe_err);
+	mlx5_cqe64 *cqe_err = NULL;
+	mlx5_cqe64 *cqe = get_cqe64(&cqe_err);
 
 	if (likely(cqe)) {
 		++m_n_wce_counter;
-		++m_qp->m_mlx5_hw_qp->rq.tail;
-		m_rx_hot_buff->sz_data = ntohl(cqe->byte_cnt);
-		m_rx_hot_buff->rx.flow_tag_id = vma_get_flow_tag(cqe);
+		++m_qp->m_hw_qp->rq.tail;
+		m_rx_hot_buffer->sz_data = ntohl(cqe->byte_cnt);
+		m_rx_hot_buffer->rx.flow_tag_id = vma_get_flow_tag(cqe);
 
 		if (unlikely(++m_qp_rec.debth >= (int)m_n_sysvar_rx_num_wr_to_post_recv)) {
-			compensate_qp_poll_success(m_rx_hot_buff);
+			compensate_qp_poll_success(m_rx_hot_buffer);
 		}
 		++packets_num;
-		*p_desc_lst = m_rx_hot_buff;
-		m_rx_hot_buff = NULL;
+		*p_desc_lst = m_rx_hot_buffer;
+		m_rx_hot_buffer = NULL;
 	}
 	else if (cqe_err) {
 		/* Return nothing in case error wc
@@ -838,11 +831,6 @@ void cq_mgr_mlx5::set_qp_rq(qp_mgr* qp)
 	m_cq_dbell = m_mlx5_cq->dbrec;
 	m_cqe_log_sz = ilog_2(m_mlx5_cq->cqe_sz);
 	m_cqes = ((uint8_t*)m_mlx5_cq->active_buf->buf) + m_mlx5_cq->cqe_sz - sizeof(struct mlx5_cqe64);
-
-#ifdef DEFINED_VMAPOLL
-	m_cq_db = m_mlx5_cq->dbrec;
-	m_mlx5_cqes = (volatile struct mlx5_cqe64 (*)[])(uintptr_t)m_mlx5_cq->active_buf->buf;
-#endif
 }
 
 void cq_mgr_mlx5::add_qp_rx(qp_mgr* qp)
@@ -889,32 +877,32 @@ void cq_mgr_mlx5::add_qp_tx(qp_mgr* qp)
 }
 
 #ifdef DEFINED_VMAPOLL
-int cq_mgr_mlx5::mlx5_poll_and_process_error_element_rx(volatile struct mlx5_cqe64 *cqe, void* pv_fd_ready_array)
+int cq_mgr_mlx5::mlx5_poll_and_process_error_element_rx(struct mlx5_cqe64 *cqe, void* pv_fd_ready_array)
 {
 	vma_ibv_wc wce;
 
 	memset(&wce, 0, sizeof(wce));
-	wce.wr_id = (uintptr_t)m_rx_hot_buff;
+	wce.wr_id = (uintptr_t)m_rx_hot_buffer;
 	mlx5_cqe64_to_vma_wc(cqe, &wce);
 
 	++m_n_wce_counter;
-	++m_qp->m_mlx5_hw_qp->rq.tail;
+	++m_qp->m_hw_qp->rq.tail;
 
-	m_rx_hot_buff = cq_mgr::process_cq_element_rx(&wce);
-	if (m_rx_hot_buff) {
+	m_rx_hot_buffer = cq_mgr::process_cq_element_rx(&wce);
+	if (m_rx_hot_buffer) {
 		if (vma_wc_opcode(wce) & VMA_IBV_WC_RECV) {
 			if ((++m_qp_rec.debth < (int)m_n_sysvar_rx_num_wr_to_post_recv) ||
-				!compensate_qp_poll_success(m_rx_hot_buff)) {
-					process_recv_buffer(m_rx_hot_buff, pv_fd_ready_array);
+				!compensate_qp_poll_success(m_rx_hot_buffer)) {
+					process_recv_buffer(m_rx_hot_buffer, pv_fd_ready_array);
 			}
 		}
 	}
-	m_rx_hot_buff = NULL;
+	m_rx_hot_buffer = NULL;
 
 	return 1;
 }
 
-inline void cq_mgr_mlx5::mlx5_cqe64_to_vma_wc(volatile struct mlx5_cqe64 *cqe, vma_ibv_wc *wc)
+inline void cq_mgr_mlx5::mlx5_cqe64_to_vma_wc(struct mlx5_cqe64 *cqe, vma_ibv_wc *wc)
 {
 	struct mlx5_err_cqe *ecqe;
 	ecqe = (struct mlx5_err_cqe *)cqe;
@@ -947,7 +935,7 @@ inline void cq_mgr_mlx5::mlx5_cqe64_to_vma_wc(volatile struct mlx5_cqe64 *cqe, v
 	wc->vendor_err = ecqe->vendor_err_synd;
 }
 
-volatile struct mlx5_cqe64 *cq_mgr_mlx5::mlx5_check_error_completion(volatile struct mlx5_cqe64 *cqe, volatile uint16_t *ci, uint8_t op_own)
+struct mlx5_cqe64 *cq_mgr_mlx5::mlx5_check_error_completion(struct mlx5_cqe64 *cqe, uint32_t *ci, uint8_t op_own)
 {
 	switch (op_own >> 4) {
 		case MLX5_CQE_INVALID:
@@ -956,57 +944,49 @@ volatile struct mlx5_cqe64 *cq_mgr_mlx5::mlx5_check_error_completion(volatile st
 		case MLX5_CQE_RESP_ERR:
 			++(*ci);
 			rmb();
-			*m_cq_db = htonl(m_cq_ci);
+			*m_cq_dbell = htonl(m_cq_cons_index);
 			return cqe;
 		default:
 			return NULL;
 	}
 }
 
-inline volatile struct mlx5_cqe64 *cq_mgr_mlx5::mlx5_get_cqe64(void)
+inline struct mlx5_cqe64 *cq_mgr_mlx5::mlx5_get_cqe64(void)
 {
-	volatile struct mlx5_cqe64 *cqe;
-	volatile struct mlx5_cqe64 *cqes;
-	uint8_t op_own;
+	struct mlx5_cqe64 *cqe = (struct mlx5_cqe64 *)(((uint8_t*)m_cqes) +
+			((m_cq_cons_index & (m_cq_size - 1)) << m_cqe_log_sz));
+	uint8_t op_own = cqe->op_own;
 
-	cqes = *m_mlx5_cqes;
-	cqe = &cqes[m_cq_ci & (m_cq_sz - 1)];
-	op_own = cqe->op_own;
-
-	if (unlikely((op_own & MLX5_CQE_OWNER_MASK) == !(m_cq_ci & m_cq_sz))) {
+	if (unlikely((op_own & MLX5_CQE_OWNER_MASK) == !(m_cq_cons_index & m_cq_size))) {
 		return NULL;
 	} else if (unlikely((op_own >> 4) == MLX5_CQE_INVALID)) {
 		return NULL;
 	}
 
-	++m_cq_ci;
+	++m_cq_cons_index;
 	rmb();
-	*m_cq_db = htonl(m_cq_ci);
+	*m_cq_dbell = htonl(m_cq_cons_index);
 
 	return cqe;
 }
 
-inline volatile struct mlx5_cqe64 *cq_mgr_mlx5::mlx5_get_cqe64(volatile struct mlx5_cqe64 **cqe_err)
+inline struct mlx5_cqe64 *cq_mgr_mlx5::mlx5_get_cqe64(struct mlx5_cqe64 **cqe_err)
 {
-	volatile struct mlx5_cqe64 *cqe;
-	volatile struct mlx5_cqe64 *cqes;
-	uint8_t op_own;
-
-	cqes = *m_mlx5_cqes;
-	cqe = &cqes[m_cq_ci & (m_cq_sz - 1)];
-	op_own = cqe->op_own;
+	struct mlx5_cqe64 *cqe = (struct mlx5_cqe64 *)(((uint8_t*)m_cqes) +
+			((m_cq_cons_index & (m_cq_size - 1)) << m_cqe_log_sz));
+	uint8_t op_own = cqe->op_own;
 
 	*cqe_err = NULL;
-	if (unlikely((op_own & MLX5_CQE_OWNER_MASK) == !(m_cq_ci & m_cq_sz))) {
+	if (unlikely((op_own & MLX5_CQE_OWNER_MASK) == !(m_cq_cons_index & m_cq_size))) {
 		return NULL;
 	} else if (unlikely(op_own & 0x80)) {
-		*cqe_err = mlx5_check_error_completion(cqe, &m_cq_ci, op_own);
+		*cqe_err = mlx5_check_error_completion(cqe, &m_cq_cons_index, op_own);
 		return NULL;
 	}
 
-	++m_cq_ci;
+	++m_cq_cons_index;
 	rmb();
-	*m_cq_db = htonl(m_cq_ci);
+	*m_cq_dbell = htonl(m_cq_cons_index);
 
 	return cqe;
 }

--- a/src/vma/dev/cq_mgr_mlx5.h
+++ b/src/vma/dev/cq_mgr_mlx5.h
@@ -61,6 +61,9 @@ public:
 	inline void                 cqe64_to_mem_buff_desc(struct mlx5_cqe64 *cqe, mem_buf_desc_t* p_rx_wc_buf_desc, enum buff_status_e& status);
 	virtual int                 drain_and_proccess(uintptr_t* p_recycle_buffers_last_wr_id = NULL);
 	virtual int                 poll_and_process_element_rx(uint64_t* p_cq_poll_sn, void* pv_fd_ready_array = NULL);
+#ifdef DEFINED_VMAPOLL
+	virtual int                 poll_and_process_element_rx(mem_buf_desc_t **p_desc_lst);
+#endif // DEFINED_VMAPOLL
 	virtual int                 poll_and_process_element_tx(uint64_t* p_cq_poll_sn);
 	int                         poll_and_process_error_element_tx(struct mlx5_cqe64 *cqe, uint64_t* p_cq_poll_sn);
 
@@ -73,6 +76,14 @@ public:
 	virtual int                 request_notification(uint64_t poll_sn);
 	virtual int                 wait_for_notification_and_process_element(uint64_t* p_cq_poll_sn, void* pv_fd_ready_array = NULL);
 
+#ifdef DEFINED_VMAPOLL
+	inline volatile struct mlx5_cqe64 *mlx5_get_cqe64(void);
+	inline volatile struct mlx5_cqe64 *mlx5_get_cqe64(volatile struct mlx5_cqe64 **cqe_err);
+	volatile struct mlx5_cqe64 *mlx5_check_error_completion(volatile struct mlx5_cqe64 *cqe, volatile uint16_t *ci, uint8_t op_own);
+	inline void mlx5_cqe64_to_vma_wc(volatile struct mlx5_cqe64 *cqe, vma_ibv_wc *wce);
+	int mlx5_poll_and_process_error_element_rx(volatile struct mlx5_cqe64 *cqe, void* pv_fd_ready_array);
+#endif // DEFINED_VMAPOLL
+
 protected:
 	inline struct mlx5_cqe64*   check_cqe(void);
 
@@ -84,8 +95,18 @@ protected:
 	int                         m_cqe_log_sz;
 
 private:
+	const uint32_t		m_n_sysvar_rx_num_wr_to_post_recv;
+
+#ifdef DEFINED_VMAPOLL
+	mem_buf_desc_t* 	m_rx_hot_buff;
+	int 			m_cq_sz;
+	uint16_t		m_cq_ci;
+	volatile struct		mlx5_cqe64 	(*m_mlx5_cqes)[];
+	volatile uint32_t 	*m_cq_db;
+#endif // DEFINED_VMAPOLL
+
 	mem_buf_desc_t              *m_rx_hot_buffer;
-	qp_mgr_eth_mlx5*            m_qp; //for tx
+	qp_mgr_eth_mlx5*            m_qp;
 	struct mlx5_cq*             m_mlx5_cq;
 
 	void                        cqe64_to_vma_wc(struct mlx5_cqe64 *cqe, vma_ibv_wc *wc);

--- a/src/vma/dev/cq_mgr_mlx5.h
+++ b/src/vma/dev/cq_mgr_mlx5.h
@@ -57,8 +57,6 @@ public:
 	virtual ~cq_mgr_mlx5();
 
 	virtual mem_buf_desc_t*     poll(enum buff_status_e& status);
-	inline struct mlx5_cqe64*   get_cqe64(struct mlx5_cqe64 **cqe_err);
-	inline void                 cqe64_to_mem_buff_desc(struct mlx5_cqe64 *cqe, mem_buf_desc_t* p_rx_wc_buf_desc, enum buff_status_e& status);
 	virtual int                 drain_and_proccess(uintptr_t* p_recycle_buffers_last_wr_id = NULL);
 	virtual int                 poll_and_process_element_rx(uint64_t* p_cq_poll_sn, void* pv_fd_ready_array = NULL);
 #ifdef DEFINED_VMAPOLL
@@ -77,11 +75,11 @@ public:
 	virtual int                 wait_for_notification_and_process_element(uint64_t* p_cq_poll_sn, void* pv_fd_ready_array = NULL);
 
 #ifdef DEFINED_VMAPOLL
-	inline volatile struct mlx5_cqe64 *mlx5_get_cqe64(void);
-	inline volatile struct mlx5_cqe64 *mlx5_get_cqe64(volatile struct mlx5_cqe64 **cqe_err);
-	volatile struct mlx5_cqe64 *mlx5_check_error_completion(volatile struct mlx5_cqe64 *cqe, volatile uint16_t *ci, uint8_t op_own);
-	inline void mlx5_cqe64_to_vma_wc(volatile struct mlx5_cqe64 *cqe, vma_ibv_wc *wce);
-	int mlx5_poll_and_process_error_element_rx(volatile struct mlx5_cqe64 *cqe, void* pv_fd_ready_array);
+	inline struct mlx5_cqe64 *mlx5_get_cqe64(void);
+	inline struct mlx5_cqe64 *mlx5_get_cqe64(struct mlx5_cqe64 **cqe_err);
+	struct mlx5_cqe64 *mlx5_check_error_completion(struct mlx5_cqe64 *cqe, uint32_t *ci, uint8_t op_own);
+	inline void mlx5_cqe64_to_vma_wc(struct mlx5_cqe64 *cqe, vma_ibv_wc *wce);
+	int mlx5_poll_and_process_error_element_rx(struct mlx5_cqe64 *cqe, void* pv_fd_ready_array);
 #endif // DEFINED_VMAPOLL
 
 protected:
@@ -97,18 +95,12 @@ protected:
 private:
 	const uint32_t		m_n_sysvar_rx_num_wr_to_post_recv;
 
-#ifdef DEFINED_VMAPOLL
-	mem_buf_desc_t* 	m_rx_hot_buff;
-	int 			m_cq_sz;
-	uint16_t		m_cq_ci;
-	volatile struct		mlx5_cqe64 	(*m_mlx5_cqes)[];
-	volatile uint32_t 	*m_cq_db;
-#endif // DEFINED_VMAPOLL
-
 	mem_buf_desc_t              *m_rx_hot_buffer;
 	qp_mgr_eth_mlx5*            m_qp;
 	struct mlx5_cq*             m_mlx5_cq;
 
+	inline struct mlx5_cqe64*   get_cqe64(struct mlx5_cqe64 **cqe_err = NULL);
+	inline void                 cqe64_to_mem_buff_desc(struct mlx5_cqe64 *cqe, mem_buf_desc_t* p_rx_wc_buf_desc, enum buff_status_e& status);
 	void                        cqe64_to_vma_wc(struct mlx5_cqe64 *cqe, vma_ibv_wc *wc);
 	inline struct mlx5_cqe64*   check_error_completion(struct mlx5_cqe64 *cqe, uint32_t *ci, uint8_t op_own);
 	inline void                 update_consumer_index();

--- a/src/vma/dev/cq_mgr_mlx5.h
+++ b/src/vma/dev/cq_mgr_mlx5.h
@@ -84,7 +84,8 @@ protected:
 	int                         m_cqe_log_sz;
 
 private:
-	const uint32_t		m_n_sysvar_rx_num_wr_to_post_recv;
+	const uint32_t              m_n_sysvar_rx_num_wr_to_post_recv;
+	const bool                  m_b_sysvar_enable_xtreme;
 
 	mem_buf_desc_t              *m_rx_hot_buffer;
 	qp_mgr_eth_mlx5*            m_qp;

--- a/src/vma/dev/cq_mgr_mlx5.h
+++ b/src/vma/dev/cq_mgr_mlx5.h
@@ -59,11 +59,10 @@ public:
 	virtual mem_buf_desc_t*     poll(enum buff_status_e& status);
 	virtual int                 drain_and_proccess(uintptr_t* p_recycle_buffers_last_wr_id = NULL);
 	virtual int                 poll_and_process_element_rx(uint64_t* p_cq_poll_sn, void* pv_fd_ready_array = NULL);
-#ifdef DEFINED_VMAPOLL
 	virtual int                 poll_and_process_element_rx(mem_buf_desc_t **p_desc_lst);
-#endif // DEFINED_VMAPOLL
 	virtual int                 poll_and_process_element_tx(uint64_t* p_cq_poll_sn);
 	int                         poll_and_process_error_element_tx(struct mlx5_cqe64 *cqe, uint64_t* p_cq_poll_sn);
+	int                         poll_and_process_error_element_rx(struct mlx5_cqe64 *cqe, void* pv_fd_ready_array);
 
 	virtual mem_buf_desc_t*     process_cq_element_rx(mem_buf_desc_t* p_mem_buf_desc, enum buff_status_e status);
 	virtual void                add_qp_rx(qp_mgr* qp);
@@ -73,14 +72,6 @@ public:
 	virtual uint32_t            clean_cq();
 	virtual int                 request_notification(uint64_t poll_sn);
 	virtual int                 wait_for_notification_and_process_element(uint64_t* p_cq_poll_sn, void* pv_fd_ready_array = NULL);
-
-#ifdef DEFINED_VMAPOLL
-	inline struct mlx5_cqe64 *mlx5_get_cqe64(void);
-	inline struct mlx5_cqe64 *mlx5_get_cqe64(struct mlx5_cqe64 **cqe_err);
-	struct mlx5_cqe64 *mlx5_check_error_completion(struct mlx5_cqe64 *cqe, uint32_t *ci, uint8_t op_own);
-	inline void mlx5_cqe64_to_vma_wc(struct mlx5_cqe64 *cqe, vma_ibv_wc *wce);
-	int mlx5_poll_and_process_error_element_rx(struct mlx5_cqe64 *cqe, void* pv_fd_ready_array);
-#endif // DEFINED_VMAPOLL
 
 protected:
 	inline struct mlx5_cqe64*   check_cqe(void);
@@ -99,7 +90,8 @@ private:
 	qp_mgr_eth_mlx5*            m_qp;
 	struct mlx5_cq*             m_mlx5_cq;
 
-	inline struct mlx5_cqe64*   get_cqe64(struct mlx5_cqe64 **cqe_err = NULL);
+	inline struct mlx5_cqe64 *mlx5_get_cqe64(void);
+	inline struct mlx5_cqe64*   get_cqe64(struct mlx5_cqe64 **cqe_err);
 	inline void                 cqe64_to_mem_buff_desc(struct mlx5_cqe64 *cqe, mem_buf_desc_t* p_rx_wc_buf_desc, enum buff_status_e& status);
 	void                        cqe64_to_vma_wc(struct mlx5_cqe64 *cqe, vma_ibv_wc *wc);
 	inline struct mlx5_cqe64*   check_error_completion(struct mlx5_cqe64 *cqe, uint32_t *ci, uint8_t op_own);

--- a/src/vma/dev/cq_mgr_mlx5.h
+++ b/src/vma/dev/cq_mgr_mlx5.h
@@ -90,8 +90,7 @@ private:
 	qp_mgr_eth_mlx5*            m_qp;
 	struct mlx5_cq*             m_mlx5_cq;
 
-	inline struct mlx5_cqe64 *mlx5_get_cqe64(void);
-	inline struct mlx5_cqe64*   get_cqe64(struct mlx5_cqe64 **cqe_err);
+	inline struct mlx5_cqe64*   get_cqe64(struct mlx5_cqe64 **cqe_err = NULL);
 	inline void                 cqe64_to_mem_buff_desc(struct mlx5_cqe64 *cqe, mem_buf_desc_t* p_rx_wc_buf_desc, enum buff_status_e& status);
 	void                        cqe64_to_vma_wc(struct mlx5_cqe64 *cqe, vma_ibv_wc *wc);
 	inline struct mlx5_cqe64*   check_error_completion(struct mlx5_cqe64 *cqe, uint32_t *ci, uint8_t op_own);

--- a/src/vma/dev/cq_mgr_mlx5.h
+++ b/src/vma/dev/cq_mgr_mlx5.h
@@ -85,7 +85,6 @@ protected:
 
 private:
 	mem_buf_desc_t              *m_rx_hot_buffer;
-	uint64_t                    *m_p_rq_wqe_idx_to_wrid;
 	qp_mgr_eth_mlx5*            m_qp; //for tx
 	struct mlx5_cq*             m_mlx5_cq;
 

--- a/src/vma/dev/qp_mgr.cpp
+++ b/src/vma/dev/qp_mgr.cpp
@@ -63,12 +63,11 @@
 
 qp_mgr::qp_mgr(const ring_simple* p_ring, const ib_ctx_handler* p_context,
 		const uint8_t port_num, const uint32_t tx_num_wr):
-	 m_rq_wqe_counter(0)
-	,m_rq_wqe_idx_to_wrid(NULL)
+	m_qp(NULL)
+	,m_p_rq_wqe_idx_to_wrid(NULL)
 #ifdef DEFINED_VMAPOLL
 	,m_mlx5_hw_qp(NULL)
 #endif
-	,m_qp(NULL)
 	,m_p_ring((ring_simple*)p_ring)
 	,m_port_num((uint8_t)port_num)
 	,m_p_ib_ctx_handler((ib_ctx_handler*)p_context)
@@ -98,13 +97,6 @@ qp_mgr::qp_mgr(const ring_simple* p_ring, const ib_ctx_handler* p_context,
 
 	set_unsignaled_count();
 
-#ifdef DEFINED_VMAPOLL
-	m_rq_wqe_idx_to_wrid = (uint64_t*)mmap(NULL, m_rx_num_wr * sizeof(*m_rq_wqe_idx_to_wrid),
-		PROT_READ | PROT_WRITE, MAP_ANONYMOUS | MAP_PRIVATE, -1, 0);
-	if (m_rq_wqe_idx_to_wrid == MAP_FAILED) {
-		qp_logerr("Failed allocating m_rq_wqe_idx_to_wrid (errno=%d %m)", errno);
-	}
-#endif // DEFINED_VMAPOLL
 	qp_logfunc("");
 }
 
@@ -140,15 +132,6 @@ qp_mgr::~qp_mgr()
 
 	delete[] m_ibv_rx_sg_array;
 	delete[] m_ibv_rx_wr_array;
-
-#ifdef DEFINED_VMAPOLL
-        if (m_rq_wqe_idx_to_wrid) {
-		if (0 != munmap(m_rq_wqe_idx_to_wrid, m_rx_num_wr * sizeof(*m_rq_wqe_idx_to_wrid))) {
-			qp_logerr("Failed deallocating memory with munmap m_rq_wqe_idx_to_wrid (errno=%d %m)", errno);
-		}
-		m_rq_wqe_idx_to_wrid = NULL;
-	}
-#endif // DEFINED_VMAPOLL
 
 	qp_logdbg("Rx buffer poll: %d free global buffers available", g_buffer_pool_rx->get_free_count());
 	qp_logdbg("delete done");
@@ -495,12 +478,6 @@ int qp_mgr::post_recv(mem_buf_desc_t* p_mem_buf_desc)
 		m_ibv_rx_sg_array[m_curr_rx_wr].addr   = (uintptr_t)p_mem_buf_desc->p_buffer;
 		m_ibv_rx_sg_array[m_curr_rx_wr].length = p_mem_buf_desc->sz_buffer;
 		m_ibv_rx_sg_array[m_curr_rx_wr].lkey   = p_mem_buf_desc->lkey;
-
-		if (m_rq_wqe_idx_to_wrid) {
-			uint32_t index = m_rq_wqe_counter & (m_rx_num_wr - 1);
-			m_rq_wqe_idx_to_wrid[index] = (uintptr_t)p_mem_buf_desc;
-			++m_rq_wqe_counter;
-		}
 
 		if (m_curr_rx_wr == m_n_sysvar_rx_num_wr_to_post_recv - 1) {
 

--- a/src/vma/dev/qp_mgr.cpp
+++ b/src/vma/dev/qp_mgr.cpp
@@ -196,7 +196,7 @@ int qp_mgr::configure(struct ibv_comp_channel* p_rx_comp_event_channel)
 
 	// Check device capabilities for max SG elements
 	uint32_t tx_max_inline = safe_mce_sys().tx_max_inline;
-	uint32_t rx_num_sge = (IS_VMAPOLL) ? 1 : MCE_DEFAULT_RX_NUM_SGE;
+	uint32_t rx_num_sge = (m_p_ring->get_xtreme_active() ? 1 : MCE_DEFAULT_RX_NUM_SGE);
 	uint32_t tx_num_sge = MCE_DEFAULT_TX_NUM_SGE;
 
 	qp_init_attr.cap.max_send_wr = m_tx_num_wr;

--- a/src/vma/dev/qp_mgr.cpp
+++ b/src/vma/dev/qp_mgr.cpp
@@ -65,9 +65,6 @@ qp_mgr::qp_mgr(const ring_simple* p_ring, const ib_ctx_handler* p_context,
 		const uint8_t port_num, const uint32_t tx_num_wr):
 	m_qp(NULL)
 	,m_p_rq_wqe_idx_to_wrid(NULL)
-#ifdef DEFINED_VMAPOLL
-	,m_mlx5_hw_qp(NULL)
-#endif
 	,m_p_ring((ring_simple*)p_ring)
 	,m_port_num((uint8_t)port_num)
 	,m_p_ib_ctx_handler((ib_ctx_handler*)p_context)
@@ -229,10 +226,6 @@ int qp_mgr::configure(struct ibv_comp_channel* p_rx_comp_event_channel)
 	m_p_ahc_head = NULL;
 	m_p_ahc_tail = NULL;
 
-#ifdef DEFINED_VMAPOLL
-	struct verbs_qp *vqp = (struct verbs_qp *)m_qp;
-	m_mlx5_hw_qp = (struct mlx5_qp*)container_of(vqp, struct mlx5_qp, verbs_qp);
-#endif //DEFINED_VMAPOLL
 	if (m_p_cq_mgr_tx) {
 		m_p_cq_mgr_tx->add_qp_tx(this);
 	}

--- a/src/vma/dev/qp_mgr.h
+++ b/src/vma/dev/qp_mgr.h
@@ -108,7 +108,7 @@ public:
 	virtual void        up();
 	virtual void        down();
 
-	int                 post_recv(mem_buf_desc_t* p_mem_buf_desc); // Post for receive a list of mem_buf_desc
+	virtual int         post_recv(mem_buf_desc_t* p_mem_buf_desc); // Post for receive a list of mem_buf_desc
 	int                 send(vma_ibv_send_wr* p_send_wqe, vma_wr_tx_packet_attr attr);
 
 	uint32_t            get_max_inline_tx_data() const {return m_max_inline_data; }
@@ -146,12 +146,11 @@ public:
 	virtual void        dm_release_data(mem_buf_desc_t* buff) { NOT_IN_USE(buff); }
 
 protected:
-	uint64_t            m_rq_wqe_counter;
-	uint64_t*           m_rq_wqe_idx_to_wrid;
+	struct ibv_qp*      m_qp;
+	uint64_t*           m_p_rq_wqe_idx_to_wrid;
 #ifdef DEFINED_VMAPOLL
 	struct mlx5_qp*	    m_mlx5_hw_qp;
 #endif // DEFINED_VMAPOLL
-	struct ibv_qp*      m_qp;
 
 	ring_simple*        m_p_ring;
 	uint8_t             m_port_num;

--- a/src/vma/dev/qp_mgr.h
+++ b/src/vma/dev/qp_mgr.h
@@ -148,9 +148,6 @@ public:
 protected:
 	struct ibv_qp*      m_qp;
 	uint64_t*           m_p_rq_wqe_idx_to_wrid;
-#ifdef DEFINED_VMAPOLL
-	struct mlx5_qp*	    m_mlx5_hw_qp;
-#endif // DEFINED_VMAPOLL
 
 	ring_simple*        m_p_ring;
 	uint8_t             m_port_num;

--- a/src/vma/dev/qp_mgr_eth_mlx5.cpp
+++ b/src/vma/dev/qp_mgr_eth_mlx5.cpp
@@ -86,6 +86,9 @@ void qp_mgr_eth_mlx5::init_sq()
 
 	struct verbs_qp *vqp = (struct verbs_qp *)m_qp;
 	m_hw_qp = (struct mlx5_qp*)container_of(vqp, struct mlx5_qp, verbs_qp);
+#ifdef DEFINED_VMAPOLL
+	m_mlx5_hw_qp = (struct mlx5_qp*)container_of(vqp, struct mlx5_qp, verbs_qp);
+#endif //DEFINED_VMAPOLL
 	m_qp_num	 = m_hw_qp->ctrl_seg.qp_num;
 	m_sq_wqes	 = (struct mlx5_wqe64 (*)[])(uintptr_t)m_hw_qp->gen_data.sqstart;
 	m_sq_wqe_hot	 = &(*m_sq_wqes)[0];
@@ -141,6 +144,9 @@ qp_mgr_eth_mlx5::qp_mgr_eth_mlx5(const ring_simple* p_ring, const ib_ctx_handler
 	,m_sq_wqe_idx_to_wrid(NULL)
 	,m_rq_wqe_counter(0)
 	,m_rq_wqe_idx_to_wrid(NULL)
+#ifdef DEFINED_VMAPOLL
+	,m_mlx5_hw_qp(NULL)
+#endif
 	,m_sq_wqes(NULL)
 	,m_sq_wqe_hot(NULL)
 	,m_sq_wqes_end(NULL)
@@ -205,11 +211,7 @@ cq_mgr* qp_mgr_eth_mlx5::init_rx_cq_mgr(struct ibv_comp_channel* p_rx_comp_event
 	}
 	m_p_rq_wqe_idx_to_wrid = m_rq_wqe_idx_to_wrid;
 
-#ifdef DEFINED_VMAPOLL
-	return new cq_mgr(m_p_ring, m_p_ib_ctx_handler, m_rx_num_wr, p_rx_comp_event_channel, true);
-#else
 	return new cq_mgr_mlx5(m_p_ring, m_p_ib_ctx_handler, m_rx_num_wr, p_rx_comp_event_channel, true);
-#endif
 }
 
 cq_mgr* qp_mgr_eth_mlx5::init_tx_cq_mgr()

--- a/src/vma/dev/qp_mgr_eth_mlx5.cpp
+++ b/src/vma/dev/qp_mgr_eth_mlx5.cpp
@@ -139,6 +139,8 @@ qp_mgr_eth_mlx5::qp_mgr_eth_mlx5(const ring_simple* p_ring, const ib_ctx_handler
 	qp_mgr_eth(p_ring, p_context, port_num, p_rx_comp_event_channel, tx_num_wr, vlan, false)
 	,m_hw_qp(NULL)
 	,m_sq_wqe_idx_to_wrid(NULL)
+	,m_rq_wqe_counter(0)
+	,m_rq_wqe_idx_to_wrid(NULL)
 	,m_sq_wqes(NULL)
 	,m_sq_wqe_hot(NULL)
 	,m_sq_wqes_end(NULL)
@@ -201,6 +203,7 @@ cq_mgr* qp_mgr_eth_mlx5::init_rx_cq_mgr(struct ibv_comp_channel* p_rx_comp_event
 		qp_logerr("Failed allocating m_rq_wqe_idx_to_wrid (errno=%d %m)", errno);
 		return NULL;
 	}
+	m_p_rq_wqe_idx_to_wrid = m_rq_wqe_idx_to_wrid;
 
 #ifdef DEFINED_VMAPOLL
 	return new cq_mgr(m_p_ring, m_p_ib_ctx_handler, m_rx_num_wr, p_rx_comp_event_channel, true);
@@ -445,6 +448,67 @@ static inline uint32_t get_mlx5_opcode(vma_ibv_wr_opcode verbs_opcode)
 		return MLX5_OPCODE_SEND;
 
 	}
+}
+
+int qp_mgr_eth_mlx5::post_recv(mem_buf_desc_t* p_mem_buf_desc)
+{
+	qp_logfuncall("");
+	// Called from cq_mgr context under cq_mgr::LOCK!
+	mem_buf_desc_t *next;
+	while (p_mem_buf_desc) {
+		next = p_mem_buf_desc->p_next_desc;
+		p_mem_buf_desc->p_next_desc = NULL;
+
+		if (m_n_sysvar_rx_prefetch_bytes_before_poll) {
+			if (m_p_prev_rx_desc_pushed)
+				m_p_prev_rx_desc_pushed->p_prev_desc = p_mem_buf_desc;
+			m_p_prev_rx_desc_pushed = p_mem_buf_desc;
+		}
+
+		m_ibv_rx_wr_array[m_curr_rx_wr].wr_id  = (uintptr_t)p_mem_buf_desc;
+		m_ibv_rx_sg_array[m_curr_rx_wr].addr   = (uintptr_t)p_mem_buf_desc->p_buffer;
+		m_ibv_rx_sg_array[m_curr_rx_wr].length = p_mem_buf_desc->sz_buffer;
+		m_ibv_rx_sg_array[m_curr_rx_wr].lkey   = p_mem_buf_desc->lkey;
+
+		if (m_rq_wqe_idx_to_wrid) {
+			uint32_t index = m_rq_wqe_counter & (m_rx_num_wr - 1);
+			m_rq_wqe_idx_to_wrid[index] = (uintptr_t)p_mem_buf_desc;
+			++m_rq_wqe_counter;
+		}
+
+		if (m_curr_rx_wr == m_n_sysvar_rx_num_wr_to_post_recv - 1) {
+
+			m_last_posted_rx_wr_id = (uintptr_t)p_mem_buf_desc;
+
+			m_p_prev_rx_desc_pushed = NULL;
+			p_mem_buf_desc->p_prev_desc = NULL;
+
+			m_curr_rx_wr = 0;
+			struct ibv_recv_wr *bad_wr = NULL;
+			IF_VERBS_FAILURE(ibv_post_recv(m_qp, &m_ibv_rx_wr_array[0], &bad_wr)) {
+				uint32_t n_pos_bad_rx_wr = ((uint8_t*)bad_wr - (uint8_t*)m_ibv_rx_wr_array) / sizeof(struct ibv_recv_wr);
+				qp_logerr("failed posting list (errno=%d %m)", errno);
+				qp_logerr("bad_wr is %d in submitted list (bad_wr=%p, m_ibv_rx_wr_array=%p, size=%d)", n_pos_bad_rx_wr, bad_wr, m_ibv_rx_wr_array, sizeof(struct ibv_recv_wr));
+				qp_logerr("bad_wr info: wr_id=%#x, next=%p, addr=%#x, length=%d, lkey=%#x", bad_wr[0].wr_id, bad_wr[0].next, bad_wr[0].sg_list[0].addr, bad_wr[0].sg_list[0].length, bad_wr[0].sg_list[0].lkey);
+				qp_logerr("QP current state: %d", priv_ibv_query_qp_state(m_qp));
+
+				// Fix broken linked list of rx_wr
+				if (n_pos_bad_rx_wr != (m_n_sysvar_rx_num_wr_to_post_recv - 1)) {
+					m_ibv_rx_wr_array[n_pos_bad_rx_wr].next = &m_ibv_rx_wr_array[n_pos_bad_rx_wr+1];
+				}
+				throw;
+			} ENDIF_VERBS_FAILURE;
+			qp_logfunc("Successful ibv_post_recv");
+		}
+		else {
+			m_curr_rx_wr++;
+		}
+
+
+		p_mem_buf_desc = next;
+	}
+
+	return 0;
 }
 
 //! Send one RAW packet by MLX5 BlueFlame

--- a/src/vma/dev/qp_mgr_eth_mlx5.cpp
+++ b/src/vma/dev/qp_mgr_eth_mlx5.cpp
@@ -86,9 +86,6 @@ void qp_mgr_eth_mlx5::init_sq()
 
 	struct verbs_qp *vqp = (struct verbs_qp *)m_qp;
 	m_hw_qp = (struct mlx5_qp*)container_of(vqp, struct mlx5_qp, verbs_qp);
-#ifdef DEFINED_VMAPOLL
-	m_mlx5_hw_qp = (struct mlx5_qp*)container_of(vqp, struct mlx5_qp, verbs_qp);
-#endif //DEFINED_VMAPOLL
 	m_qp_num	 = m_hw_qp->ctrl_seg.qp_num;
 	m_sq_wqes	 = (struct mlx5_wqe64 (*)[])(uintptr_t)m_hw_qp->gen_data.sqstart;
 	m_sq_wqe_hot	 = &(*m_sq_wqes)[0];
@@ -144,9 +141,6 @@ qp_mgr_eth_mlx5::qp_mgr_eth_mlx5(const ring_simple* p_ring, const ib_ctx_handler
 	,m_sq_wqe_idx_to_wrid(NULL)
 	,m_rq_wqe_counter(0)
 	,m_rq_wqe_idx_to_wrid(NULL)
-#ifdef DEFINED_VMAPOLL
-	,m_mlx5_hw_qp(NULL)
-#endif
 	,m_sq_wqes(NULL)
 	,m_sq_wqe_hot(NULL)
 	,m_sq_wqes_end(NULL)

--- a/src/vma/dev/qp_mgr_eth_mlx5.h
+++ b/src/vma/dev/qp_mgr_eth_mlx5.h
@@ -61,6 +61,10 @@ protected:
 	uint64_t            m_rq_wqe_counter;
 	uint64_t*           m_rq_wqe_idx_to_wrid;
 
+#ifdef DEFINED_VMAPOLL
+	struct mlx5_qp*	    m_mlx5_hw_qp;
+#endif // DEFINED_VMAPOLL
+
 private:
 	cq_mgr*		init_rx_cq_mgr(struct ibv_comp_channel* p_rx_comp_event_channel);
 	virtual cq_mgr* init_tx_cq_mgr(void);

--- a/src/vma/dev/qp_mgr_eth_mlx5.h
+++ b/src/vma/dev/qp_mgr_eth_mlx5.h
@@ -51,11 +51,15 @@ public:
 	virtual ~qp_mgr_eth_mlx5();
 	virtual void up();
 	virtual void down();
+	virtual int  post_recv(mem_buf_desc_t* p_mem_buf_desc); // Post for receive a list of mem_buf_desc
 
 protected:
 	void			trigger_completion_for_all_sent_packets();
 	struct mlx5_qp*		m_hw_qp;
-	uint64_t*               m_sq_wqe_idx_to_wrid;
+	uint64_t*           m_sq_wqe_idx_to_wrid;
+
+	uint64_t            m_rq_wqe_counter;
+	uint64_t*           m_rq_wqe_idx_to_wrid;
 
 private:
 	cq_mgr*		init_rx_cq_mgr(struct ibv_comp_channel* p_rx_comp_event_channel);

--- a/src/vma/dev/qp_mgr_eth_mlx5.h
+++ b/src/vma/dev/qp_mgr_eth_mlx5.h
@@ -61,10 +61,6 @@ protected:
 	uint64_t            m_rq_wqe_counter;
 	uint64_t*           m_rq_wqe_idx_to_wrid;
 
-#ifdef DEFINED_VMAPOLL
-	struct mlx5_qp*	    m_mlx5_hw_qp;
-#endif // DEFINED_VMAPOLL
-
 private:
 	cq_mgr*		init_rx_cq_mgr(struct ibv_comp_channel* p_rx_comp_event_channel);
 	virtual cq_mgr* init_tx_cq_mgr(void);

--- a/src/vma/dev/rfs_uc.cpp
+++ b/src/vma/dev/rfs_uc.cpp
@@ -147,26 +147,19 @@ bool rfs_uc::prepare_flow_spec()
 
 bool rfs_uc::rx_dispatch_packet(mem_buf_desc_t* p_rx_wc_buf_desc, void* pv_fd_ready_array)
 {
-	// Dispatching: Notify new packet to the FIRST registered receiver ONLY
+	uint32_t num_sinks = (safe_mce_sys().enable_xtreme ? 1 : m_n_sinks_list_entries);
+
 	p_rx_wc_buf_desc->reset_ref_count();
-#ifdef DEFINED_VMAPOLL	
+	for (uint32_t i=0; i < num_sinks; ++i) {
+		if (m_sinks_list[i]) {
 #ifdef RDTSC_MEASURE_RX_DISPATCH_PACKET
 	RDTSC_TAKE_START(g_rdtsc_instr_info_arr[RDTSC_FLOW_RX_DISPATCH_PACKET]);
 #endif //RDTSC_MEASURE_RX_DISPATCH_PACKET
-	//for (uint32_t i=0; i < m_n_sinks_list_entries; ++i) 
-	{
-		if (likely(m_sinks_list[0])) {
 			p_rx_wc_buf_desc->inc_ref_count();
-			m_sinks_list[0]->rx_input_cb(p_rx_wc_buf_desc, pv_fd_ready_array);
+			m_sinks_list[i]->rx_input_cb(p_rx_wc_buf_desc, pv_fd_ready_array);
 #ifdef RDTSC_MEASURE_RX_DISPATCH_PACKET
 	RDTSC_TAKE_END(g_rdtsc_instr_info_arr[RDTSC_FLOW_RX_DISPATCH_PACKET]);
 #endif //RDTSC_MEASURE_RX_DISPATCH_PACKET
-#else
-	for (uint32_t i=0; i < m_n_sinks_list_entries; ++i) {
-		if (m_sinks_list[i]) {
-			p_rx_wc_buf_desc->inc_ref_count();
-			m_sinks_list[i]->rx_input_cb(p_rx_wc_buf_desc, pv_fd_ready_array);
-#endif // DEFINED_VMAPOLL
 			// Check packet ref_count to see the last receiver is interested in this packet
 			if (p_rx_wc_buf_desc->dec_ref_count() > 1) {
 				// The sink will be responsible to return the buffer to CQ for reuse

--- a/src/vma/dev/rfs_uc.cpp
+++ b/src/vma/dev/rfs_uc.cpp
@@ -147,7 +147,11 @@ bool rfs_uc::prepare_flow_spec()
 
 bool rfs_uc::rx_dispatch_packet(mem_buf_desc_t* p_rx_wc_buf_desc, void* pv_fd_ready_array)
 {
+#ifdef DEFINED_VMAPOLL
 	uint32_t num_sinks = (safe_mce_sys().enable_xtreme ? 1 : m_n_sinks_list_entries);
+#else
+	uint32_t num_sinks = m_n_sinks_list_entries;
+#endif /* DEFINED_VMAPOLL */
 
 	p_rx_wc_buf_desc->reset_ref_count();
 	for (uint32_t i=0; i < num_sinks; ++i) {

--- a/src/vma/dev/ring.cpp
+++ b/src/vma/dev/ring.cpp
@@ -43,11 +43,7 @@ ring::ring(int count, uint32_t mtu) :
 	m_n_num_resources(count), m_p_n_rx_channel_fds(NULL), m_parent(NULL),
 	m_is_mp_ring(false), m_mtu(mtu)
 {
-#ifdef DEFINED_VMAPOLL
-	xtreme.m_active = true; /* TODO: This VMA version supports socketXtreme usage mode only */
-#else
-	xtreme.m_active = false; /* TODO: This VMA version supports socketXtreme usage mode only */
-#endif // DEFINED_VMAPOLL
+	xtreme.m_active = safe_mce_sys().enable_xtreme;
 	INIT_LIST_HEAD(&xtreme.m_ec_list);
 	xtreme.m_vma_poll_completion = NULL;
 }

--- a/src/vma/dev/ring.cpp
+++ b/src/vma/dev/ring.cpp
@@ -44,10 +44,12 @@ ring::ring(int count, uint32_t mtu) :
 	m_is_mp_ring(false), m_mtu(mtu)
 {
 #ifdef DEFINED_VMAPOLL
-	m_vma_active = true; /* TODO: This VMA version supports vma_poll() usage mode only */
-	INIT_LIST_HEAD(&m_ec_list);
-	m_vma_poll_completion = NULL;
-#endif // DEFINED_VMAPOLL	
+	xtreme.m_active = true; /* TODO: This VMA version supports socketXtreme usage mode only */
+#else
+	xtreme.m_active = false; /* TODO: This VMA version supports socketXtreme usage mode only */
+#endif // DEFINED_VMAPOLL
+	INIT_LIST_HEAD(&xtreme.m_ec_list);
+	xtreme.m_vma_poll_completion = NULL;
 }
 
 uint32_t ring::get_mtu(const route_rule_table_key &key)
@@ -68,8 +70,6 @@ int ring::get_rx_channel_fds_index(uint32_t index) const {
 };
 ring::~ring()
 {
-#ifdef DEFINED_VMAPOLL
 	ring_logdbg("queue of event completion elements is %s",
-			(list_empty(&m_ec_list) ? "empty" : "not empty"));
-#endif // DEFINED_VMAPOLL		
+			(list_empty(&xtreme.m_ec_list) ? "empty" : "not empty"));
 }

--- a/src/vma/dev/ring.h
+++ b/src/vma/dev/ring.h
@@ -329,7 +329,6 @@ public:
 
 #ifdef DEFINED_VMAPOLL		
 	virtual int		vma_poll(struct vma_completion_t *vma_completions, unsigned int ncompletions, int flags) = 0;
-	virtual bool		reclaim_recv_buffers_no_lock(mem_buf_desc_t* rx_reuse_lst) {NOT_IN_USE(rx_reuse_lst); return false;}
 
 	virtual int		vma_poll_reclaim_single_recv_buffer(mem_buf_desc_t* rx_reuse_lst) {NOT_IN_USE(rx_reuse_lst); return -1;}
 	virtual void		vma_poll_reclaim_recv_buffers(mem_buf_desc_t* rx_reuse_lst) {NOT_IN_USE(rx_reuse_lst); return;}

--- a/src/vma/dev/ring.h
+++ b/src/vma/dev/ring.h
@@ -305,6 +305,8 @@ public:
 	virtual bool 		get_hw_dummy_send_support(ring_user_id_t id, vma_ibv_send_wr* p_send_wqe) = 0;
 	virtual int		request_notification(cq_type_t cq_type, uint64_t poll_sn) = 0;
 	virtual bool		reclaim_recv_buffers(descq_t *rx_reuse) = 0;
+	virtual bool		reclaim_recv_buffers(mem_buf_desc_t* rx_reuse_lst) = 0;
+	virtual int		reclaim_recv_single_buffer(mem_buf_desc_t* rx_reuse) = 0;
 	virtual int		drain_and_proccess(cq_type_t cq_type) = 0;
 	virtual int		wait_for_notification_and_process_element(cq_type_t cq_type, int cq_channel_fd, uint64_t* p_cq_poll_sn, void* pv_fd_ready_array = NULL) = 0;
 	virtual int		poll_and_process_element_rx(uint64_t* p_cq_poll_sn, void* pv_fd_ready_array = NULL) = 0;
@@ -329,9 +331,6 @@ public:
 
 #ifdef DEFINED_VMAPOLL		
 	virtual int		vma_poll(struct vma_completion_t *vma_completions, unsigned int ncompletions, int flags) = 0;
-
-	virtual int		vma_poll_reclaim_single_recv_buffer(mem_buf_desc_t* rx_reuse_lst) {NOT_IN_USE(rx_reuse_lst); return -1;}
-	virtual void		vma_poll_reclaim_recv_buffers(mem_buf_desc_t* rx_reuse_lst) {NOT_IN_USE(rx_reuse_lst); return;}
 
 	inline void set_vma_active(bool flag) {m_vma_active = flag;}
 	inline bool get_vma_active(void) {return m_vma_active;}

--- a/src/vma/dev/ring_bond.cpp
+++ b/src/vma/dev/ring_bond.cpp
@@ -393,6 +393,20 @@ void ring_bond::inc_tx_retransmissions(ring_user_id_t id)
 		active_ring->inc_tx_retransmissions(id);
 }
 
+bool ring_bond::reclaim_recv_buffers(mem_buf_desc_t* rx_reuse_lst)
+{
+	/* TODO: not supported */
+	NOT_IN_USE(rx_reuse_lst);
+	return false;
+}
+
+int ring_bond::reclaim_recv_single_buffer(mem_buf_desc_t* rx_reuse)
+{
+	/* TODO: not supported */
+	NOT_IN_USE(rx_reuse);
+	return -1;
+}
+
 bool ring_bond::reclaim_recv_buffers(descq_t *rx_reuse)
 {
 	/* use this local array to avoid locking mechanizm

--- a/src/vma/dev/ring_bond.cpp
+++ b/src/vma/dev/ring_bond.cpp
@@ -658,11 +658,6 @@ bool ring_bond::is_ratelimit_supported(uint32_t rate)
 }
 
 #ifdef DEFINED_VMAPOLL	
-int ring_bond::fast_poll_and_process_element_rx(vma_packets_t *vma_pkts)
-{
-	NOT_IN_USE(vma_pkts);
-	return 0;
-}
 
 int ring_bond::vma_poll(struct vma_completion_t *vma_completions, unsigned int ncompletions, int flags)
 {

--- a/src/vma/dev/ring_bond.cpp
+++ b/src/vma/dev/ring_bond.cpp
@@ -671,9 +671,7 @@ bool ring_bond::is_ratelimit_supported(uint32_t rate)
 	return true;
 }
 
-#ifdef DEFINED_VMAPOLL	
-
-int ring_bond::vma_poll(struct vma_completion_t *vma_completions, unsigned int ncompletions, int flags)
+int ring_bond::xtreme_poll(struct vma_completion_t *vma_completions, unsigned int ncompletions, int flags)
 {
 	NOT_IN_USE(vma_completions);
 	NOT_IN_USE(ncompletions);
@@ -681,4 +679,3 @@ int ring_bond::vma_poll(struct vma_completion_t *vma_completions, unsigned int n
 
 	return 0;
 }
-#endif // DEFINED_VMAPOLL	

--- a/src/vma/dev/ring_bond.h
+++ b/src/vma/dev/ring_bond.h
@@ -70,9 +70,7 @@ public:
 	virtual bool 		get_hw_dummy_send_support(ring_user_id_t id, vma_ibv_send_wr* p_send_wqe);
 	virtual int 		modify_ratelimit(const uint32_t ratelimit_kbps);
 	virtual bool		is_ratelimit_supported(uint32_t rate);
-#ifdef DEFINED_VMAPOLL		
-	int 			vma_poll(struct vma_completion_t *vma_completions, unsigned int ncompletions, int flags);
-#endif // DEFINED_VMAPOLL		
+	int 			xtreme_poll(struct vma_completion_t *vma_completions, unsigned int ncompletions, int flags);
 protected:
 	virtual void		create_slave_list(in_addr_t local_if, ring_resource_creation_info_t* p_ring_info, bool active_slaves[], uint16_t partition) = 0;
 	void			update_rx_channel_fds();

--- a/src/vma/dev/ring_bond.h
+++ b/src/vma/dev/ring_bond.h
@@ -69,7 +69,6 @@ public:
 	virtual int 		modify_ratelimit(const uint32_t ratelimit_kbps);
 	virtual bool		is_ratelimit_supported(uint32_t rate);
 #ifdef DEFINED_VMAPOLL		
-	virtual int		fast_poll_and_process_element_rx(vma_packets_t *vma_pkts);
 	int 			vma_poll(struct vma_completion_t *vma_completions, unsigned int ncompletions, int flags);
 #endif // DEFINED_VMAPOLL		
 protected:

--- a/src/vma/dev/ring_bond.h
+++ b/src/vma/dev/ring_bond.h
@@ -44,6 +44,8 @@ public:
 	virtual int		poll_and_process_element_rx(uint64_t* p_cq_poll_sn, void* pv_fd_ready_array = NULL);
 	virtual void		adapt_cq_moderation();
 	virtual bool		reclaim_recv_buffers(descq_t *rx_reuse);
+	virtual bool		reclaim_recv_buffers(mem_buf_desc_t* rx_reuse_lst);
+	virtual int		reclaim_recv_single_buffer(mem_buf_desc_t* rx_reuse); // No locks
 	virtual int		drain_and_proccess(cq_type_t cq_type);
 	virtual int		wait_for_notification_and_process_element(cq_type_t cq_type, int cq_channel_fd, uint64_t* p_cq_poll_sn, void* pv_fd_ready_array = NULL);
 	virtual void		mem_buf_desc_completion_with_error_rx(mem_buf_desc_t* p_rx_wc_buf_desc); // Assume locked...

--- a/src/vma/dev/ring_simple.cpp
+++ b/src/vma/dev/ring_simple.cpp
@@ -1223,9 +1223,8 @@ int ring_simple::xtreme_poll(struct vma_completion_t *vma_completions, unsigned 
 				 * in right order. It is done to avoid locking and
 				 * may be it is not so critical
 				 */
-#ifdef DEFINED_VMAPOLL
 				mem_buf_desc_t *desc;
-				if (likely(m_p_cq_mgr_rx->vma_poll_and_process_element_rx(&desc))) {
+				if (likely(m_p_cq_mgr_rx->poll_and_process_element_rx(&desc))) {
 					desc->rx.vma_polled = true;
 					rx_process_buffer(desc, NULL);
 					if (xtreme.m_vma_poll_completion->events) {
@@ -1235,7 +1234,6 @@ int ring_simple::xtreme_poll(struct vma_completion_t *vma_completions, unsigned 
 				} else {
 					break;
 				}
-#endif // DEFINED_VMAPOLL
 			}
 		}
 

--- a/src/vma/dev/ring_simple.h
+++ b/src/vma/dev/ring_simple.h
@@ -52,9 +52,7 @@ public:
 	bool			reclaim_recv_buffers_no_lock(mem_buf_desc_t* rx_reuse_lst); // No locks
 	virtual bool		reclaim_recv_buffers(mem_buf_desc_t* rx_reuse_lst);
 	virtual int		reclaim_recv_single_buffer(mem_buf_desc_t* rx_reuse); // No locks
-#ifdef DEFINED_VMAPOLL	
-	virtual int 		vma_poll(struct vma_completion_t *vma_completions, unsigned int ncompletions, int flags);	
-#endif // DEFINED_VMAPOLL
+	virtual int 		xtreme_poll(struct vma_completion_t *vma_completions, unsigned int ncompletions, int flags);	
 	virtual int		drain_and_proccess(cq_type_t cq_type);
 	virtual int		wait_for_notification_and_process_element(cq_type_t cq_type, int cq_channel_fd, uint64_t* p_cq_poll_sn, void* pv_fd_ready_array = NULL);
 	virtual void		mem_buf_desc_completion_with_error_rx(mem_buf_desc_t* p_rx_wc_buf_desc); // Assume locked...

--- a/src/vma/dev/ring_simple.h
+++ b/src/vma/dev/ring_simple.h
@@ -48,13 +48,13 @@ public:
 	virtual int		poll_and_process_element_rx(uint64_t* p_cq_poll_sn, void* pv_fd_ready_array = NULL);
 	virtual void		adapt_cq_moderation();
 	bool			reclaim_recv_buffers_no_lock(descq_t *rx_reuse); // No locks
+	virtual bool		reclaim_recv_buffers(descq_t *rx_reuse);
 	bool			reclaim_recv_buffers_no_lock(mem_buf_desc_t* rx_reuse_lst); // No locks
+	virtual bool		reclaim_recv_buffers(mem_buf_desc_t* rx_reuse_lst);
+	virtual int		reclaim_recv_single_buffer(mem_buf_desc_t* rx_reuse); // No locks
 #ifdef DEFINED_VMAPOLL	
 	virtual int 		vma_poll(struct vma_completion_t *vma_completions, unsigned int ncompletions, int flags);	
-	virtual int		vma_poll_reclaim_single_recv_buffer(mem_buf_desc_t* rx_reuse_lst); // No locks
-	virtual void		vma_poll_reclaim_recv_buffers(mem_buf_desc_t* rx_reuse_lst); // No locks
 #endif // DEFINED_VMAPOLL
-	virtual bool		reclaim_recv_buffers(descq_t *rx_reuse);
 	virtual int		drain_and_proccess(cq_type_t cq_type);
 	virtual int		wait_for_notification_and_process_element(cq_type_t cq_type, int cq_channel_fd, uint64_t* p_cq_poll_sn, void* pv_fd_ready_array = NULL);
 	virtual void		mem_buf_desc_completion_with_error_rx(mem_buf_desc_t* p_rx_wc_buf_desc); // Assume locked...
@@ -157,10 +157,7 @@ private:
 	flow_spec_udp_uc_map_t	m_flow_udp_uc_map;
 	const bool		m_b_sysvar_eth_mc_l2_only_rules;
 	const bool		m_b_sysvar_mc_force_flowtag;
-#ifdef DEFINED_VMAPOLL
-	mem_buf_desc_t*		m_rx_buffs_rdy_for_free_head;
-	mem_buf_desc_t*		m_rx_buffs_rdy_for_free_tail;
-#endif // DEFINED_VMAPOLL		
+
 	bool			m_flow_tag_enabled;
 };
 

--- a/src/vma/dev/ring_simple.h
+++ b/src/vma/dev/ring_simple.h
@@ -101,9 +101,6 @@ protected:
 	virtual qp_mgr*		create_qp_mgr(const ib_ctx_handler* ib_ctx, uint8_t port_num, struct ibv_comp_channel* p_rx_comp_event_channel) = 0;
 	virtual void		create_resources(ring_resource_creation_info_t* p_ring_info, bool active);
 	// Internal functions. No need for locks mechanism.
-#ifdef DEFINED_VMAPOLL	
-	inline void 		vma_poll_process_recv_buffer(mem_buf_desc_t* p_rx_wc_buf_desc);
-#endif // DEFINED_VMAPOLL	
 	bool			rx_process_buffer(mem_buf_desc_t* p_rx_wc_buf_desc, void* pv_fd_ready_array);
 	void			print_flow_to_rfs_udp_uc_map(flow_spec_udp_uc_map_t *p_flow_map);
 	void			print_flow_to_rfs_tcp_map(flow_spec_tcp_map_t *p_flow_map);

--- a/src/vma/main.cpp
+++ b/src/vma/main.cpp
@@ -83,11 +83,7 @@ void check_netperf_flags();
 // Start of vma_version_str - used in "$ strings libvma.so | grep VMA_VERSION"
 #define STR_EXPAND(x) #x
 #define STR(x) STR_EXPAND(x)
-#ifdef DEFINED_VMAPOLL
-const char *vma_version_str = "VMA_VERSION: " PACKAGE_VERSION "-" STR(VMA_LIBRARY_RELEASE) " (vmapoll)"
-#else
 const char *vma_version_str = "VMA_VERSION: " PACKAGE_VERSION "-" STR(VMA_LIBRARY_RELEASE)
-#endif // DEFINED_VMAPOLL
 
 #if _BullseyeCoverage
 			      " Bullseye"

--- a/src/vma/main.cpp
+++ b/src/vma/main.cpp
@@ -599,6 +599,7 @@ void print_vma_global_settings()
 	VLOG_PARAM_NUMBER("Num of neigh restart retries", safe_mce_sys().neigh_num_err_retries, MCE_DEFAULT_NEIGH_NUM_ERR_RETRIES, SYS_VAR_NEIGH_NUM_ERR_RETRIES );
 
 	VLOG_PARAM_STRING("IPOIB support", safe_mce_sys().enable_ipoib, MCE_DEFAULT_IPOIB_FLAG, SYS_VAR_IPOIB, safe_mce_sys().enable_ipoib ? "Enabled " : "Disabled");
+	VLOG_PARAM_STRING("SocketXtreme mode", safe_mce_sys().enable_xtreme, MCE_DEFAULT_XTREME, SYS_VAR_XTREME, safe_mce_sys().enable_xtreme ? "Enabled " : "Disabled");
 	VLOG_PARAM_STRING("BF (Blue Flame)", safe_mce_sys().handle_bf, MCE_DEFAULT_BF_FLAG, SYS_VAR_BF, safe_mce_sys().handle_bf ? "Enabled " : "Disabled");
 	VLOG_PARAM_STRING("fork() support", safe_mce_sys().handle_fork, MCE_DEFAULT_FORK_SUPPORT, SYS_VAR_FORK, safe_mce_sys().handle_fork ? "Enabled " : "Disabled");
 	VLOG_PARAM_STRING("close on dup2()", safe_mce_sys().close_on_dup2, MCE_DEFAULT_CLOSE_ON_DUP2, SYS_VAR_CLOSE_ON_DUP2, safe_mce_sys().close_on_dup2 ? "Enabled " : "Disabled");

--- a/src/vma/main.cpp
+++ b/src/vma/main.cpp
@@ -685,9 +685,7 @@ extern "C" void sock_redirect_exit(void)
 	finit_instrumentation(safe_mce_sys().vma_time_measure_filename);
 #endif
 	vlog_printf(VLOG_DEBUG, "%s()\n", __FUNCTION__);
-#ifndef DEFINED_VMAPOLL // if not defined	
 	vma_shmem_stats_close();
-#endif // DEFINED_VMAPOLL
 }
 
 #if _BullseyeCoverage

--- a/src/vma/proto/mem_buf_desc.h
+++ b/src/vma/proto/mem_buf_desc.h
@@ -105,11 +105,7 @@ public:
 			bool 		is_vma_thr; 	// specify whether packet drained from VMA internal thread or from user app thread
 			bool		is_sw_csum_need; // specify if software checksum is need for this packet
 
-	#ifdef DEFINED_VMAPOLL
-			bool 		vma_polled;
-	#else
-			bool		pad[1];
-	#endif // DEFINED_VMAPOLL
+			bool 		vma_polled; // special flag used for socketxtreme
 		} rx;
 		struct {
 			size_t		dev_mem_length; // Total data aligned to 4 bytes.

--- a/src/vma/sock/sock-redirect.cpp
+++ b/src/vma/sock/sock-redirect.cpp
@@ -381,7 +381,7 @@ int vma_poll(int fd, struct vma_completion_t* completions, unsigned int ncomplet
 	if (likely(cq_ch_info)) {
 		ring* p_ring = cq_ch_info->get_ring();
 
-		ret_val = p_ring->vma_poll(completions, ncompletions, flags);
+		ret_val = p_ring->xtreme_poll(completions, ncompletions, flags);
 #ifdef RDTSC_MEASURE_RX_PROCCESS_BUFFER_TO_RECIVEFROM
 	RDTSC_TAKE_END(g_rdtsc_instr_info_arr[RDTSC_FLOW_PROCCESS_RX_BUFFER_TO_RECIVEFROM]);
 #endif //RDTSC_MEASURE_RX_PROCCESS_BUFFER_TO_RECIVEFROM

--- a/src/vma/sock/sock-redirect.cpp
+++ b/src/vma/sock/sock-redirect.cpp
@@ -423,7 +423,7 @@ int vma_free_vma_packets(struct vma_packet_desc_t *packets, int num)
 					p_socket_object->free_buffs(packets[i].total_len);
 				}
 				if (rng) {
-					rng->vma_poll_reclaim_recv_buffers(desc);
+					rng->reclaim_recv_buffers(desc);
 				} else {
 					goto err;
 				}
@@ -473,7 +473,7 @@ int vma_buff_free(vma_buff_t *buff)
 	if (likely(buff)) {
 		desc = (mem_buf_desc_t*)buff;
 		ring* rng = (ring*)desc->p_desc_owner;
-		ret_val = rng->vma_poll_reclaim_single_recv_buffer(desc);
+		ret_val = rng->reclaim_recv_single_buffer(desc);
 	}
 	else {
 		errno = EINVAL;

--- a/src/vma/sock/sock-redirect.cpp
+++ b/src/vma/sock/sock-redirect.cpp
@@ -369,7 +369,6 @@ int vma_free_packets(int __fd, struct vma_packet_t *pkts, size_t count)
 	return -1;
 }
 
-#ifdef DEFINED_VMAPOLL
 extern "C"
 int vma_poll(int fd, struct vma_completion_t* completions, unsigned int ncompletions, int flags)
 {
@@ -475,7 +474,6 @@ int vma_buff_free(vma_buff_t *buff)
 	}
 	return ret_val;
 }
-#endif // DEFINED_VMAPOLL
 
 extern "C"
 int vma_get_socket_rings_num(int fd)
@@ -884,14 +882,11 @@ int getsockopt(int __fd, int __level, int __optname,
 		vma_api->get_socket_rings_num = vma_get_socket_rings_num;
 		vma_api->get_socket_rings_fds = vma_get_socket_rings_fds;
 		vma_api->vma_add_ring_profile = vma_add_ring_profile;
-#ifdef DEFINED_VMAPOLL
+		vma_api->dump_fd_stats = vma_dump_fd_stats;
 		vma_api->free_vma_packets = vma_free_vma_packets;
 		vma_api->vma_poll = vma_poll;
 		vma_api->ref_vma_buff = vma_buff_ref;
 		vma_api->free_vma_buff = vma_buff_free;
-#else
-		vma_api->dump_fd_stats = vma_dump_fd_stats;
-#endif // DEFINED_VMAPOLL
 
 #ifdef HAVE_MP_RQ
 		vma_api->vma_cyclic_buffer_read = vma_cyclic_buffer_read;

--- a/src/vma/sock/sock-redirect.cpp
+++ b/src/vma/sock/sock-redirect.cpp
@@ -404,9 +404,7 @@ int vma_poll(int fd, struct vma_completion_t* completions, unsigned int ncomplet
 		return ret_val;
 	}
 }
-#endif // DEFINED_VMAPOLL
 
-#ifdef DEFINED_VMAPOLL
 extern "C"
 int vma_free_vma_packets(struct vma_packet_desc_t *packets, int num)
 {
@@ -442,9 +440,7 @@ err:
 	errno = EINVAL;
 	return -1;
 }
-#endif // DEFINED_VMAPOLL
 
-#ifdef DEFINED_VMAPOLL
 extern "C"
 int vma_buff_ref(vma_buff_t *buff)
 {
@@ -461,9 +457,7 @@ int vma_buff_ref(vma_buff_t *buff)
 	}
 	return ret_val;
 }
-#endif // DEFINED_VMAPOLL
 
-#ifdef DEFINED_VMAPOLL
 extern "C"
 int vma_buff_free(vma_buff_t *buff)
 {
@@ -546,17 +540,11 @@ int vma_thread_offload(int offload, pthread_t tid)
 extern "C"
 int vma_dump_fd_stats(int fd, int log_level)
 {
-#ifdef DEFINED_VMAPOLL
-NOT_IN_USE(fd);
-NOT_IN_USE(log_level);
-	return 0;
-#else
 	if (g_p_fd_collection) {
 		g_p_fd_collection->statistics_print(fd, log_level::from_int(log_level));
 		return 0;
 	}
 	return -1;
-#endif // DEFINED_VMAPOLL
 }
 
 #ifdef HAVE_MP_RQ

--- a/src/vma/sock/sock-redirect.cpp
+++ b/src/vma/sock/sock-redirect.cpp
@@ -1351,7 +1351,6 @@ ssize_t recvfrom(int __fd, void *__buf, size_t __nbytes, int __flags,
 		BULLSEYE_EXCLUDE_BLOCK_END
 		ret_val = orig_os_api.recvfrom(__fd, __buf, __nbytes, __flags, __from, __fromlen);
 	}
-#ifdef DEFINED_VMAPOLL
 #ifdef RDTSC_MEASURE_RX_PROCCESS_BUFFER_TO_RECIVEFROM
 	RDTSC_TAKE_END(g_rdtsc_instr_info_arr[RDTSC_FLOW_PROCCESS_RX_BUFFER_TO_RECIVEFROM]);
 #endif //RDTSC_MEASURE_RX_PROCCESS_BUFFER_TO_RECIVEFROM
@@ -1367,7 +1366,6 @@ ssize_t recvfrom(int __fd, void *__buf, size_t __nbytes, int __flags,
 #ifdef RDTSC_MEASURE_RECEIVEFROM_TO_SENDTO
 	RDTSC_TAKE_START(g_rdtsc_instr_info_arr[RDTSC_FLOW_RECEIVEFROM_TO_SENDTO]);
 #endif //RDTSC_MEASURE_RECEIVEFROM_TO_SENDTO
-#endif // DEFINED_VMAPOLL
 	return ret_val;
 }
 
@@ -1569,7 +1567,6 @@ extern "C"
 ssize_t sendto(int __fd, __const void *__buf, size_t __nbytes, int __flags,
 	       const struct sockaddr *__to, socklen_t __tolen)
 {
-#ifdef DEFINED_VMAPOLL	
 #ifdef RDTSC_MEASURE_TX_SENDTO_TO_AFTER_POST_SEND
 	RDTSC_TAKE_START(g_rdtsc_instr_info_arr[RDTSC_FLOW_SENDTO_TO_AFTER_POST_SEND]);
 #endif //RDTSC_MEASURE_TX_SENDTO_TO_AFTER_POST_SEND
@@ -1577,7 +1574,6 @@ ssize_t sendto(int __fd, __const void *__buf, size_t __nbytes, int __flags,
 #ifdef RDTSC_MEASURE_RECEIVEFROM_TO_SENDTO
 	RDTSC_TAKE_END(g_rdtsc_instr_info_arr[RDTSC_FLOW_RECEIVEFROM_TO_SENDTO]);
 #endif //RDTSC_MEASURE_TX_SENDTO_TO_AFTER_POST_SEND
-#endif // DEFINED_VMAPOLL
 	srdr_logfuncall_entry("fd=%d, nbytes=%d", __fd, __nbytes);
 
 	socket_fd_api* p_socket_object = NULL;

--- a/src/vma/sock/socket_fd_api.cpp
+++ b/src/vma/sock/socket_fd_api.cpp
@@ -342,13 +342,11 @@ int socket_fd_api::free_packets(struct vma_packet_t *pkts, size_t count)
 	return -1;
 }
 
-#ifdef DEFINED_VMAPOLL 
 int socket_fd_api::free_buffs(uint16_t len)
 {
 	NOT_IN_USE(len);
 	return -1;
 }
-#endif // DEFINED_VMAPOLL 
 
 #if _BullseyeCoverage
     #pragma BullseyeCoverage on

--- a/src/vma/sock/socket_fd_api.h
+++ b/src/vma/sock/socket_fd_api.h
@@ -193,9 +193,8 @@ public:
 	
 	virtual int free_packets(struct vma_packet_t *pkts, size_t count);
 
-#ifdef DEFINED_VMAPOLL
+	/* This function is used for socketxtreme mode */
 	virtual	int free_buffs(uint16_t len);
-#endif // DEFINED_VMAPOLL	
 
 	virtual int get_fd( ) const { return m_fd; };
 

--- a/src/vma/sock/sockinfo.cpp
+++ b/src/vma/sock/sockinfo.cpp
@@ -86,9 +86,7 @@ sockinfo::sockinfo(int fd):
 		m_rx_callback(NULL),
 		m_rx_callback_context(NULL),
 		m_so_ratelimit(0)
-#ifdef DEFINED_VMAPOLL
 		, m_fd_context((void *)((uintptr_t)m_fd))
-#endif // DEFINED_VMAPOLL
 		, m_flow_tag_id(0)
 		, m_flow_tag_enabled(false)
 		, m_tcp_flow_is_5t(false)
@@ -233,7 +231,6 @@ int sockinfo::ioctl(unsigned long int __request, unsigned long int __arg)
 	return orig_os_api.ioctl(m_fd, __request, __arg);
 }
 
-#ifdef DEFINED_VMAPOLL 
 int sockinfo::setsockopt(int __level, int __optname, const void *__optval, socklen_t __optlen)
 {
 	int ret = -1;
@@ -255,7 +252,6 @@ int sockinfo::setsockopt(int __level, int __optname, const void *__optval, sockl
 
 	return ret;
 }
-#endif // DEFINED_VMAPOLL
 
 int sockinfo::getsockopt(int __level, int __optname, void *__optval, socklen_t *__optlen)
 {
@@ -264,7 +260,6 @@ int sockinfo::getsockopt(int __level, int __optname, void *__optval, socklen_t *
 	switch (__level) {
 	case SOL_SOCKET:
 		switch(__optname) {
-#ifdef DEFINED_VMAPOLL
 		case SO_VMA_USER_DATA:
 			if (*__optlen == sizeof(m_fd_context)) {
 				*(void **)__optval = m_fd_context;
@@ -273,7 +268,6 @@ int sockinfo::getsockopt(int __level, int __optname, void *__optval, socklen_t *
 				errno = EINVAL;
 			}
 		break;
-#endif // DEFINED_VMAPOLL
 
 		case SO_MAX_PACING_RATE:
 			if (*__optlen >= sizeof(int)) {
@@ -1212,14 +1206,6 @@ int sockinfo::modify_ratelimit(dst_entry* p_dst_entry, const uint32_t rate_limit
 		   "socket.");
 	return -1;
 }
-
-#ifdef DEFINED_VMAPOLL
-int sockinfo::fast_nonblocking_rx(vma_packets_t *vma_pkts)
-{
-	NOT_IN_USE(vma_pkts);
-	return 0;
-}
-#endif // DEFINED_VMAPOLL
 
 int sockinfo::get_rings_num()
 {

--- a/src/vma/sock/sockinfo.cpp
+++ b/src/vma/sock/sockinfo.cpp
@@ -100,11 +100,9 @@ sockinfo::sockinfo(int fd):
 	m_p_socket_stats->b_blocking = m_b_blocking;
 	m_rx_reuse_buff.n_buff_num = 0;
 
-#ifdef DEFINED_VMAPOLL 
-	m_ec.clear();
-	m_vma_poll_completion = NULL;
-	m_vma_poll_last_buff_lst = NULL;
-#endif // DEFINED_VMAPOLL 
+	xtreme.m_ec.clear();
+	xtreme.m_vma_poll_completion = NULL;
+	xtreme.m_vma_poll_last_buff_lst = NULL;
 }
 
 sockinfo::~sockinfo()
@@ -1007,14 +1005,12 @@ void sockinfo::rx_del_ring_cb(flow_tuple_with_local_if &flow_key, ring* p_ring, 
 				if (m_rx_ring_map.size() == 1) {
 					m_p_rx_ring = m_rx_ring_map.begin()->first;
 				} else {
-#ifdef DEFINED_VMAPOLL
 					/* Remove event from rx ring if it is active
 					 * or just reinitialize
 					 * ring should not have events related closed socket
 					 * in wait list
 					 */
-					m_p_rx_ring->del_ec(&m_ec);
-#endif // DEFINED_VMAPOLL					
+					m_p_rx_ring->del_ec(&xtreme.m_ec);
 					m_p_rx_ring = NULL;
 				}
 

--- a/src/vma/sock/sockinfo.cpp
+++ b/src/vma/sock/sockinfo.cpp
@@ -58,14 +58,6 @@
 #define si_logfunc		__log_info_func
 #define si_logfuncall		__log_info_funcall
 
-#ifndef DEFINED_VMAPOLL // if not defined
-const char * const in_protocol_str[] = {
-  "PROTO_UNDEFINED",
-  "PROTO_UDP",
-  "PROTO_TCP",
-  "PROTO_ALL",
-};
-#endif // DEFINED_VMAPOLL
 
 sockinfo::sockinfo(int fd):
 		socket_fd_api(fd),
@@ -823,6 +815,12 @@ void sockinfo::remove_epoll_context(epfd_info *epfd)
 #ifndef DEFINED_VMAPOLL // if not defined
 void sockinfo::statistics_print(vlog_levels_t log_level /* = VLOG_DEBUG */)
 {
+	const char * const in_protocol_str[] = {
+	  "PROTO_UNDEFINED",
+	  "PROTO_UDP",
+	  "PROTO_TCP",
+	  "PROTO_ALL",
+	};
 	bool b_any_activity = false;
 
 	socket_fd_api::statistics_print(log_level);

--- a/src/vma/sock/sockinfo.cpp
+++ b/src/vma/sock/sockinfo.cpp
@@ -474,10 +474,6 @@ bool sockinfo::attach_receiver(flow_tuple_with_local_if &flow_key)
 
 	// Map flow in local map
 	m_rx_flow_map[flow_key] = p_nd_resources->p_ring;
-#ifndef DEFINED_VMAPOLL // is not defined
-		// Save the new CQ from ring
-		rx_add_ring_cb(flow_key, p_nd_resources->p_ring);
-#endif // DEFINED_VMAPOLL
 
 	// Attach tuple
 	BULLSEYE_EXCLUDE_BLOCK_START
@@ -535,9 +531,6 @@ bool sockinfo::detach_receiver(flow_tuple_with_local_if &flow_key)
 	lock_rx_q();
 
 	// Un-map flow from local map
-#ifndef DEFINED_VMAPOLL // is not defined
-	rx_del_ring_cb(flow_key, p_ring);
-#endif // DEFINED_VMAPOLL
 	m_rx_flow_map.erase(rx_flow_iter);
 
 	return destroy_nd_resources((const ip_address)flow_key.get_local_if());
@@ -609,13 +602,12 @@ net_device_resources_t* sockinfo::create_nd_resources(const ip_address ip_local)
 	/* just increment reference counter on attach */
 	p_nd_resources->refcnt++;
 
-#ifdef DEFINED_VMAPOLL
-	// Save the new CQ from ring (dummy_flow_key is not used)
+	/* Save the new CQ from ring (dummy_flow_key is not used) */
 	{
 		flow_tuple_with_local_if dummy_flow_key(m_bound, m_connected, m_protocol, ip_local.get_in_addr());
 		rx_add_ring_cb(dummy_flow_key, p_nd_resources->p_ring);
 	}
-#endif // DEFINED_VMAPOLL
+
 	return p_nd_resources;
 err:
 	return NULL;
@@ -636,11 +628,11 @@ bool sockinfo::destroy_nd_resources(const ip_address ip_local)
 
 	p_nd_resources->refcnt--;
 
-#ifdef DEFINED_VMAPOLL
-		// Release the new CQ from ring (dummy_flow_key is not used)
+	/* Release the new CQ from ring (dummy_flow_key is not used) */
+	{
 		flow_tuple_with_local_if dummy_flow_key(m_bound, m_connected, m_protocol, ip_local.get_in_addr());
 		rx_del_ring_cb(dummy_flow_key, p_nd_resources->p_ring);
-#endif // DEFINED_VMAPOLL
+	}
 
 	if (p_nd_resources->refcnt == 0) {
 
@@ -915,7 +907,7 @@ void sockinfo::rx_add_ring_cb(flow_tuple_with_local_if &flow_key, ring* p_ring, 
 		m_rx_ring_map[p_ring] = p_ring_info;
 		p_ring_info->refcnt = 1;
 		p_ring_info->rx_reuse_info.n_buff_num = 0;
-#ifdef DEFINED_VMAPOLL
+
 		/* m_p_rx_ring is updated in following functions:
 		 *  - rx_add_ring_cb()
 		 *  - rx_del_ring_cb()
@@ -924,7 +916,7 @@ void sockinfo::rx_add_ring_cb(flow_tuple_with_local_if &flow_key, ring* p_ring, 
 		if (m_rx_ring_map.size() == 1) {
 			m_p_rx_ring = m_rx_ring_map.begin()->first;
 		}
-#endif
+
 		notify_epoll = true;
 
 		// Add this new CQ channel fd to the rx epfd handle (no need to wake up any sleeping thread about this new fd)
@@ -1182,12 +1174,10 @@ void sockinfo::destructor_helper()
 		rx_flow_iter = m_rx_flow_map.begin(); // Pop next flow rule
 	}
 
-#ifdef DEFINED_VMAPOLL
 	/* Destroy resources in case they are allocated using SO_BINDTODEVICE call */
 	if (m_rx_nd_map.size()) {
 		destroy_nd_resources(m_so_bindtodevice_ip);
 	}
-#endif // DEFINED_VMAPOLL
 
 	// Delete all dst_entry in our list
 	if (m_p_connected_dst_entry)

--- a/src/vma/sock/sockinfo.h
+++ b/src/vma/sock/sockinfo.h
@@ -136,9 +136,7 @@ public:
 	virtual int get_rings_num();
 	virtual bool check_rings() {return m_p_rx_ring ? true: false;}
 
-#ifdef DEFINED_VMAPOLL
-	virtual int fast_nonblocking_rx(vma_packets_t *vma_pkts);
-#else
+#ifndef DEFINED_VMAPOLL
 	virtual void statistics_print(vlog_levels_t log_level = VLOG_DEBUG);	
 #endif // DEFINED_VMAPOLL	
 protected:
@@ -201,9 +199,7 @@ protected:
 	vma_recv_callback_t	m_rx_callback;
 	void*			m_rx_callback_context; // user context
 	uint32_t		m_so_ratelimit;
-#ifdef DEFINED_VMAPOLL	
-	void*			m_fd_context;
-#endif // DEFINED_VMAPOLL	
+	void*			m_fd_context; // Context data stored with socket
 	uint32_t		m_flow_tag_id;	// Flow Tag for this socket
 	bool			m_flow_tag_enabled; // for this socket
 	bool			m_tcp_flow_is_5t; // to bypass packet analysis
@@ -212,9 +208,7 @@ protected:
 	virtual void 		set_blocking(bool is_blocked);
 	virtual int 		fcntl(int __cmd, unsigned long int __arg);
 	virtual int 		ioctl(unsigned long int __request, unsigned long int __arg);
-#ifdef DEFINED_VMAPOLL	
 	virtual int setsockopt(int __level, int __optname, const void *__optval, socklen_t __optlen);
-#endif // DEFINED_VMAPOLL	
 	virtual int getsockopt(int __level, int __optname, void *__optval, socklen_t *__optlen);
 
 	virtual	mem_buf_desc_t* get_front_m_rx_pkt_ready_list() = 0;

--- a/src/vma/sock/sockinfo.h
+++ b/src/vma/sock/sockinfo.h
@@ -276,6 +276,7 @@ protected:
 
 	inline void set_events(uint64_t events)
 	{
+#ifdef DEFINED_VMAPOLL
 		/* Collect all events if rx ring is enabled */
 		if (m_p_rx_ring) {
 			if (xtreme.m_vma_poll_completion) {
@@ -296,6 +297,9 @@ protected:
 		if ((uint32_t)events) {
 			socket_fd_api::notify_epoll_context((uint32_t)events);
 		}
+#else
+		socket_fd_api::notify_epoll_context((uint32_t)events);
+#endif /* DEFINED_VMAPOLL */
 	}
 
 	inline uint64_t get_events(void)

--- a/src/vma/sock/sockinfo.h
+++ b/src/vma/sock/sockinfo.h
@@ -138,9 +138,7 @@ public:
 	virtual int get_rings_num();
 	virtual bool check_rings() {return m_p_rx_ring ? true: false;}
 
-#ifndef DEFINED_VMAPOLL
 	virtual void statistics_print(vlog_levels_t log_level = VLOG_DEBUG);	
-#endif // DEFINED_VMAPOLL	
 protected:
 	bool			m_b_closed;
 	bool 			m_b_blocking;

--- a/src/vma/sock/sockinfo.h
+++ b/src/vma/sock/sockinfo.h
@@ -186,14 +186,14 @@ protected:
 	ring_alloc_logic_attr			m_ring_alloc_log_rx;
 	ring_alloc_logic_attr			m_ring_alloc_log_tx;
 
-#ifdef DEFINED_VMAPOLL
-	/* Track internal events to return in vma_poll()
+	/* Track internal events to return in socketxtreme()
 	 * Current design support single event for socket at a particular time
 	 */
-	struct ring_ec m_ec;
-	struct vma_completion_t* m_vma_poll_completion;
-	struct vma_buff_t*       m_vma_poll_last_buff_lst;
-#endif // DEFINED_VMAPOLL
+	struct {
+		struct ring_ec m_ec;
+		struct vma_completion_t* m_vma_poll_completion;
+		struct vma_buff_t*       m_vma_poll_last_buff_lst;
+	} xtreme;
 
 	// Callback function pointer to support VMA extra API (vma_extra.h)
 	vma_recv_callback_t	m_rx_callback;
@@ -260,36 +260,36 @@ protected:
 	void 			move_owned_rx_ready_descs(const mem_buf_desc_owner* p_desc_owner, descq_t* toq); // Move all owner's rx ready packets ro 'toq'
 
 	virtual bool try_un_offloading(); // un-offload the socket if possible
-#ifdef DEFINED_VMAPOLL	
+
 	virtual inline void do_wakeup()
 	{
 		/* TODO: Let consider if we really need this check */
-		if (!check_vma_active()) {
+		if (!check_xtreme_active()) {
 			wakeup_pipe::do_wakeup();
 		}
 	}
 
-	inline bool check_vma_active(void)
+	inline bool check_xtreme_active(void)
 	{
-		return (m_p_rx_ring && m_p_rx_ring->get_vma_active());
+		return (m_p_rx_ring && m_p_rx_ring->get_xtreme_active());
 	}
 
 	inline void set_events(uint64_t events)
 	{
 		/* Collect all events if rx ring is enabled */
 		if (m_p_rx_ring) {
-			if (m_vma_poll_completion) {
-				if (!m_vma_poll_completion->events) {
-					m_vma_poll_completion->user_data = (uint64_t)m_fd_context;
+			if (xtreme.m_vma_poll_completion) {
+				if (!xtreme.m_vma_poll_completion->events) {
+					xtreme.m_vma_poll_completion->user_data = (uint64_t)m_fd_context;
 				}
-				m_vma_poll_completion->events |= events;
+				xtreme.m_vma_poll_completion->events |= events;
 			}
 			else {
-				if (!m_ec.completion.events) {
-					m_ec.completion.user_data = (uint64_t)m_fd_context;
-					m_p_rx_ring->put_ec(&m_ec);
+				if (!xtreme.m_ec.completion.events) {
+					xtreme.m_ec.completion.user_data = (uint64_t)m_fd_context;
+					m_p_rx_ring->put_ec(&xtreme.m_ec);
 				}
-				m_ec.completion.events |= events;
+				xtreme.m_ec.completion.events |= events;
 			}
 		}
 
@@ -300,14 +300,13 @@ protected:
 
 	inline uint64_t get_events(void)
 	{
-		return m_ec.completion.events;
+		return xtreme.m_ec.completion.events;
 	}
 
 	inline void clear_events(void)
 	{
-		m_ec.completion.events = 0;
+		xtreme.m_ec.completion.events = 0;
 	}
-#endif // DEFINED_VMAPOLL	
 
 	// This function validates the ipoib's properties
 	// Input params:
@@ -533,7 +532,7 @@ protected:
 #ifdef DEFINED_VMAPOLL
 #define NOTIFY_ON_EVENTS(context, events) context->set_events(events)
 #else
-#define NOTIFY_ON_EVENTS(context, events) context->notify_epoll_context(events)
+#define NOTIFY_ON_EVENTS(context, events) context->notify_epoll_context((uint32_t)events)
 #endif // DEFINED_VMAPOLL
 
 #endif /* BASE_SOCKINFO_H */

--- a/src/vma/sock/sockinfo.h
+++ b/src/vma/sock/sockinfo.h
@@ -60,6 +60,8 @@
 #define BYTE_TO_KB(BYTEVALUE)		(((BYTEVALUE) * 8) / 1000)
 #define KB_TO_BYTE(BYTEVALUE)		(((BYTEVALUE) * 1000) / 8)
 
+#define NOTIFY_ON_EVENTS(context, events) context->set_events(events)
+
 struct buff_info_t {
 		buff_info_t(){
 			rx_reuse.set_id("buff_info_t (%p) : rx_reuse", this);
@@ -528,11 +530,5 @@ protected:
     }
     //////////////////////////////////////////////////////////////////
 };
-
-#ifdef DEFINED_VMAPOLL
-#define NOTIFY_ON_EVENTS(context, events) context->set_events(events)
-#else
-#define NOTIFY_ON_EVENTS(context, events) context->notify_epoll_context((uint32_t)events)
-#endif // DEFINED_VMAPOLL
 
 #endif /* BASE_SOCKINFO_H */

--- a/src/vma/sock/sockinfo.h
+++ b/src/vma/sock/sockinfo.h
@@ -134,13 +134,7 @@ public:
 	virtual bool addr_in_reuse(void) = 0;
 	virtual int* get_rings_fds(int &res_length);
 	virtual int get_rings_num();
-#ifdef DEFINED_VMAPOLL
-
 	virtual bool check_rings() {return m_p_rx_ring ? true: false;}
-#else
-	virtual bool check_rings() {return true;}
-#endif
-
 
 #ifdef DEFINED_VMAPOLL
 	virtual int fast_nonblocking_rx(vma_packets_t *vma_pkts);

--- a/src/vma/sock/sockinfo_tcp.cpp
+++ b/src/vma/sock/sockinfo_tcp.cpp
@@ -3440,14 +3440,12 @@ int sockinfo_tcp::setsockopt(int __level, int __optname,
 	bool supported = true;
 	bool allow_privileged_sock_opt = false;
 
-#ifdef DEFINED_VMAPOLL
 	/* Process VMA specific options only at the moment
 	 * VMA option does not require additional processing after return
 	 */
 	if (0 == sockinfo::setsockopt(__level, __optname, __optval, __optlen)) {
 		return 0;
 	}
-#endif // DEFINED_VMAPOLL
 
 	if (__level == IPPROTO_TCP) {
 		switch(__optname) {
@@ -3552,7 +3550,6 @@ int sockinfo_tcp::setsockopt(int __level, int __optname,
 			} else {
 				m_so_bindtodevice_ip = sockaddr.sin_addr.s_addr;
 
-#ifdef DEFINED_VMAPOLL
 				if (!is_connected()) {
 					/* Current implementation allows to create separate rings for tx and rx.
 					 * tx ring is created basing on destination ip during connect() call,
@@ -3563,7 +3560,7 @@ int sockinfo_tcp::setsockopt(int __level, int __optname,
 					 * (!m_bound.is_anyaddr() && !m_bound.is_local_loopback())
 					 * and can not detect offload/non-offload socket
 					 * Note:
-					 * This inconsistence should be resolved.
+					 * This inconsistency should be resolved.
 					 */
 					ip_address local_ip(m_so_bindtodevice_ip);
 
@@ -3576,7 +3573,6 @@ int sockinfo_tcp::setsockopt(int __level, int __optname,
 					}
 					unlock_tcp_con();
 				}
-#endif // DEFINED_VMAPOLL				
 			}
 			// handle TX side
 			if (m_p_connected_dst_entry) {
@@ -3660,14 +3656,12 @@ int sockinfo_tcp::getsockopt_offload(int __level, int __optname, void *__optval,
 		return ret;
 	}
 	
-#ifdef DEFINED_VMAPOLL
 	/* Process VMA specific options only at the moment
 	 * VMA option does not require additional processing after return
 	 */
 	if (0 == sockinfo::getsockopt(__level, __optname, __optval, __optlen)) {
 		return 0;
 	}
-#endif // DEFINED_VMAPOLL	
 
 	if (__level == IPPROTO_TCP) {
 		switch(__optname) {

--- a/src/vma/sock/sockinfo_tcp.cpp
+++ b/src/vma/sock/sockinfo_tcp.cpp
@@ -1898,7 +1898,6 @@ bool sockinfo_tcp::rx_input_cb(mem_buf_desc_t* p_rx_pkt_mem_buf_desc_info, void*
 	}
 
 	sock->m_vma_thr = p_rx_pkt_mem_buf_desc_info->rx.is_vma_thr;
-#ifdef DEFINED_VMAPOLL	
 #ifdef RDTSC_MEASURE_RX_READY_POLL_TO_LWIP
 	RDTSC_TAKE_END(g_rdtsc_instr_info_arr[RDTSC_FLOW_RX_READY_POLL_TO_LWIP]);
 #endif //RDTSC_MEASURE_RX_READY_POLL_TO_LWIP
@@ -1906,10 +1905,8 @@ bool sockinfo_tcp::rx_input_cb(mem_buf_desc_t* p_rx_pkt_mem_buf_desc_info, void*
 #ifdef RDTSC_MEASURE_RX_LWIP
 	RDTSC_TAKE_START(g_rdtsc_instr_info_arr[RDTSC_FLOW_MEASURE_RX_LWIP]);
 #endif //RDTSC_MEASURE_RX_LWIP
-#endif // DEFINED_VMAPOLL	
 	L3_level_tcp_input((pbuf *)p_rx_pkt_mem_buf_desc_info, pcb);
 
-#ifdef DEFINED_VMAPOLL	
 #ifdef RDTSC_MEASURE_RX_LWIP
 	RDTSC_TAKE_END(g_rdtsc_instr_info_arr[RDTSC_FLOW_MEASURE_RX_LWIP]);
 #endif //RDTSC_MEASURE_RX_LWIP
@@ -1917,7 +1914,6 @@ bool sockinfo_tcp::rx_input_cb(mem_buf_desc_t* p_rx_pkt_mem_buf_desc_info, void*
 #ifdef RDTSC_MEASURE_RX_LWIP_TO_RECEVEFROM
 	RDTSC_TAKE_START(g_rdtsc_instr_info_arr[RDTSC_FLOW_RX_LWIP_TO_RECEVEFROM]);
 #endif //RDTSC_MEASURE_RX_LWIP_TO_RECEVEFROM
-#endif // DEFINED_VMAPOLL	
 	sock->m_vma_thr = false;
 
 	if (sock != this) {

--- a/src/vma/sock/sockinfo_tcp.cpp
+++ b/src/vma/sock/sockinfo_tcp.cpp
@@ -1513,9 +1513,7 @@ err_t sockinfo_tcp::rx_lwip_cb(void *arg, struct tcp_pcb *pcb,
 	conn->m_connected.get_sa(p_first_desc->rx.src);
 
 	while (p_curr_buff) {
-#ifdef DEFINED_VMAPOLL		
 		p_curr_desc->rx.context = conn;
-#endif // DEFINED_VMAPOLL				
 		p_first_desc->rx.n_frags++;
 		p_curr_desc->rx.frag.iov_base = p_curr_buff->payload;
 		p_curr_desc->rx.frag.iov_len = p_curr_buff->len;
@@ -1601,7 +1599,7 @@ err_t sockinfo_tcp::rx_lwip_cb(void *arg, struct tcp_pcb *pcb,
 			}
 			// notify io_mux
 			NOTIFY_ON_EVENTS(conn, EPOLLIN);
-		}				
+		}
 		io_mux_call::update_fd_array(conn->m_iomux_ready_fd_array, conn->m_fd);
 
 		if (callback_retval != VMA_PACKET_HOLD) {
@@ -1610,8 +1608,8 @@ err_t sockinfo_tcp::rx_lwip_cb(void *arg, struct tcp_pcb *pcb,
 		} else {
 			conn->m_p_socket_stats->n_rx_zcopy_pkt_count++;
 		}
-	}	
-	
+	}
+
 	/*
 	* RCVBUFF Accounting: tcp_recved here(stream into the 'internal' buffer) only if the user buffer is not 'filled'
 	*/

--- a/src/vma/sock/sockinfo_tcp.cpp
+++ b/src/vma/sock/sockinfo_tcp.cpp
@@ -1457,9 +1457,8 @@ err_t sockinfo_tcp::rx_lwip_cb(void *arg, struct tcp_pcb *pcb,
 
 		NOTIFY_ON_EVENTS(conn, EPOLLIN|EPOLLRDHUP);
 				
-		/* VMAPOLL comment:
-		 * Add this fd to the ready fd list
-		 * Note: No issue is expected in case vma_poll() usage because 'pv_fd_ready_array' is null
+		/* Add this fd to the ready fd list
+		 * Note: No issue is expected in case socketXtreme mode because 'pv_fd_ready_array' is null
 		 * in such case and as a result update_fd_array() call means nothing
 		 */
 		io_mux_call::update_fd_array(conn->m_iomux_ready_fd_array, conn->m_fd);
@@ -1560,52 +1559,53 @@ err_t sockinfo_tcp::rx_lwip_cb(void *arg, struct tcp_pcb *pcb,
 	// In ZERO COPY case we let the user's application manage the ready queue
 	}
 	else {
-#ifdef DEFINED_VMAPOLL
-		/* Update vma_completion with
-		 * VMA_POLL_PACKET related data
-		 */
-		struct vma_completion_t *completion;
-		struct vma_buff_t *buf_lst;
+		if (conn->check_xtreme_active()) {
+			/* Update vma_completion with
+			 * VMA_POLL_PACKET related data
+			 */
+			struct vma_completion_t *completion;
+			struct vma_buff_t *buf_lst;
 
-		if (conn->m_vma_poll_completion) {
-			completion = conn->m_vma_poll_completion;
-			buf_lst = conn->m_vma_poll_last_buff_lst;
-		} else {
-			completion = &conn->m_ec.completion;
-			buf_lst = conn->m_ec.last_buff_lst;
-		}
+			if (conn->xtreme.m_vma_poll_completion) {
+				completion = conn->xtreme.m_vma_poll_completion;
+				buf_lst = conn->xtreme.m_vma_poll_last_buff_lst;
+			} else {
+				completion = &conn->xtreme.m_ec.completion;
+				buf_lst = conn->xtreme.m_ec.last_buff_lst;
+			}
 
-		if (!buf_lst) {
-			completion->packet.buff_lst = (struct vma_buff_t*)p_first_desc;
-			completion->packet.total_len = p->tot_len;
-			completion->src = p_first_desc->rx.src;
-			completion->packet.num_bufs = p_first_desc->rx.n_frags;
-			NOTIFY_ON_EVENTS(conn, VMA_POLL_PACKET);
+			if (!buf_lst) {
+				completion->packet.buff_lst = (struct vma_buff_t*)p_first_desc;
+				completion->packet.total_len = p->tot_len;
+				completion->src = p_first_desc->rx.src;
+				completion->packet.num_bufs = p_first_desc->rx.n_frags;
+				NOTIFY_ON_EVENTS(conn, VMA_POLL_PACKET);
+			}
+			else {
+				mem_buf_desc_t* prev_lst_tail_desc = (mem_buf_desc_t*)buf_lst;
+				mem_buf_desc_t* list_head_desc = (mem_buf_desc_t*)completion->packet.buff_lst;
+				prev_lst_tail_desc->p_next_desc = p_first_desc;
+				list_head_desc->rx.n_frags += p_first_desc->rx.n_frags;
+				p_first_desc->rx.n_frags = 0;
+				completion->packet.total_len += p->tot_len;
+				completion->packet.num_bufs += list_head_desc->rx.n_frags;
+				pbuf_cat((pbuf*)completion->packet.buff_lst, p);
+			}
 		}
 		else {
-			mem_buf_desc_t* prev_lst_tail_desc = (mem_buf_desc_t*)buf_lst;
-			mem_buf_desc_t* list_head_desc = (mem_buf_desc_t*)completion->packet.buff_lst;
-			prev_lst_tail_desc->p_next_desc = p_first_desc;
-			list_head_desc->rx.n_frags += p_first_desc->rx.n_frags;
-			p_first_desc->rx.n_frags = 0;
-			completion->packet.total_len += p->tot_len;
-			completion->packet.num_bufs += list_head_desc->rx.n_frags;
-			pbuf_cat((pbuf*)completion->packet.buff_lst, p);
-		}
-#else
-		if (callback_retval == VMA_PACKET_RECV) {
-			// Save rx packet info in our ready list
-			conn->m_rx_pkt_ready_list.push_back(p_first_desc);
-			conn->m_n_rx_pkt_ready_list_count++;
-			conn->m_rx_ready_byte_count += p->tot_len;
-			conn->m_p_socket_stats->n_rx_ready_byte_count += p->tot_len;
-			conn->m_p_socket_stats->n_rx_ready_pkt_count++;
-			conn->m_p_socket_stats->counters.n_rx_ready_pkt_max = max((uint32_t)conn->m_p_socket_stats->n_rx_ready_pkt_count, conn->m_p_socket_stats->counters.n_rx_ready_pkt_max);
-			conn->m_p_socket_stats->counters.n_rx_ready_byte_max = max((uint32_t)conn->m_p_socket_stats->n_rx_ready_byte_count, conn->m_p_socket_stats->counters.n_rx_ready_byte_max);
-		}
-		// notify io_mux
-		NOTIFY_ON_EVENTS(conn, EPOLLIN);
-#endif // DEFINED_VMAPOLL				
+			if (callback_retval == VMA_PACKET_RECV) {
+				// Save rx packet info in our ready list
+				conn->m_rx_pkt_ready_list.push_back(p_first_desc);
+				conn->m_n_rx_pkt_ready_list_count++;
+				conn->m_rx_ready_byte_count += p->tot_len;
+				conn->m_p_socket_stats->n_rx_ready_byte_count += p->tot_len;
+				conn->m_p_socket_stats->n_rx_ready_pkt_count++;
+				conn->m_p_socket_stats->counters.n_rx_ready_pkt_max = max((uint32_t)conn->m_p_socket_stats->n_rx_ready_pkt_count, conn->m_p_socket_stats->counters.n_rx_ready_pkt_max);
+				conn->m_p_socket_stats->counters.n_rx_ready_byte_max = max((uint32_t)conn->m_p_socket_stats->n_rx_ready_byte_count, conn->m_p_socket_stats->counters.n_rx_ready_byte_max);
+			}
+			// notify io_mux
+			NOTIFY_ON_EVENTS(conn, EPOLLIN);
+		}				
 		io_mux_call::update_fd_array(conn->m_iomux_ready_fd_array, conn->m_fd);
 
 		if (callback_retval != VMA_PACKET_HOLD) {
@@ -1832,13 +1832,11 @@ bool sockinfo_tcp::rx_input_cb(mem_buf_desc_t* p_rx_pkt_mem_buf_desc_info, void*
 
 	m_iomux_ready_fd_array = (fd_array_t*)pv_fd_ready_array;
 
-#ifdef DEFINED_VMAPOLL
 	/* Try to process vma_poll() completion directly */
 	if (p_rx_pkt_mem_buf_desc_info->rx.vma_polled) {
-		m_vma_poll_completion = m_p_rx_ring->get_comp();
-		m_vma_poll_last_buff_lst = NULL;
+		xtreme.m_vma_poll_completion = m_p_rx_ring->get_comp();
+		xtreme.m_vma_poll_last_buff_lst = NULL;
 	}
-#endif // DEFINED_VMAPOLL
 
 	if (unlikely(get_tcp_state(&m_pcb) == LISTEN)) {
 		pcb = get_syn_received_pcb(p_rx_pkt_mem_buf_desc_info->rx.src.sin_addr.s_addr,
@@ -1866,20 +1864,20 @@ bool sockinfo_tcp::rx_input_cb(mem_buf_desc_t* p_rx_pkt_mem_buf_desc_info, void*
 				// TODO: consider check if we can now drain into Q of established
 				si_tcp_logdbg("SYN/CTL packet drop. established-backlog=%d (limit=%d) num_con_waiting=%d (limit=%d)",
 						(int)m_syn_received.size(), m_backlog, num_con_waiting, MAX_SYN_RCVD);
-#ifdef DEFINED_VMAPOLL
-				m_vma_poll_completion = NULL;
-				m_vma_poll_last_buff_lst = NULL;
-#endif // DEFINED_VMAPOLL
+
+				xtreme.m_vma_poll_completion = NULL;
+				xtreme.m_vma_poll_last_buff_lst = NULL;
+
 				unlock_tcp_con();
 				return false;// return without inc_ref_count() => packet will be dropped
 			}
 		}
 		if (m_sysvar_tcp_ctl_thread > CTL_THREAD_DISABLE || established_backlog_full) { /* 2nd check only worth when MAX_SYN_RCVD>0 for non tcp_ctl_thread  */
 			queue_rx_ctl_packet(pcb, p_rx_pkt_mem_buf_desc_info); // TODO: need to trigger queue pulling from accept in case no tcp_ctl_thread
-#ifdef DEFINED_VMAPOLL
-			m_vma_poll_completion = NULL;
-			m_vma_poll_last_buff_lst = NULL;
-#endif // DEFINED_VMAPOLL
+
+			xtreme.m_vma_poll_completion = NULL;
+			xtreme.m_vma_poll_last_buff_lst = NULL;
+
 			unlock_tcp_con();
 			return true;
 		}
@@ -1923,21 +1921,17 @@ bool sockinfo_tcp::rx_input_cb(mem_buf_desc_t* p_rx_pkt_mem_buf_desc_info, void*
 	sock->m_vma_thr = false;
 
 	if (sock != this) {
-#ifdef DEFINED_VMAPOLL		
-		if (unlikely(sock->m_vma_poll_completion)) {
-			sock->m_vma_poll_completion = NULL;
-			sock->m_vma_poll_last_buff_lst = NULL;
+		if (unlikely(sock->xtreme.m_vma_poll_completion)) {
+			sock->xtreme.m_vma_poll_completion = NULL;
+			sock->xtreme.m_vma_poll_last_buff_lst = NULL;
 		}
-#endif // DEFINED_VMAPOLL			
 		sock->m_tcp_con_lock.unlock();
 	}
 
 	m_iomux_ready_fd_array = NULL;
-#ifdef DEFINED_VMAPOLL		
-	m_vma_poll_completion = NULL;
-	m_vma_poll_last_buff_lst = NULL;
+	xtreme.m_vma_poll_completion = NULL;
+	xtreme.m_vma_poll_last_buff_lst = NULL;
 	p_rx_pkt_mem_buf_desc_info->rx.vma_polled = false;
-#endif // DEFINED_VMAPOLL			
 
 	while (dropped_count--) {
 		mem_buf_desc_t* p_rx_pkt_desc = m_rx_cb_dropped_list.get_and_pop_front();
@@ -2623,22 +2617,22 @@ void sockinfo_tcp::auto_accept_connection(sockinfo_tcp *parent, sockinfo_tcp *ch
 	child->m_p_socket_stats->connected_port = child->m_connected.get_in_port();
 	child->m_p_socket_stats->bound_if = child->m_bound.get_in_addr();
 	child->m_p_socket_stats->bound_port = child->m_bound.get_in_port();
-	if (child->m_vma_poll_completion) {
-		child->m_connected.get_sa(parent->m_vma_poll_completion->src);
+	if (child->xtreme.m_vma_poll_completion) {
+		child->m_connected.get_sa(parent->xtreme.m_vma_poll_completion->src);
 	} else {
-		child->m_connected.get_sa(parent->m_ec.completion.src);
+		child->m_connected.get_sa(parent->xtreme.m_ec.completion.src);
 	}
 
 	/* Update vma_completion with
 	 * VMA_POLL_NEW_CONNECTION_ACCEPTED related data
 	 */
 	if (likely(child->m_parent)) {
-		if (child->m_vma_poll_completion) {
-			child->m_vma_poll_completion->src = parent->m_vma_poll_completion->src;
-			child->m_vma_poll_completion->listen_fd = child->m_parent->get_fd();
+		if (child->xtreme.m_vma_poll_completion) {
+			child->xtreme.m_vma_poll_completion->src = parent->xtreme.m_vma_poll_completion->src;
+			child->xtreme.m_vma_poll_completion->listen_fd = child->m_parent->get_fd();
 		} else {
-			child->m_ec.completion.src = parent->m_ec.completion.src;
-			child->m_ec.completion.listen_fd = child->m_parent->get_fd();
+			child->xtreme.m_ec.completion.src = parent->xtreme.m_ec.completion.src;
+			child->xtreme.m_ec.completion.listen_fd = child->m_parent->get_fd();
 		}
 		child->set_events(VMA_POLL_NEW_CONNECTION_ACCEPTED);
 	}

--- a/src/vma/sock/sockinfo_tcp.cpp
+++ b/src/vma/sock/sockinfo_tcp.cpp
@@ -78,30 +78,6 @@
 tcp_seg_pool *g_tcp_seg_pool = NULL;
 tcp_timers_collection* g_tcp_timers_collection = NULL;
 
-#ifndef DEFINED_VMAPOLL // if not defined
-const char * const tcp_sock_state_str[] = {
-  "NA",
-  "TCP_SOCK_INITED",
-  "TCP_SOCK_BOUND",
-  "TCP_SOCK_LISTEN_READY",
-  "TCP_SOCK_ACCEPT_READY",
-  "TCP_SOCK_CONNECTED_RD",
-  "TCP_SOCK_CONNECTED_WR",
-  "TCP_SOCK_CONNECTED_RDWR",
-  "TCP_SOCK_ASYNC_CONNECT",
-  "TCP_SOCK_ACCEPT_SHUT",
-};
-
-const char * const tcp_conn_state_str[] = {
-  "TCP_CONN_INIT",
-  "TCP_CONN_CONNECTING",
-  "TCP_CONN_CONNECTED",
-  "TCP_CONN_FAILED",
-  "TCP_CONN_TIMEOUT",
-  "TCP_CONN_ERROR",
-  "TCP_CONN_RESETED",
-};
-#endif // DEFINED_VMAPOLL
 
 /**/
 /** inlining functions can only help if they are implemented before their usage **/
@@ -2728,10 +2704,6 @@ err_t sockinfo_tcp::accept_lwip_cb(void *arg, struct tcp_pcb *child_pcb, err_t e
 	if (new_sock->m_conn_state == TCP_CONN_INIT) { //in case m_conn_state is not in one of the error states
 		new_sock->m_conn_state = TCP_CONN_CONNECTED;
 	}
-
-#ifndef DEFINED_VMAPOLL // if not defined
-	new_sock->m_parent = NULL;
-#endif // DEFINED_VMAPOLL
 	
 	/* if attach failed, we should continue getting traffic through the listen socket */
 	// todo register as 3-tuple rule for the case the listener is gone?
@@ -2784,10 +2756,10 @@ err_t sockinfo_tcp::accept_lwip_cb(void *arg, struct tcp_pcb *child_pcb, err_t e
 
 	conn->unlock_tcp_con();
 
-	new_sock->lock_tcp_con();
-#ifdef DEFINED_VMAPOLL
+	/* Do this after auto_accept_connection() call */
 	new_sock->m_parent = NULL;
-#endif // DEFINED_VMAPOLL	
+
+	new_sock->lock_tcp_con();
 
 	return ERR_OK;
 }
@@ -4159,6 +4131,28 @@ int sockinfo_tcp::zero_copy_rx(iovec *p_iov, mem_buf_desc_t *pdesc, int *p_flags
 #ifndef DEFINED_VMAPOLL // if not defined
 void sockinfo_tcp::statistics_print(vlog_levels_t log_level /* = VLOG_DEBUG */)
 {
+	const char * const tcp_sock_state_str[] = {
+	  "NA",
+	  "TCP_SOCK_INITED",
+	  "TCP_SOCK_BOUND",
+	  "TCP_SOCK_LISTEN_READY",
+	  "TCP_SOCK_ACCEPT_READY",
+	  "TCP_SOCK_CONNECTED_RD",
+	  "TCP_SOCK_CONNECTED_WR",
+	  "TCP_SOCK_CONNECTED_RDWR",
+	  "TCP_SOCK_ASYNC_CONNECT",
+	  "TCP_SOCK_ACCEPT_SHUT",
+	};
+
+	const char * const tcp_conn_state_str[] = {
+	  "TCP_CONN_INIT",
+	  "TCP_CONN_CONNECTING",
+	  "TCP_CONN_CONNECTED",
+	  "TCP_CONN_FAILED",
+	  "TCP_CONN_TIMEOUT",
+	  "TCP_CONN_ERROR",
+	  "TCP_CONN_RESETED",
+	};
 	struct tcp_pcb pcb;
 	tcp_sock_state_e sock_state;
 	tcp_conn_state_e conn_state;
@@ -4336,13 +4330,11 @@ int sockinfo_tcp::free_packets(struct vma_packet_t *pkts, size_t count)
 	return ret;
 }
 
-#ifdef DEFINED_VMAPOLL
 int sockinfo_tcp::free_buffs(uint16_t len)
 {
 	tcp_recved(&m_pcb, len);
 	return 0;
 }
-#endif // DEFINED_VMAPOLL
 
 struct pbuf * sockinfo_tcp::tcp_tx_pbuf_alloc(void* p_conn)
 {

--- a/src/vma/sock/sockinfo_tcp.h
+++ b/src/vma/sock/sockinfo_tcp.h
@@ -134,9 +134,7 @@ public:
 	/* This function is used for socketxtreme mode */
 	virtual int free_buffs(uint16_t len);
 
-#ifndef DEFINED_VMAPOLL // if not defined
 	virtual void statistics_print(vlog_levels_t log_level = VLOG_DEBUG);	
-#endif // DEFINED_VMAPOLL	
 
 	//Returns the connected pcb, with 5 tuple which matches the input arguments,
 	//in state "SYN Received" or NULL if pcb wasn't found
@@ -313,10 +311,8 @@ private:
 	//Builds rfs key
 	static void create_flow_tuple_key_from_pcb(flow_tuple &key, struct tcp_pcb *pcb);
 
-#ifdef DEFINED_VMAPOLL
 	//auto accept function
 	static void auto_accept_connection(sockinfo_tcp *parent, sockinfo_tcp *child);
-#endif // DEFINED_VMAPOLL	
 
 	// accept cb func
 	static err_t accept_lwip_cb(void *arg, struct tcp_pcb *child_pcb, err_t err);

--- a/src/vma/sock/sockinfo_tcp.h
+++ b/src/vma/sock/sockinfo_tcp.h
@@ -130,9 +130,11 @@ public:
 	virtual int getpeername(sockaddr *__name, socklen_t *__namelen);
 
 	virtual	int	free_packets(struct vma_packet_t *pkts, size_t count);
-#ifdef DEFINED_VMAPOLL	
-	virtual	int	free_buffs(uint16_t len);
-#else
+
+	/* This function is used for socketxtreme mode */
+	virtual int free_buffs(uint16_t len);
+
+#ifndef DEFINED_VMAPOLL // if not defined
 	virtual void statistics_print(vlog_levels_t log_level = VLOG_DEBUG);	
 #endif // DEFINED_VMAPOLL	
 

--- a/src/vma/sock/sockinfo_udp.cpp
+++ b/src/vma/sock/sockinfo_udp.cpp
@@ -764,14 +764,12 @@ int sockinfo_udp::setsockopt(int __level, int __optname, __const void *__optval,
 	if (unlikely(m_b_closed) || unlikely(g_b_exit))
 		return orig_os_api.setsockopt(m_fd, __level, __optname, __optval, __optlen);
 
-#ifdef DEFINED_VMAPOLL
 	/* Process VMA specific options only at the moment
 	 * VMA option does not require additional processing after return
 	 */
 	if (0 == sockinfo::setsockopt(__level, __optname, __optval, __optlen)) {
 		return 0;
 	}
-#endif // DEFINED_VMAPOLL
 
 	auto_unlocker lock_tx(m_lock_snd);
 	auto_unlocker lock_rx(m_lock_rcv);
@@ -1283,14 +1281,12 @@ int sockinfo_udp::getsockopt(int __level, int __optname, void *__optval, socklen
 	if (unlikely(m_b_closed) || unlikely(g_b_exit))
 		return ret;
 
-#ifdef DEFINED_VMAPOLL
 	/* Process VMA specific options only at the moment
 	 * VMA option does not require additional processing after return
 	 */
 	if (0 == sockinfo::getsockopt(__level, __optname, __optval, __optlen)) {
 		return 0;
 	}
-#endif // DEFINED_VMAPOLL	
 
 	auto_unlocker lock_tx(m_lock_snd);
 	auto_unlocker lock_rx(m_lock_rcv);

--- a/src/vma/sock/sockinfo_udp.h
+++ b/src/vma/sock/sockinfo_udp.h
@@ -161,7 +161,7 @@ public:
 	// This callback will handle ready rx packet notification from any ib_conn_mgr
 	/**
 	 *	Method sockinfo_udp::rx_process_packet run packet processor
-	 *	with inspection, in case packet is OK, completion for VMAPOLL mode
+	 *	with inspection, in case packet is OK, completion for socketXtreme mode
 	 *	will be filled or in other cases packet go to ready queue.
 	 *	If packet to be discarded, packet ref. counter will not be
 	 *	incremented and method returns false.

--- a/src/vma/util/instrumentation.cpp
+++ b/src/vma/util/instrumentation.cpp
@@ -32,7 +32,6 @@
 
 #include "config.h"
 #include "instrumentation.h"
-#ifdef DEFINED_VMAPOLL
 #include <string.h>
 
 #ifdef RDTSC_MEASURE
@@ -91,7 +90,6 @@ void print_rdtsc_summary()
 
 
 #endif //RDTSC_MEASURE
-#endif // DEFINED_VMAPOLL
 
 #ifdef VMA_TIME_MEASURE
 

--- a/src/vma/util/instrumentation.h
+++ b/src/vma/util/instrumentation.h
@@ -48,7 +48,7 @@
 
 #include <stdint.h>
 #include <unistd.h>
-#ifdef DEFINED_VMAPOLL
+
 #include "utils/rdtsc.h"
 #define __STDC_FORMAT_MACROS
 #include <inttypes.h>
@@ -98,7 +98,7 @@ extern char g_rdtsc_flow_names[RDTSC_FLOW_MAX][256];
 extern instr_info g_rdtsc_instr_info_arr[RDTSC_FLOW_MAX];
 
 #endif //RDTS_MEASURE
-#endif // DEFINED_VMAPOLL
+
 
 //#define VMA_TIME_MEASURE 1
 #ifdef VMA_TIME_MEASURE

--- a/src/vma/util/sys_vars.cpp
+++ b/src/vma/util/sys_vars.cpp
@@ -524,6 +524,7 @@ void mce_sys_var::get_env_params()
 	buffer_batching_mode	= MCE_DEFAULT_BUFFER_BATCHING_MODE;
 	mem_alloc_type          = MCE_DEFAULT_MEM_ALLOC_TYPE;
 	enable_ipoib		= MCE_DEFAULT_IPOIB_FLAG;
+	enable_xtreme		= MCE_DEFAULT_XTREME;
 	handle_fork		= MCE_DEFAULT_FORK_SUPPORT;
 	handle_bf		= MCE_DEFAULT_BF_FLAG;
 	close_on_dup2		= MCE_DEFAULT_CLOSE_ON_DUP2;
@@ -1124,6 +1125,9 @@ void mce_sys_var::get_env_params()
 
 	if((env_ptr = getenv(SYS_VAR_IPOIB )) != NULL)
 		enable_ipoib = atoi(env_ptr) ? true : false;
+
+	if((env_ptr = getenv(SYS_VAR_XTREME )) != NULL)
+		enable_xtreme = atoi(env_ptr) ? true : false;
 
 	if ((env_ptr = getenv(SYS_VAR_CLOSE_ON_DUP2)) != NULL)
 		close_on_dup2 = atoi(env_ptr) ? true : false;

--- a/src/vma/util/sys_vars.cpp
+++ b/src/vma/util/sys_vars.cpp
@@ -688,6 +688,7 @@ void mce_sys_var::get_env_params()
 	if (enable_xtreme) {
 		rx_num_wr = 1024;
 		gro_streams_max = 0;
+		progress_engine_interval_msec = MCE_CQ_DRAIN_INTERVAL_DISABLED;
 	}
 
 	if ((env_ptr = getenv(SYS_VAR_SPEC_PARAM1)) != NULL)
@@ -992,8 +993,13 @@ void mce_sys_var::get_env_params()
 		cq_poll_batch_max = MCE_DEFAULT_CQ_POLL_BATCH;
 	}
 
-	if ((env_ptr = getenv(SYS_VAR_PROGRESS_ENGINE_INTERVAL)) != NULL)
+	if ((env_ptr = getenv(SYS_VAR_PROGRESS_ENGINE_INTERVAL)) != NULL) {
 		progress_engine_interval_msec = (uint32_t)atoi(env_ptr);
+	}
+	if (enable_xtreme && (progress_engine_interval_msec != MCE_CQ_DRAIN_INTERVAL_DISABLED)) {
+		progress_engine_interval_msec = MCE_CQ_DRAIN_INTERVAL_DISABLED;
+		vlog_printf(VLOG_WARNING,"%s parameter is ignored in case %s is enabled\n", SYS_VAR_PROGRESS_ENGINE_INTERVAL, SYS_VAR_XTREME);
+	}
 
 	if ((env_ptr = getenv(SYS_VAR_PROGRESS_ENGINE_WCE_MAX)) != NULL)
 		progress_engine_wce_max = (uint32_t)atoi(env_ptr);

--- a/src/vma/util/sys_vars.cpp
+++ b/src/vma/util/sys_vars.cpp
@@ -679,7 +679,18 @@ void mce_sys_var::get_env_params()
 
 	is_hypervisor = check_cpuinfo_flag(VIRTUALIZATION_FLAG);
 
-       if ((env_ptr = getenv(SYS_VAR_SPEC_PARAM1)) != NULL)
+	if ((env_ptr = getenv(SYS_VAR_XTREME )) != NULL) {
+		enable_xtreme = atoi(env_ptr) ? true : false;
+	}
+	/* TODO: consider avoiding these settings and use VMA_SPEC as ultra latency or latency
+	 * It is done just as a part of code unification
+	 */
+	if (enable_xtreme) {
+		rx_num_wr = 1024;
+		gro_streams_max = 0;
+	}
+
+	if ((env_ptr = getenv(SYS_VAR_SPEC_PARAM1)) != NULL)
 		mce_spec_param1 = (uint32_t)atoi(env_ptr);
 
 	if ((env_ptr = getenv(SYS_VAR_SPEC_PARAM2)) != NULL)
@@ -1125,9 +1136,6 @@ void mce_sys_var::get_env_params()
 
 	if((env_ptr = getenv(SYS_VAR_IPOIB )) != NULL)
 		enable_ipoib = atoi(env_ptr) ? true : false;
-
-	if((env_ptr = getenv(SYS_VAR_XTREME )) != NULL)
-		enable_xtreme = atoi(env_ptr) ? true : false;
 
 	if ((env_ptr = getenv(SYS_VAR_CLOSE_ON_DUP2)) != NULL)
 		close_on_dup2 = atoi(env_ptr) ? true : false;

--- a/src/vma/util/sys_vars.h
+++ b/src/vma/util/sys_vars.h
@@ -663,11 +663,7 @@ extern mce_sys_var & safe_mce_sys();
 #define MCE_MIN_CQ_POLL_BATCH				(1)
 #define MCE_MAX_CQ_POLL_BATCH				(128)
 #define MCE_DEFAULT_IPOIB_FLAG				(1)
-#ifdef DEFINED_VMAPOLL
-#define MCE_DEFAULT_XTREME				(true)
-#else
 #define MCE_DEFAULT_XTREME				(false)
-#endif // DEFINED_VMAPOLL
 #define MCE_DEFAULT_RX_POLL_ON_TX_TCP			(false)
 #define MCE_DEFAULT_TRIGGER_DUMMY_SEND_GETSOCKNAME	(false)
 

--- a/src/vma/util/sys_vars.h
+++ b/src/vma/util/sys_vars.h
@@ -393,6 +393,7 @@ struct mce_sys_var {
 	bool 		handle_bf;
 
 	bool 		enable_ipoib;
+	bool 		enable_xtreme;
 	uint32_t	timer_netlink_update_msec;
 
 	//Neigh parameters
@@ -523,6 +524,7 @@ extern mce_sys_var & safe_mce_sys();
 #define SYS_VAR_SPEC_PARAM2				"VMA_SPEC_PARAM2"
 
 #define SYS_VAR_IPOIB					"VMA_IPOIB"
+#define SYS_VAR_XTREME					"VMA_XTREME"
 
 #define SYS_VAR_INTERNAL_THREAD_AFFINITY		"VMA_INTERNAL_THREAD_AFFINITY"
 #define SYS_VAR_INTERNAL_THREAD_CPUSET			"VMA_INTERNAL_THREAD_CPUSET"
@@ -669,6 +671,11 @@ extern mce_sys_var & safe_mce_sys();
 #define MCE_MIN_CQ_POLL_BATCH				(1)
 #define MCE_MAX_CQ_POLL_BATCH				(128)
 #define MCE_DEFAULT_IPOIB_FLAG				(1)
+#ifdef DEFINED_VMAPOLL
+#define MCE_DEFAULT_XTREME				(true)
+#else
+#define MCE_DEFAULT_XTREME				(false)
+#endif // DEFINED_VMAPOLL
 #define MCE_DEFAULT_RX_POLL_ON_TX_TCP			(false)
 #define MCE_DEFAULT_TRIGGER_DUMMY_SEND_GETSOCKNAME	(false)
 

--- a/src/vma/util/sys_vars.h
+++ b/src/vma/util/sys_vars.h
@@ -663,7 +663,11 @@ extern mce_sys_var & safe_mce_sys();
 #define MCE_MIN_CQ_POLL_BATCH				(1)
 #define MCE_MAX_CQ_POLL_BATCH				(128)
 #define MCE_DEFAULT_IPOIB_FLAG				(1)
+#ifdef DEFINED_VMAPOLL
+#define MCE_DEFAULT_XTREME				(true)
+#else
 #define MCE_DEFAULT_XTREME				(false)
+#endif // DEFINED_VMAPOLL
 #define MCE_DEFAULT_RX_POLL_ON_TX_TCP			(false)
 #define MCE_DEFAULT_TRIGGER_DUMMY_SEND_GETSOCKNAME	(false)
 

--- a/src/vma/util/sys_vars.h
+++ b/src/vma/util/sys_vars.h
@@ -573,11 +573,7 @@ extern mce_sys_var & safe_mce_sys();
 #define MCE_DEFAULT_TX_NUM_SGE				(2)
 #define MCE_DEFAULT_RX_NUM_BUFS				(200000)
 #define MCE_DEFAULT_RX_BUFS_BATCH			(64)
-#ifdef DEFINED_VMAPOLL
-#define MCE_DEFAULT_RX_NUM_WRE				(1024)
-#else
 #define MCE_DEFAULT_RX_NUM_WRE				(16000)
-#endif // DEFINED_VMAPOLL
 #define MCE_DEFAULT_RX_NUM_WRE_TO_POST_RECV		(64)
 #define MCE_DEFAULT_RX_NUM_SGE				(1)
 #define MCE_DEFAULT_RX_NUM_POLLS			(100000)
@@ -590,11 +586,7 @@ extern mce_sys_var & safe_mce_sys();
 #define MCE_DEFAULT_RX_PREFETCH_BYTES			(256)
 #define MCE_DEFAULT_RX_PREFETCH_BYTES_BEFORE_POLL	(0)
 #define MCE_DEFAULT_RX_CQ_DRAIN_RATE			(MCE_RX_CQ_DRAIN_RATE_DISABLED)
-#ifdef DEFINED_VMAPOLL
-#define MCE_DEFAULT_GRO_STREAMS_MAX			(0)
-#else
 #define MCE_DEFAULT_GRO_STREAMS_MAX			(32)
-#endif // DEFINED_VMAPOLL
 #define MCE_DEFAULT_TCP_3T_RULES			(false)
 #define MCE_DEFAULT_ETH_MC_L2_ONLY_RULES		(false)
 #define MCE_DEFAULT_MC_FORCE_FLOWTAG			(false)


### PR DESCRIPTION
These changes allows to get single VMA library workable in two modes as Default and SocketXtreme.
The current mode is controlled by VMA_XTREME environment option.
By default VMA_XTREME=0.