### PR TITLE
issue: 1242606 Disable TCP congestion control using VMA parameter

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -1,4 +1,4 @@
-Update: 23 Nov 2017
+Update: 14 Dec 2017
 
 Introduction
 ============
@@ -921,7 +921,8 @@ TCP congestion control algorithm.
 The default algorithm coming with LWIP is a variation of Reno/New-Reno.
 The new Cubic algorithm was adapted from FreeBsd implementation.
 Use value of 0 for LWIP algorithm.
-Use value of 1 for the Cubic algorithm.
+Use value of 1 for Cubic algorithm.
+Use vlaue of 2 for disabling the congestion algorithm.
 Default value is 0 (LWIP).
 
 VMA_TCP_MAX_SYN_RATE

--- a/README.txt
+++ b/README.txt
@@ -922,7 +922,7 @@ The default algorithm coming with LWIP is a variation of Reno/New-Reno.
 The new Cubic algorithm was adapted from FreeBsd implementation.
 Use value of 0 for LWIP algorithm.
 Use value of 1 for Cubic algorithm.
-Use vlaue of 2 for disabling the congestion algorithm.
+Use value of 2 in order to disable the congestion algorithm.
 Default value is 0 (LWIP).
 
 VMA_TCP_MAX_SYN_RATE

--- a/src/vma/Makefile.am
+++ b/src/vma/Makefile.am
@@ -119,6 +119,7 @@ libvma_la_SOURCES := \
 	lwip/cc.c \
 	lwip/cc_lwip.c \
 	lwip/cc_cubic.c \
+	lwip/cc_none.c \
 	lwip/init.c \
 	\
 	proto/ip_frag.cpp \

--- a/src/vma/lwip/cc.h
+++ b/src/vma/lwip/cc.h
@@ -92,7 +92,8 @@ struct tcp_pcb;
 /* types of different cc algorithms */
 enum cc_algo_mod {
 	CC_MOD_LWIP,
-	CC_MOD_CUBIC
+	CC_MOD_CUBIC,
+	CC_MOD_NONE
 };
 
 /* ACK types passed to the ack_received() hook. */
@@ -148,6 +149,7 @@ struct cc_algo {
 
 extern struct cc_algo lwip_cc_algo;
 extern struct cc_algo cubic_cc_algo;
+extern struct cc_algo none_cc_algo;
 
 void cc_init(struct tcp_pcb *pcb);
 void cc_destroy(struct tcp_pcb *pcb);

--- a/src/vma/lwip/cc_none.c
+++ b/src/vma/lwip/cc_none.c
@@ -1,0 +1,51 @@
+/*
+ * Copyright (c) 2001-2017 Mellanox Technologies, Ltd. All rights reserved.
+ *
+ * This software is available to you under a choice of one of two
+ * licenses.  You may choose to be licensed under the terms of the GNU
+ * General Public License (GPL) Version 2, available from the file
+ * COPYING in the main directory of this source tree, or the
+ * BSD license below:
+ *
+ *     Redistribution and use in source and binary forms, with or
+ *     without modification, are permitted provided that the following
+ *     conditions are met:
+ *
+ *      - Redistributions of source code must retain the above
+ *        copyright notice, this list of conditions and the following
+ *        disclaimer.
+ *
+ *      - Redistributions in binary form must reproduce the above
+ *        copyright notice, this list of conditions and the following
+ *        disclaimer in the documentation and/or other materials
+ *        provided with the distribution.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+ * BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ * ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#include "vma/lwip/cc.h"
+#include "vma/lwip/tcp.h"
+
+#if TCP_CC_ALGO_MOD
+
+static void	none_cc_conn_init(struct tcp_pcb *pcb);
+
+struct cc_algo none_cc_algo = {
+		.name = "none_cc",
+		.conn_init = none_cc_conn_init,
+};
+
+static void
+none_cc_conn_init(struct tcp_pcb *pcb)
+{
+	pcb->cwnd = UINT32_MAX;
+}
+
+#endif //TCP_CC_ALGO_MOD

--- a/src/vma/lwip/tcp.c
+++ b/src/vma/lwip/tcp.c
@@ -1101,6 +1101,9 @@ void tcp_pcb_init (struct tcp_pcb* pcb, u8_t prio)
 	case CC_MOD_CUBIC:
 		pcb->cc_algo = &cubic_cc_algo;
 		break;
+	case CC_MOD_NONE:
+		pcb->cc_algo = &none_cc_algo;
+		break;
 	case CC_MOD_LWIP:
 	default:
 		pcb->cc_algo = &lwip_cc_algo;

--- a/src/vma/proto/vma_lwip.h
+++ b/src/vma/proto/vma_lwip.h
@@ -66,6 +66,7 @@ static inline const char* lwip_cc_algo_str(uint32_t algo)
 {
 	switch (algo) {
 	case CC_MOD_CUBIC:	return "(CUBIC)";
+	case CC_MOD_NONE:	return "(NONE)";
 	case CC_MOD_LWIP:
 	default:		return "(LWIP)";
 	}


### PR DESCRIPTION
While TCP congestion control algorithm is disabled, VMA will send data
as long as there is room in the advertised window.
Usage : VMA_TCP_CC_ALGO = 2.
For more details about Congestion Control Algorithms see RFC-2581.

Signed-off-by: Liran Oz <lirano@mellanox.com>