### PR TITLE
issue: 1258245 Fix SYN messages are sent to invalid peer

### DIFF
--- a/src/vma/proto/neighbour.h
+++ b/src/vma/proto/neighbour.h
@@ -326,6 +326,7 @@ protected:
 	bool 			priv_get_neigh_state(int & state);
 	bool 			priv_get_neigh_l2(address_t & l2_addr);
 	bool 			priv_is_reachable(int state) { return state & (NUD_REACHABLE | NUD_PERMANENT); }
+	bool 			priv_is_failed(int state) { return state & (NUD_FAILED | NUD_INCOMPLETE); }
 
 	void			event_handler(event_t event, void* p_event_info = NULL);
 	void			priv_event_handler_no_locks(event_t event, void* p_event_info = NULL);


### PR DESCRIPTION
Wrong handling of INCOMPLETE neighbor state causes VMA to send
SYN packets to invalid peers.

Signed-off-by: Liran Oz <lirano@mellanox.com>