### PR TITLE
issue: 1254846 Add support for packet packing burst control

### DIFF
--- a/config/m4/verbs.m4
+++ b/config/m4/verbs.m4
@@ -151,6 +151,10 @@ AC_CHECK_DECLS([IBV_EXP_QP_RATE_LIMIT],
 	[AC_DEFINE(DEFINED_IBV_EXP_QP_RATE_LIMIT, 1, [Define to 1 if IBV_EXP_QP_RATE_LIMIT defined])],
 	[], [[#include <infiniband/mlx5_hw.h>]])
 
+AC_CHECK_DECLS([IBV_EXP_QP_BURST_INFO],
+	[AC_DEFINE(DEFINED_IBV_EXP_QP_BURST_INFO, 1, [Define to 1 if IBV_EXP_QP_BURST_INFO defined])],
+	[], [[#include <infiniband/mlx5_hw.h>]])
+
 have_mp_rq=yes
 AC_CHECK_DECLS([IBV_EXP_DEVICE_ATTR_VLAN_OFFLOADS,
 		IBV_EXP_DEVICE_ATTR_MAX_CTX_RES_DOMAIN,

--- a/config/m4/verbs.m4
+++ b/config/m4/verbs.m4
@@ -149,11 +149,11 @@ AC_CHECK_DECL([IBV_EXP_DEVICE_ATTR_MAX_DM_SIZE],
 
 AC_CHECK_DECLS([IBV_EXP_QP_RATE_LIMIT],
 	[AC_DEFINE(DEFINED_IBV_EXP_QP_RATE_LIMIT, 1, [Define to 1 if IBV_EXP_QP_RATE_LIMIT defined])],
-	[], [[#include <infiniband/mlx5_hw.h>]])
+	[], [[#include <infiniband/verbs_exp.h>]])
 
 AC_CHECK_DECLS([IBV_EXP_QP_BURST_INFO],
 	[AC_DEFINE(DEFINED_IBV_EXP_QP_BURST_INFO, 1, [Define to 1 if IBV_EXP_QP_BURST_INFO defined])],
-	[], [[#include <infiniband/mlx5_hw.h>]])
+	[], [[#include <infiniband/verbs_exp.h>]])
 
 have_mp_rq=yes
 AC_CHECK_DECLS([IBV_EXP_DEVICE_ATTR_VLAN_OFFLOADS,

--- a/src/vma/dev/qp_mgr.cpp
+++ b/src/vma/dev/qp_mgr.cpp
@@ -816,9 +816,11 @@ uint32_t qp_mgr::is_ratelimit_change(struct vma_rate_limit_t &rate_limit)
 	return rl_changes;
 }
 
-bool qp_mgr::is_ratelimit_supported(ibv_exp_packet_pacing_caps &pp_caps, struct vma_rate_limit_t &rate_limit)
+bool qp_mgr::is_ratelimit_supported(vma_ibv_device_attr *attr, struct vma_rate_limit_t &rate_limit)
 {
 #ifdef DEFINED_IBV_EXP_QP_RATE_LIMIT
+	ibv_exp_packet_pacing_caps pp_caps = attr->packet_pacing_caps;
+
 	/* for any rate limit settings the rate must be between the supported min and max values */
 	if (rate_limit.rate < pp_caps.qp_rate_limit_min || pp_caps.qp_rate_limit_max < rate_limit.rate) {
 		return false;
@@ -839,7 +841,7 @@ bool qp_mgr::is_ratelimit_supported(ibv_exp_packet_pacing_caps &pp_caps, struct 
 
 	return true;
 #else
-	NOT_IN_USE(pp_caps);
+	NOT_IN_USE(attr);
 	NOT_IN_USE(rate_limit);
 	return false;
 #endif

--- a/src/vma/dev/qp_mgr.h
+++ b/src/vma/dev/qp_mgr.h
@@ -142,7 +142,7 @@ public:
 	void                release_tx_buffers();
 	virtual void        trigger_completion_for_all_sent_packets();
 	uint32_t            is_ratelimit_change(struct vma_rate_limit_t &rate_limit);
-	bool                is_ratelimit_supported(ibv_exp_packet_pacing_caps &pp_caps, struct vma_rate_limit_t &rate_limit);
+	bool                is_ratelimit_supported(vma_ibv_device_attr *attr, struct vma_rate_limit_t &rate_limit);
 	int                 modify_qp_ratelimit(struct vma_rate_limit_t &rate_limit, uint32_t rl_changes);
 	static inline bool  is_lib_mlx5(const char* device_name) {return strstr(device_name, "mlx5");}
 	virtual void        dm_release_data(mem_buf_desc_t* buff) { NOT_IN_USE(buff); }

--- a/src/vma/dev/qp_mgr.h
+++ b/src/vma/dev/qp_mgr.h
@@ -141,8 +141,9 @@ public:
 	void                release_rx_buffers();
 	void                release_tx_buffers();
 	virtual void        trigger_completion_for_all_sent_packets();
-	bool                set_qp_ratelimit(const uint32_t ratelimit_kbps);
-	int                 modify_qp_ratelimit(const uint32_t ratelimit_kbps);
+	uint32_t            is_ratelimit_change(struct vma_rate_limit_t &rate_limit);
+	bool                is_ratelimit_supported(ibv_exp_packet_pacing_caps &pp_caps, struct vma_rate_limit_t &rate_limit);
+	int                 modify_qp_ratelimit(struct vma_rate_limit_t &rate_limit, uint32_t rl_changes);
 	static inline bool  is_lib_mlx5(const char* device_name) {return strstr(device_name, "mlx5");}
 	virtual void        dm_release_data(mem_buf_desc_t* buff) { NOT_IN_USE(buff); }
 	virtual bool        fill_hw_descriptors(vma_mlx_hw_device_data &data) {NOT_IN_USE(data);return false;};
@@ -191,7 +192,7 @@ protected:
 	// generating packet IDs
 	uint16_t            m_n_ip_id_base;
 	uint16_t            m_n_ip_id_offset;
-	uint32_t            m_ratelimit_kbps;
+	struct vma_rate_limit_t m_rate_limit;
 
 	mgid_ref_count_map_t  m_attach_mc_grp_ref_cnt;
 

--- a/src/vma/dev/ring.h
+++ b/src/vma/dev/ring.h
@@ -325,8 +325,8 @@ public:
 	virtual ring_user_id_t	generate_id(const address_t src_mac, const address_t dst_mac, uint16_t eth_proto, uint16_t encap_proto, uint32_t src_ip, uint32_t dst_ip, uint16_t src_port, uint16_t dst_port) = 0;
 	uint32_t		get_mtu(const route_rule_table_key &key);
 	bool			is_mp_ring() {return m_is_mp_ring;};
-	virtual int		modify_ratelimit(const uint32_t ratelimit_kbps) = 0;
-	virtual bool		is_ratelimit_supported(uint32_t rate) = 0;
+	virtual int		modify_ratelimit(struct vma_rate_limit_t &rate_limit) = 0;
+	virtual bool		is_ratelimit_supported(struct vma_rate_limit_t &rate_limit) = 0;
 	virtual int		get_ring_descriptors(vma_mlx_hw_device_data &data) { NOT_IN_USE(data);return -1;};
 	virtual int		reg_mr(void *addr, size_t length, uint32_t &lkey) { NOT_IN_USE(addr); NOT_IN_USE(length); NOT_IN_USE(lkey); return -1;};
 	virtual int		dereg_mr(void *addr, size_t length) { NOT_IN_USE(addr);NOT_IN_USE(length); return -1;};

--- a/src/vma/dev/ring_bond.cpp
+++ b/src/vma/dev/ring_bond.cpp
@@ -637,20 +637,20 @@ ring_user_id_t ring_bond::generate_id(const address_t src_mac, const address_t d
 	return hash % m_n_num_resources;
 }
 
-int ring_bond::modify_ratelimit(const uint32_t ratelimit_kbps) {
+int ring_bond::modify_ratelimit(struct vma_rate_limit_t &rate_limit) {
 	for (uint32_t i = 0; i < m_n_num_resources; i++) {
 		if (m_bond_rings[i]) {
-			m_bond_rings[i]->modify_ratelimit(ratelimit_kbps);
+			m_bond_rings[i]->modify_ratelimit(rate_limit);
 		}
 	}
 	return 0;
 }
 
-bool ring_bond::is_ratelimit_supported(uint32_t rate)
+bool ring_bond::is_ratelimit_supported(struct vma_rate_limit_t &rate_limit)
 {
 	for (uint32_t i = 0; i < m_n_num_resources; i++) {
 		if (m_bond_rings[i] &&
-		    !m_bond_rings[i]->is_ratelimit_supported(rate)) {
+		    !m_bond_rings[i]->is_ratelimit_supported(rate_limit)) {
 				return false;
 		}
 	}

--- a/src/vma/dev/ring_bond.h
+++ b/src/vma/dev/ring_bond.h
@@ -66,8 +66,8 @@ public:
 	virtual ring_user_id_t	generate_id();
 	virtual ring_user_id_t	generate_id(const address_t src_mac, const address_t dst_mac, uint16_t eth_proto, uint16_t encap_proto, uint32_t src_ip, uint32_t dst_ip, uint16_t src_port, uint16_t dst_port);
 	virtual bool 		get_hw_dummy_send_support(ring_user_id_t id, vma_ibv_send_wr* p_send_wqe);
-	virtual int 		modify_ratelimit(const uint32_t ratelimit_kbps);
-	virtual bool		is_ratelimit_supported(uint32_t rate);
+	virtual int		modify_ratelimit(struct vma_rate_limit_t &rate_limit);
+	virtual bool		is_ratelimit_supported(struct vma_rate_limit_t &rate_limit);
 #ifdef DEFINED_SOCKETXTREME		
 	virtual int		fast_poll_and_process_element_rx(vma_packets_t *vma_pkts);
 	int 			socketxtreme_poll(struct vma_completion_t *vma_completions, unsigned int ncompletions, int flags);

--- a/src/vma/dev/ring_simple.cpp
+++ b/src/vma/dev/ring_simple.cpp
@@ -96,9 +96,7 @@ qp_mgr* ring_eth::create_qp_mgr(const ib_ctx_handler* ib_ctx, uint8_t port_num, 
 bool ring_eth::is_ratelimit_supported(struct vma_rate_limit_t &rate_limit)
 {
 #ifdef DEFINED_IBV_EXP_QP_RATE_LIMIT
-	ibv_exp_packet_pacing_caps &pp_caps =
-		m_p_ib_ctx->get_ibv_device_attr()->packet_pacing_caps;
-	return m_p_qp_mgr->is_ratelimit_supported(pp_caps, rate_limit);
+	return m_p_qp_mgr->is_ratelimit_supported(m_p_ib_ctx->get_ibv_device_attr(), rate_limit);
 #else
 	NOT_IN_USE(rate_limit);
 	return false;

--- a/src/vma/dev/ring_simple.cpp
+++ b/src/vma/dev/ring_simple.cpp
@@ -93,14 +93,14 @@ qp_mgr* ring_eth::create_qp_mgr(const ib_ctx_handler* ib_ctx, uint8_t port_num, 
 	return new qp_mgr_eth(this, ib_ctx, port_num, p_rx_comp_event_channel, get_tx_num_wr(), get_partition());
 }
 
-bool ring_eth::is_ratelimit_supported(uint32_t rate)
+bool ring_eth::is_ratelimit_supported(struct vma_rate_limit_t &rate_limit)
 {
 #ifdef DEFINED_IBV_EXP_QP_RATE_LIMIT
 	ibv_exp_packet_pacing_caps &pp_caps =
-			m_p_ib_ctx->get_ibv_device_attr()->packet_pacing_caps;
-	return rate >= pp_caps.qp_rate_limit_min && rate <= pp_caps.qp_rate_limit_max;
+		m_p_ib_ctx->get_ibv_device_attr()->packet_pacing_caps;
+	return m_p_qp_mgr->is_ratelimit_supported(pp_caps, rate_limit);
 #else
-	NOT_IN_USE(rate);
+	NOT_IN_USE(rate_limit);
 	return false;
 #endif
 }
@@ -110,9 +110,9 @@ qp_mgr* ring_ib::create_qp_mgr(const ib_ctx_handler* ib_ctx, uint8_t port_num, s
 	return new qp_mgr_ib(this, ib_ctx, port_num, p_rx_comp_event_channel, get_tx_num_wr(), get_partition());
 }
 
-bool ring_ib::is_ratelimit_supported(uint32_t rate)
+bool ring_ib::is_ratelimit_supported(struct vma_rate_limit_t &rate_limit)
 {
-	NOT_IN_USE(rate);
+	NOT_IN_USE(rate_limit);
 	return false;
 }
 
@@ -1993,9 +1993,12 @@ ring_user_id_t ring_simple::generate_id(const address_t src_mac, const address_t
 	return 0;
 }
 
-int ring_simple::modify_ratelimit(const uint32_t ratelimit_kbps) {
-	if (m_p_qp_mgr->set_qp_ratelimit(ratelimit_kbps) && m_up) {
-		return m_p_qp_mgr->modify_qp_ratelimit(ratelimit_kbps);
-	}
+int ring_simple::modify_ratelimit(struct vma_rate_limit_t &rate_limit)
+{
+	uint32_t rl_changes = m_p_qp_mgr->is_ratelimit_change(rate_limit);
+
+	if (m_up && rl_changes)
+		return m_p_qp_mgr->modify_qp_ratelimit(rate_limit, rl_changes);
+
 	return 0;
 }

--- a/src/vma/dev/ring_simple.h
+++ b/src/vma/dev/ring_simple.h
@@ -84,7 +84,7 @@ public:
 	virtual bool 		get_hw_dummy_send_support(ring_user_id_t id, vma_ibv_send_wr* p_send_wqe);
 	inline void 		convert_hw_time_to_system_time(uint64_t hwtime, struct timespec* systime) { m_p_cq_mgr_rx->convert_hw_time_to_system_time(hwtime, systime); }
 	inline uint32_t		get_qpn() const { return (m_p_l2_addr ? ((IPoIB_addr *)m_p_l2_addr)->get_qpn() : 0); }
-	virtual int 		modify_ratelimit(const uint32_t ratelimit_kbps);
+	virtual int		modify_ratelimit(struct vma_rate_limit_t &rate_limit);
 	virtual int		get_tx_channel_fd() const { return m_p_tx_comp_event_channel ? m_p_tx_comp_event_channel->fd : -1; };
 	struct ibv_comp_channel* get_tx_comp_event_channel() { return m_p_tx_comp_event_channel; }
 	friend class cq_mgr;
@@ -178,7 +178,7 @@ public:
 		if (call_create_res)
 			create_resources(p_ring_info, active);
 	};
-	virtual bool is_ratelimit_supported(uint32_t rate);
+	virtual bool is_ratelimit_supported(struct vma_rate_limit_t &rate_limit);
 protected:
 	virtual qp_mgr* create_qp_mgr(const ib_ctx_handler* ib_ctx, uint8_t port_num, struct ibv_comp_channel* p_rx_comp_event_channel);
 };
@@ -188,7 +188,7 @@ class ring_ib : public ring_simple
 public:
 	ring_ib(in_addr_t local_if, ring_resource_creation_info_t* p_ring_info, int count, bool active, uint16_t pkey, uint32_t mtu, ring* parent = NULL):
 		ring_simple(p_ring_info, local_if, pkey, count, VMA_TRANSPORT_IB, mtu, parent) { create_resources(p_ring_info, active); };
-	virtual bool is_ratelimit_supported(uint32_t rate);
+	virtual bool is_ratelimit_supported(struct vma_rate_limit_t &rate_limit);
 protected:
 	virtual qp_mgr* create_qp_mgr(const ib_ctx_handler* ib_ctx, uint8_t port_num, struct ibv_comp_channel* p_rx_comp_event_channel);
 };

--- a/src/vma/proto/dst_entry.cpp
+++ b/src/vma/proto/dst_entry.cpp
@@ -531,7 +531,7 @@ bool dst_entry::offloaded_according_to_rules()
 	return ret_val;
 }
 
-bool dst_entry::prepare_to_send(const int ratelimit_kbps, bool skip_rules, bool is_connect)
+bool dst_entry::prepare_to_send(struct vma_rate_limit_t &rate_limit, bool skip_rules, bool is_connect)
 {
 	bool resolved = false;
 	m_slow_path_lock.lock();
@@ -554,9 +554,7 @@ bool dst_entry::prepare_to_send(const int ratelimit_kbps, bool skip_rules, bool 
 			m_max_ip_payload_size = m_max_udp_payload_size & ~0x7;
 			if (resolve_ring()) {
 				is_ofloaded = true;
-				if (ratelimit_kbps) {
-					modify_ratelimit(ratelimit_kbps);
-				}
+				modify_ratelimit(rate_limit);
 				if (resolve_neigh()) {
 					if (get_obs_transport_type() == VMA_TRANSPORT_ETH) {
 						dst_logdbg("local mac: %s peer mac: %s", m_p_net_dev_val->get_l2_address()->to_str().c_str(), m_p_neigh_val->get_l2_address()->to_str().c_str());
@@ -765,10 +763,10 @@ void dst_entry::return_buffers_pool()
 	}
 }
 
-int dst_entry::modify_ratelimit(const uint32_t ratelimit_kbps)
+int dst_entry::modify_ratelimit(struct vma_rate_limit_t &rate_limit)
 {
 	if (m_p_ring) {
-		return m_p_ring->modify_ratelimit(ratelimit_kbps);
+		return m_p_ring->modify_ratelimit(rate_limit);
 	}
 	return 0;
 }

--- a/src/vma/proto/dst_entry.h
+++ b/src/vma/proto/dst_entry.h
@@ -70,8 +70,8 @@ public:
 
 	virtual void 	notify_cb();
 
-	virtual bool 	prepare_to_send(const int ratelimit_kbps, bool skip_rules=false, bool is_connect=false);
-	virtual ssize_t slow_send(const iovec* p_iov, size_t sz_iov, bool is_dummy, const int ratelimit_kbps, bool b_blocked = true, bool is_rexmit = false, int flags = 0, socket_fd_api* sock = 0, tx_call_t call_type = TX_UNDEF) = 0 ;
+	virtual bool 	prepare_to_send(struct vma_rate_limit_t &rate_limit, bool skip_rules=false, bool is_connect=false);
+	virtual ssize_t slow_send(const iovec* p_iov, size_t sz_iov, bool is_dummy, struct vma_rate_limit_t &rate_limit, bool b_blocked = true, bool is_rexmit = false, int flags = 0, socket_fd_api* sock = 0, tx_call_t call_type = TX_UNDEF) = 0 ;
 	virtual ssize_t fast_send(const iovec* p_iov, const ssize_t sz_iov, bool is_dummy, bool b_blocked = true, bool is_rexmit = false) = 0;
 
 	bool		try_migrate_ring(lock_base& socket_lock);
@@ -84,7 +84,7 @@ public:
 	inline in_addr_t get_src_addr() const {
 		return m_pkt_src_ip;
 	}
-	int		modify_ratelimit(const uint32_t ratelimit_kbps);
+	int		modify_ratelimit(struct vma_rate_limit_t &rate_limit);
 
 #if _BullseyeCoverage
     #pragma BullseyeCoverage off

--- a/src/vma/proto/dst_entry_tcp.cpp
+++ b/src/vma/proto/dst_entry_tcp.cpp
@@ -190,7 +190,7 @@ out:
 
 
 
-ssize_t dst_entry_tcp::slow_send(const iovec* p_iov, size_t sz_iov, bool is_dummy, const int ratelimit_kbps, bool b_blocked /*= true*/, bool is_rexmit /*= false*/, int flags /*= 0*/, socket_fd_api* sock /*= 0*/, tx_call_t call_type /*= 0*/)
+ssize_t dst_entry_tcp::slow_send(const iovec* p_iov, size_t sz_iov, bool is_dummy, struct vma_rate_limit_t &rate_limit, bool b_blocked /*= true*/, bool is_rexmit /*= false*/, int flags /*= 0*/, socket_fd_api* sock /*= 0*/, tx_call_t call_type /*= 0*/)
 {
 	ssize_t ret_val = -1;
 
@@ -200,7 +200,7 @@ ssize_t dst_entry_tcp::slow_send(const iovec* p_iov, size_t sz_iov, bool is_dumm
 
 	m_slow_path_lock.lock();
 
-	prepare_to_send(ratelimit_kbps, true);
+	prepare_to_send(rate_limit, true);
 
 	if (m_b_is_offloaded) {
 		if (!is_valid()) { // That means that the neigh is not resolved yet
@@ -218,13 +218,13 @@ ssize_t dst_entry_tcp::slow_send(const iovec* p_iov, size_t sz_iov, bool is_dumm
 	return ret_val;
 }
 
-ssize_t dst_entry_tcp::slow_send_neigh( const iovec* p_iov, size_t sz_iov, const int ratelimit_kbps)
+ssize_t dst_entry_tcp::slow_send_neigh( const iovec* p_iov, size_t sz_iov, struct vma_rate_limit_t &rate_limit)
 {
 	ssize_t ret_val = -1;
 
 	m_slow_path_lock.lock();
 
-	prepare_to_send(ratelimit_kbps, true);
+	prepare_to_send(rate_limit, true);
 
 	if (m_b_is_offloaded) {
 		ret_val = pass_buff_to_neigh(p_iov, sz_iov);

--- a/src/vma/proto/dst_entry_tcp.h
+++ b/src/vma/proto/dst_entry_tcp.h
@@ -51,8 +51,8 @@ public:
 	virtual ~dst_entry_tcp();
 
 	virtual ssize_t fast_send(const iovec* p_iov, const ssize_t sz_iov, bool is_dummy, bool b_blocked = true, bool is_rexmit = false);
-	ssize_t slow_send(const iovec* p_iov, size_t sz_iov, bool is_dummy, const int ratelimit_kbps, bool b_blocked = true, bool is_rexmit = false, int flags = 0, socket_fd_api* sock = 0, tx_call_t call_type = TX_UNDEF);
-	ssize_t slow_send_neigh(const iovec* p_iov, size_t sz_iov, const int ratelimit_kbps);
+	ssize_t slow_send(const iovec* p_iov, size_t sz_iov, bool is_dummy, struct vma_rate_limit_t &rate_limit, bool b_blocked = true, bool is_rexmit = false, int flags = 0, socket_fd_api* sock = 0, tx_call_t call_type = TX_UNDEF);
+	ssize_t slow_send_neigh(const iovec* p_iov, size_t sz_iov, struct vma_rate_limit_t &rate_limit);
 
 	mem_buf_desc_t* get_buffer(bool b_blocked = false);
 	void put_buffer(mem_buf_desc_t * p_desc);

--- a/src/vma/proto/dst_entry_udp.cpp
+++ b/src/vma/proto/dst_entry_udp.cpp
@@ -323,7 +323,7 @@ ssize_t dst_entry_udp::fast_send(const iovec* p_iov, const ssize_t sz_iov,
 }
 
 ssize_t dst_entry_udp::slow_send(const iovec* p_iov, size_t sz_iov, bool is_dummy,
-				 const int ratelimit_kbps, bool b_blocked /*= true*/,
+				 struct vma_rate_limit_t &rate_limit, bool b_blocked /*= true*/,
 				 bool is_rexmit /*= false*/, int flags /*= 0*/,
 				 socket_fd_api* sock /*= 0*/, tx_call_t call_type /*= 0*/)
 {
@@ -333,7 +333,7 @@ ssize_t dst_entry_udp::slow_send(const iovec* p_iov, size_t sz_iov, bool is_dumm
 
 	dst_udp_logdbg("In slow send");
 
-	prepare_to_send(ratelimit_kbps, false);
+	prepare_to_send(rate_limit, false);
 
 	if (m_b_force_os || !m_b_is_offloaded) {
 		struct sockaddr_in to_saddr;

--- a/src/vma/proto/dst_entry_udp.h
+++ b/src/vma/proto/dst_entry_udp.h
@@ -43,7 +43,7 @@ public:
 			socket_data &sock_data, resource_allocation_key &ring_alloc_logic);
 	virtual ~dst_entry_udp();
 
-	virtual ssize_t 	slow_send(const iovec* p_iov, size_t sz_iov, bool is_dummy, const int ratelimit_kbps, bool b_blocked = true, bool is_rexmit = false, int flags = 0, socket_fd_api* sock = 0, tx_call_t call_type = TX_UNDEF);
+	virtual ssize_t 	slow_send(const iovec* p_iov, size_t sz_iov, bool is_dummy, struct vma_rate_limit_t &rate_limit, bool b_blocked = true, bool is_rexmit = false, int flags = 0, socket_fd_api* sock = 0, tx_call_t call_type = TX_UNDEF);
 	virtual ssize_t 	fast_send(const iovec* p_iov, const ssize_t sz_iov, bool is_dummy, bool b_blocked = true, bool is_rexmit = false);
 
 protected:

--- a/src/vma/sock/sockinfo.cpp
+++ b/src/vma/sock/sockinfo.cpp
@@ -281,15 +281,14 @@ int sockinfo::getsockopt(int __level, int __optname, void *__optval, socklen_t *
 #endif // DEFINED_SOCKETXTREME
 
 		case SO_MAX_PACING_RATE:
-#ifdef DEFINED_IBV_EXP_QP_BURST_INFO
 			if (*__optlen >= sizeof(struct vma_rate_limit_t)) {
 				*(struct vma_rate_limit_t*)__optval = m_so_ratelimit;
 				(*(struct vma_rate_limit_t*)__optval).rate = KB_TO_BYTE(m_so_ratelimit.rate);
+				*__optlen = sizeof(struct vma_rate_limit_t);
 				si_logdbg("(SO_MAX_PACING_RATE) value: %d, %d, %d", (*(struct vma_rate_limit_t*)__optval).rate, (*(struct vma_rate_limit_t*)__optval).upper_bound_sz, (*(struct vma_rate_limit_t*)__optval).typical_pkt_sz);
-			} else
-#endif
-			if (*__optlen >= sizeof(uint32_t)) {
+			} else if (*__optlen >= sizeof(uint32_t)) {
 				*(uint32_t*)__optval = KB_TO_BYTE(m_so_ratelimit.rate);
+				*__optlen = sizeof(uint32_t);
 				si_logdbg("(SO_MAX_PACING_RATE) value: %d", *(int *)__optval);
 				ret = 0;
 			} else {

--- a/src/vma/sock/sockinfo.cpp
+++ b/src/vma/sock/sockinfo.cpp
@@ -85,8 +85,7 @@ sockinfo::sockinfo(int fd):
 		m_ring_alloc_log_tx(safe_mce_sys().ring_allocation_logic_tx),
 		m_pcp(0),
 		m_rx_callback(NULL),
-		m_rx_callback_context(NULL),
-		m_so_ratelimit(0)
+		m_rx_callback_context(NULL)
 #ifdef DEFINED_SOCKETXTREME
 		, m_fd_context((void *)((uintptr_t)m_fd))
 #endif // DEFINED_SOCKETXTREME
@@ -110,6 +109,7 @@ sockinfo::sockinfo(int fd):
 	m_p_socket_stats->inode = fd2inode(m_fd);
 	m_p_socket_stats->b_blocking = m_b_blocking;
 	m_rx_reuse_buff.n_buff_num = 0;
+	memset(&m_so_ratelimit, 0, sizeof(struct vma_rate_limit_t));
 
 #ifdef DEFINED_SOCKETXTREME 
 	m_ec.clear();
@@ -281,8 +281,15 @@ int sockinfo::getsockopt(int __level, int __optname, void *__optval, socklen_t *
 #endif // DEFINED_SOCKETXTREME
 
 		case SO_MAX_PACING_RATE:
-			if (*__optlen >= sizeof(int)) {
-				*(int *)__optval = KB_TO_BYTE(m_so_ratelimit);
+#ifdef DEFINED_IBV_EXP_QP_BURST_INFO
+			if (*__optlen >= sizeof(struct vma_rate_limit_t)) {
+				*(struct vma_rate_limit_t*)__optval = m_so_ratelimit;
+				(*(struct vma_rate_limit_t*)__optval).rate = KB_TO_BYTE(m_so_ratelimit.rate);
+				si_logdbg("(SO_MAX_PACING_RATE) value: %d, %d, %d", (*(struct vma_rate_limit_t*)__optval).rate, (*(struct vma_rate_limit_t*)__optval).upper_bound_sz, (*(struct vma_rate_limit_t*)__optval).typical_pkt_sz);
+			} else
+#endif
+			if (*__optlen >= sizeof(uint32_t)) {
+				*(uint32_t*)__optval = KB_TO_BYTE(m_so_ratelimit.rate);
 				si_logdbg("(SO_MAX_PACING_RATE) value: %d", *(int *)__optval);
 				ret = 0;
 			} else {
@@ -1208,23 +1215,28 @@ int sockinfo::register_callback(vma_recv_callback_t callback, void *context)
 	return 0;
 }
 
-int sockinfo::modify_ratelimit(dst_entry* p_dst_entry, const uint32_t rate_limit_bytes_per_second)
+int sockinfo::modify_ratelimit(dst_entry* p_dst_entry, struct vma_rate_limit_t &rate_limit)
 {
-	if (m_ring_alloc_log_tx.get_ring_alloc_logic() == RING_LOGIC_PER_SOCKET) {
+	if (m_ring_alloc_log_tx.get_ring_alloc_logic() == RING_LOGIC_PER_SOCKET ||
+	    m_ring_alloc_log_tx.get_ring_alloc_logic() == RING_LOGIC_PER_USER_ID) {
 		// check in qp attr that device supports
-		if (m_p_rx_ring && !m_p_rx_ring->is_ratelimit_supported(BYTE_TO_KB(rate_limit_bytes_per_second))) {
+		if (m_p_rx_ring && !m_p_rx_ring->is_ratelimit_supported(rate_limit)) {
 			si_logwarn("device doesn't support packet pacing or bad value, run ibv_devinfo -v");
 			return -1;
 		}
-		m_so_ratelimit = BYTE_TO_KB(rate_limit_bytes_per_second);
+
 		if (p_dst_entry) {
+			int ret = p_dst_entry->modify_ratelimit(rate_limit);
+
+			if (!ret)
+				m_so_ratelimit = rate_limit;
 			// value is in bytes (per second). we need to convert it to kilo-bits (per second)
-			return p_dst_entry->modify_ratelimit(m_so_ratelimit);
+			return ret;
 		}
 		return 0;
 	}
 	si_logwarn("VMA is not configured with TX ring allocation logic per "
-		   "socket.");
+		   "socket or user-id.");
 	return -1;
 }
 

--- a/src/vma/sock/sockinfo.h
+++ b/src/vma/sock/sockinfo.h
@@ -207,7 +207,7 @@ protected:
 	// Callback function pointer to support VMA extra API (vma_extra.h)
 	vma_recv_callback_t	m_rx_callback;
 	void*			m_rx_callback_context; // user context
-	uint32_t		m_so_ratelimit;
+	struct vma_rate_limit_t m_so_ratelimit;
 #ifdef DEFINED_SOCKETXTREME	
 	void*			m_fd_context;
 #endif // DEFINED_SOCKETXTREME	
@@ -269,7 +269,7 @@ protected:
 	virtual void		unlock_rx_q() {m_lock_rcv.unlock();}
 
 	void 			destructor_helper();
-	int 			modify_ratelimit(dst_entry* p_dst_entry, const uint32_t rate_limit_bytes_per_second);
+	int 			modify_ratelimit(dst_entry* p_dst_entry, struct vma_rate_limit_t &rate_limit);
 
 	void 			move_owned_rx_ready_descs(const mem_buf_desc_owner* p_desc_owner, descq_t* toq); // Move all owner's rx ready packets ro 'toq'
 	void			set_sockopt_prio(__const void *__optval, socklen_t __optlen);

--- a/src/vma/sock/sockinfo_udp.cpp
+++ b/src/vma/sock/sockinfo_udp.cpp
@@ -919,9 +919,24 @@ int sockinfo_udp::setsockopt(int __level, int __optname, __const void *__optval,
 				break;
 			case SO_MAX_PACING_RATE:
 				if (__optval) {
-					uint32_t val = *(uint32_t *)__optval; // value is in bytes per second
+					struct vma_rate_limit_t val;
+
+					if (sizeof(struct vma_rate_limit_t) <= __optlen) {
+						val = *(struct vma_rate_limit_t*)__optval; // value is in bytes per second
+					} else if (sizeof(uint32_t) <= __optlen) {
+						val.rate = *(uint32_t*)__optval; // value is in bytes per second
+						val.upper_bound_sz = 0;
+						val.typical_pkt_sz = 0;
+					} else {
+						si_udp_logdbg("SOL_SOCKET, %s=\"???\" - bad length got %d",
+							      setsockopt_so_opt_to_str(__optname), __optlen);
+						return -1;
+					}
+
+					val.rate = BYTE_TO_KB(val.rate); // value is in bytes per second
+
 					if (modify_ratelimit(m_p_connected_dst_entry, val) < 0) {
-						si_udp_logdbg("error setting setsockopt SO_MAX_PACING_RATE for connected dst_entry %p: %d bytes/second ", m_p_connected_dst_entry, val);
+						si_udp_logdbg("error setting setsockopt SO_MAX_PACING_RATE for connected dst_entry %p: %d bytes/second ", m_p_connected_dst_entry, val.rate);
 
 						// Do not fall back to kernel in this case.
 						// The kernel's support for packet pacing is of no consequence
@@ -938,7 +953,7 @@ int sockinfo_udp::setsockopt(int __level, int __optname, __const void *__optval,
 						if (modify_ratelimit(p_dst_entry, val) < 0) {
 							si_udp_logdbg("error setting setsockopt SO_MAX_PACING_RATE "
 								      "for dst_entry %p: %d bytes/second ",
-								      p_dst_entry, val);
+								      p_dst_entry, val.rate);
 							dst_entries_not_modified++;
 						}
 					}

--- a/src/vma/util/verbs_extra.cpp
+++ b/src/vma/util/verbs_extra.cpp
@@ -35,6 +35,7 @@
 #include <vlogger/vlogger.h>
 
 #include "verbs_extra.h"
+#include "vma_extra.h"
 #include "valgrind.h"
 
 #undef  MODULE_NAME
@@ -327,10 +328,11 @@ int vma_rdma_lib_reset() {
 }
 
 // be advised that this method will change packet pacing value and also change state to RTS
-int priv_ibv_modify_qp_ratelimit(struct ibv_qp *qp, uint32_t ratelimit_kbps )
+int priv_ibv_modify_qp_ratelimit(struct ibv_qp *qp, struct vma_rate_limit_t &rate_limit, uint32_t rl_changes)
 {
 #ifdef DEFINED_IBV_EXP_QP_RATE_LIMIT
 	vma_ibv_qp_attr qp_attr;
+	uint64_t exp_attr_mask = IBV_QP_STATE;
 
 	if (priv_ibv_query_qp_state(qp) != IBV_QPS_RTS) {
 		vlog_printf(VLOG_DEBUG, "failed querying QP");
@@ -338,19 +340,36 @@ int priv_ibv_modify_qp_ratelimit(struct ibv_qp *qp, uint32_t ratelimit_kbps )
 	}
 	memset(&qp_attr, 0, sizeof(qp_attr));
 	qp_attr.qp_state = IBV_QPS_RTS;
-	qp_attr.rate_limit = ratelimit_kbps;
+
+	if (rate_limit.rate && (rl_changes & RL_RATE)) {
+		qp_attr.rate_limit = rate_limit.rate;
+		exp_attr_mask |= IBV_EXP_QP_RATE_LIMIT;
+	}
+#ifdef DEFINED_IBV_EXP_QP_BURST_INFO
+	if (rate_limit.upper_bound_sz && rate_limit.typical_pkt_sz && (rl_changes & (RL_BURST_SIZE | RL_PKT_SIZE))) {
+		qp_attr.burst_info.upper_bound_sz = rate_limit.upper_bound_sz;
+		qp_attr.burst_info.typical_pkt_sz = rate_limit.typical_pkt_sz;
+		exp_attr_mask |= IBV_EXP_QP_BURST_INFO;
+	}
+#endif
 	BULLSEYE_EXCLUDE_BLOCK_START
-	IF_VERBS_FAILURE(vma_ibv_modify_qp(qp, &qp_attr, IBV_QP_STATE | IBV_EXP_QP_RATE_LIMIT)) {
+	IF_VERBS_FAILURE(vma_ibv_modify_qp(qp, &qp_attr, exp_attr_mask)) {
 		vlog_printf(VLOG_WARNING, "failed setting rate limit");
 		return -2;
 	} ENDIF_VERBS_FAILURE;
 	BULLSEYE_EXCLUDE_BLOCK_END
-	vlog_printf(VLOG_DEBUG, "qp was set to rate limit %d", ratelimit_kbps);
+#ifdef DEFINED_IBV_EXP_QP_BURST_INFO
+	vlog_printf(VLOG_DEBUG, "qp was set to rate limit %d", rate_limit.rate);
+#else
+	vlog_printf(VLOG_DEBUG, "qp was set to rate limit %d, burst size %d, packet size %d",
+			rate_limit.rate, rate_limit.upper_bound_sz, rate_limit.typical_pkt_sz);
+#endif
 	return 0;
 #else
 	vlog_printf(VLOG_DEBUG, "rate limit not supported");
 	NOT_IN_USE(qp);
-	NOT_IN_USE(ratelimit_kbps);
+	NOT_IN_USE(rate_limit);
+	NOT_IN_USE(rl_changes);
 	return 0;
 #endif
 }

--- a/src/vma/util/verbs_extra.cpp
+++ b/src/vma/util/verbs_extra.cpp
@@ -359,10 +359,10 @@ int priv_ibv_modify_qp_ratelimit(struct ibv_qp *qp, struct vma_rate_limit_t &rat
 	} ENDIF_VERBS_FAILURE;
 	BULLSEYE_EXCLUDE_BLOCK_END
 #ifdef DEFINED_IBV_EXP_QP_BURST_INFO
-	vlog_printf(VLOG_DEBUG, "qp was set to rate limit %d", rate_limit.rate);
-#else
 	vlog_printf(VLOG_DEBUG, "qp was set to rate limit %d, burst size %d, packet size %d",
 			rate_limit.rate, rate_limit.upper_bound_sz, rate_limit.typical_pkt_sz);
+#else
+	vlog_printf(VLOG_DEBUG, "qp was set to rate limit %d", rate_limit.rate);
 #endif
 	return 0;
 #else

--- a/src/vma/util/verbs_extra.cpp
+++ b/src/vma/util/verbs_extra.cpp
@@ -319,10 +319,10 @@ int priv_ibv_query_flow_tag_supported(struct ibv_qp *qp, uint8_t port_num)
 
 int vma_rdma_lib_reset() {
 #ifdef HAVE_RDMA_LIB_RESET
-	vlog_printf(VLOG_DEBUG, "rdma_lib_reset called");
+	vlog_printf(VLOG_DEBUG, "rdma_lib_reset called\n");
 	return rdma_lib_reset();
 #else
-	vlog_printf(VLOG_DEBUG, "rdma_lib_reset doesn't exist returning 0");
+	vlog_printf(VLOG_DEBUG, "rdma_lib_reset doesn't exist returning 0\n");
 	return 0;
 #endif
 }
@@ -335,7 +335,7 @@ int priv_ibv_modify_qp_ratelimit(struct ibv_qp *qp, struct vma_rate_limit_t &rat
 	uint64_t exp_attr_mask = IBV_QP_STATE;
 
 	if (priv_ibv_query_qp_state(qp) != IBV_QPS_RTS) {
-		vlog_printf(VLOG_DEBUG, "failed querying QP");
+		vlog_printf(VLOG_DEBUG, "failed querying QP\n");
 		return -1;
 	}
 	memset(&qp_attr, 0, sizeof(qp_attr));
@@ -354,19 +354,19 @@ int priv_ibv_modify_qp_ratelimit(struct ibv_qp *qp, struct vma_rate_limit_t &rat
 #endif
 	BULLSEYE_EXCLUDE_BLOCK_START
 	IF_VERBS_FAILURE(vma_ibv_modify_qp(qp, &qp_attr, exp_attr_mask)) {
-		vlog_printf(VLOG_WARNING, "failed setting rate limit");
+		vlog_printf(VLOG_WARNING, "failed setting rate limit\n");
 		return -2;
 	} ENDIF_VERBS_FAILURE;
 	BULLSEYE_EXCLUDE_BLOCK_END
 #ifdef DEFINED_IBV_EXP_QP_BURST_INFO
-	vlog_printf(VLOG_DEBUG, "qp was set to rate limit %d, burst size %d, packet size %d",
+	vlog_printf(VLOG_DEBUG, "qp was set to rate limit %d, burst size %d, packet size %d\n",
 			rate_limit.rate, rate_limit.upper_bound_sz, rate_limit.typical_pkt_sz);
 #else
-	vlog_printf(VLOG_DEBUG, "qp was set to rate limit %d", rate_limit.rate);
+	vlog_printf(VLOG_DEBUG, "qp was set to rate limit %d\n", rate_limit.rate);
 #endif
 	return 0;
 #else
-	vlog_printf(VLOG_DEBUG, "rate limit not supported");
+	vlog_printf(VLOG_DEBUG, "rate limit not supported\n");
 	NOT_IN_USE(qp);
 	NOT_IN_USE(rate_limit);
 	NOT_IN_USE(rl_changes);

--- a/src/vma/util/verbs_extra.h
+++ b/src/vma/util/verbs_extra.h
@@ -95,7 +95,7 @@ int priv_ibv_modify_qp_from_init_to_rts(struct ibv_qp *qp, uint32_t underly_qpn 
 int priv_ibv_query_qp_state(struct ibv_qp *qp);
 
 // change  ib rate limit
-int priv_ibv_modify_qp_ratelimit(struct ibv_qp *qp, uint32_t ratelimit_kbps);
+int priv_ibv_modify_qp_ratelimit(struct ibv_qp *qp, struct vma_rate_limit_t &rate_limit, uint32_t rl_changes);
 
 
 #ifndef VLAN_VID_MASK
@@ -315,6 +315,12 @@ typedef struct ibv_exp_flow_spec_action_tag_dummy {}	vma_ibv_flow_spec_action_ta
 #else
 #define vma_ibv_dm_size(attr)			(0)
 #endif
+
+typedef enum {
+	RL_RATE = 1<<0,
+	RL_BURST_SIZE = 1<<1,
+	RL_PKT_SIZE = 1<<2,
+} vma_rl_changed;
 
 typedef enum vma_wr_tx_packet_attr {
 	VMA_TX_PACKET_BLOCK   = (1 << 0), // blocking send

--- a/src/vma/vma_extra.h
+++ b/src/vma/vma_extra.h
@@ -78,12 +78,6 @@ typedef enum {
     VMA_SOCKETXTREME_NEW_CONNECTION_ACCEPTED	= (1ULL << 33)  /* New connection is auto accepted by server */
 } vma_socketxtreme_events_t;
 
-struct vma_rate_limit_t {
-	uint32_t rate;				/* rate limit in Kbps */
-	uint32_t upper_bound_sz;		/* maximum burst size in bytes */
-	uint16_t typical_pkt_sz;		/* typical packet size in bytes */
-};
-
 /*
  * Represents  VMA buffer
  * Used in SocketXtreme extended API.
@@ -175,6 +169,12 @@ struct __attribute__ ((packed)) vma_info_t {
 	/* Packet timestamping information */
 	struct timespec		hw_timestamp;
 	struct timespec		sw_timestamp;
+};
+
+struct vma_rate_limit_t {
+	uint32_t rate;				/* rate limit in Kbps */
+	uint32_t upper_bound_sz;		/* maximum burst size in bytes */
+	uint16_t typical_pkt_sz;		/* typical packet size in bytes */
 };
 
 typedef enum {

--- a/src/vma/vma_extra.h
+++ b/src/vma/vma_extra.h
@@ -78,6 +78,12 @@ typedef enum {
     VMA_SOCKETXTREME_NEW_CONNECTION_ACCEPTED	= (1ULL << 33)  /* New connection is auto accepted by server */
 } vma_socketxtreme_events_t;
 
+struct vma_rate_limit_t {
+	uint32_t rate;				/* rate limit in Kbps */
+	uint32_t upper_bound_sz;		/* maximum burst size in bytes */
+	uint16_t typical_pkt_sz;		/* typical packet size in bytes */
+};
+
 /*
  * Represents  VMA buffer
  * Used in SocketXtreme extended API.


### PR DESCRIPTION
Enable configuring burst control by modify_qp. By using burst control
with rate limiting, the user can achieve best performance and accuracy.

If only one of the options is specified by the user between RATE_LIMIT
and BURST_INFO, mlx5 driver will use the saved value for the other field.

Signed-off-by: Ilan Smith <ilansm@mellanox.com>