### PR TITLE
issue: 1259552 Optimize global get buffers procedure

### DIFF
--- a/src/vma/dev/buffer_pool.h
+++ b/src/vma/dev/buffer_pool.h
@@ -66,7 +66,7 @@ public:
 	 * @param lkey The registered memory lkey.
 	 * @return False if no buffers are available, else True.
 	 */
-	bool get_buffers_thread_safe(descq_t *pDeque, mem_buf_desc_owner* desc_owner, size_t count, uint32_t lkey);
+	bool get_buffers_thread_safe(descq_t &pDeque, mem_buf_desc_owner* desc_owner, size_t count, uint32_t lkey);
 
 	/**
 	 * Return buffers to the pool.

--- a/src/vma/dev/buffer_pool.h
+++ b/src/vma/dev/buffer_pool.h
@@ -60,11 +60,13 @@ public:
 
 	/**
 	 * Get buffers from the pool - thread safe
+	 * @parma pDeque List to put the buffers.
+	 * @param desc_owner The new owner of the buffers.
 	 * @param count Number of buffers required.
-	 * @param lkey the registered memory lkey.
-	 * @return List of buffers, or NULL if don't have enough buffers.
+	 * @param lkey The registered memory lkey.
+	 * @return False if no buffers are available, else True.
 	 */
-	mem_buf_desc_t *get_buffers_thread_safe(size_t count, uint32_t lkey);
+	bool get_buffers_thread_safe(descq_t *pDeque, mem_buf_desc_owner* desc_owner, size_t count, uint32_t lkey);
 
 	/**
 	 * Return buffers to the pool.
@@ -104,14 +106,6 @@ private:
 	 * Add a buffer to the pool
 	 */
 	inline void	put_buffer_helper(mem_buf_desc_t *buff);
-
-	/**
-	 * Get buffers from the pool - no thread safe
-	 * @param count Number of buffers required.
-	 * @param lkey the registered memory lkey.
-	 * @return List of buffers, or NULL if don't have enough buffers.
-	 */
-	inline mem_buf_desc_t *get_buffers(size_t count, uint32_t lkey);
 
 	void		buffersPanic();
 

--- a/src/vma/dev/cq_mgr.cpp
+++ b/src/vma/dev/cq_mgr.cpp
@@ -586,7 +586,7 @@ bool cq_mgr::compensate_qp_poll_success(mem_buf_desc_t* buff_cur)
 #endif // DEFINED_SOCKETXTREME
 		
 		if (m_rx_pool.size() || request_more_buffers()) {
-			m_qp_rec.debt -= m_qp_rec.qp->post_recv_buffers(&m_rx_pool, MIN(m_qp_rec.debt, m_rx_pool.size()));
+			m_qp_rec.debt -= m_qp_rec.qp->post_recv_buffers(&m_rx_pool, MIN((size_t)m_qp_rec.debt, m_rx_pool.size()));
 			m_p_cq_stat->n_buffer_pool_len = m_rx_pool.size();
 		}
 		else if (m_b_sysvar_cq_keep_qp_full ||

--- a/src/vma/dev/cq_mgr.cpp
+++ b/src/vma/dev/cq_mgr.cpp
@@ -583,7 +583,9 @@ bool cq_mgr::compensate_qp_poll_success(mem_buf_desc_t* buff_cur)
 #endif // DEFINED_SOCKETXTREME
 		
 		if (m_rx_pool.size() || request_more_buffers()) {
-			m_qp_rec.debt -= m_qp_rec.qp->post_recv_buffers(&m_rx_pool, std::min<size_t>(m_qp_rec.debt, m_rx_pool.size()));
+			size_t buffers = std::min<size_t>(m_qp_rec.debt, m_rx_pool.size());
+			m_qp_rec.qp->post_recv_buffers(&m_rx_pool, buffers);
+			m_qp_rec.debt -= buffers;
 			m_p_cq_stat->n_buffer_pool_len = m_rx_pool.size();
 		}
 		else if (m_b_sysvar_cq_keep_qp_full ||

--- a/src/vma/dev/cq_mgr.inl
+++ b/src/vma/dev/cq_mgr.inl
@@ -58,7 +58,7 @@ inline void cq_mgr::compensate_qp_poll_failed()
 	// Compensate QP for all completions debt
 	if (m_qp_rec.debt) {
 		if (likely(m_rx_pool.size() || request_more_buffers())) {
-			m_qp_rec.debt -= m_qp_rec.qp->post_recv_buffers(&m_rx_pool, MIN(m_qp_rec.debt, m_rx_pool.size()));
+			m_qp_rec.debt -= m_qp_rec.qp->post_recv_buffers(&m_rx_pool, MIN((size_t)m_qp_rec.debt, m_rx_pool.size()));
 			m_p_cq_stat->n_buffer_pool_len = m_rx_pool.size();
 		}
 	}

--- a/src/vma/dev/cq_mgr.inl
+++ b/src/vma/dev/cq_mgr.inl
@@ -58,7 +58,7 @@ inline void cq_mgr::compensate_qp_poll_failed()
 	// Compensate QP for all completions debt
 	if (m_qp_rec.debt) {
 		if (likely(m_rx_pool.size() || request_more_buffers())) {
-			m_qp_rec.debt -= m_qp_rec.qp->post_recv_buffers(&m_rx_pool, MIN((size_t)m_qp_rec.debt, m_rx_pool.size()));
+			m_qp_rec.debt -= m_qp_rec.qp->post_recv_buffers(&m_rx_pool, std::min<size_t>(m_qp_rec.debt, m_rx_pool.size()));
 			m_p_cq_stat->n_buffer_pool_len = m_rx_pool.size();
 		}
 	}

--- a/src/vma/dev/cq_mgr.inl
+++ b/src/vma/dev/cq_mgr.inl
@@ -58,10 +58,7 @@ inline void cq_mgr::compensate_qp_poll_failed()
 	// Compensate QP for all completions debt
 	if (m_qp_rec.debt) {
 		if (likely(m_rx_pool.size() || request_more_buffers())) {
-			do {
-				mem_buf_desc_t *buff_new = m_rx_pool.get_and_pop_front();
-				m_qp_rec.qp->post_recv(buff_new);
-			} while (--m_qp_rec.debt > 0 && m_rx_pool.size());
+			m_qp_rec.debt -= m_qp_rec.qp->post_recv_buffers(&m_rx_pool, MIN(m_qp_rec.debt, m_rx_pool.size()));
 			m_p_cq_stat->n_buffer_pool_len = m_rx_pool.size();
 		}
 	}

--- a/src/vma/dev/cq_mgr.inl
+++ b/src/vma/dev/cq_mgr.inl
@@ -58,7 +58,9 @@ inline void cq_mgr::compensate_qp_poll_failed()
 	// Compensate QP for all completions debt
 	if (m_qp_rec.debt) {
 		if (likely(m_rx_pool.size() || request_more_buffers())) {
-			m_qp_rec.debt -= m_qp_rec.qp->post_recv_buffers(&m_rx_pool, std::min<size_t>(m_qp_rec.debt, m_rx_pool.size()));
+			size_t buffers = std::min<size_t>(m_qp_rec.debt, m_rx_pool.size());
+			m_qp_rec.qp->post_recv_buffers(&m_rx_pool, buffers);
+			m_qp_rec.debt -= buffers;
 			m_p_cq_stat->n_buffer_pool_len = m_rx_pool.size();
 		}
 	}

--- a/src/vma/dev/qp_mgr.cpp
+++ b/src/vma/dev/qp_mgr.cpp
@@ -476,7 +476,7 @@ uint32_t qp_mgr::get_rx_max_wr_num()
 	return m_rx_num_wr;
 }
 
-int qp_mgr::post_recv_buffer(mem_buf_desc_t* p_mem_buf_desc)
+void qp_mgr::post_recv_buffer(mem_buf_desc_t* p_mem_buf_desc)
 {
 	if (m_n_sysvar_rx_prefetch_bytes_before_poll) {
 		if (m_p_prev_rx_desc_pushed)
@@ -522,22 +522,17 @@ int qp_mgr::post_recv_buffer(mem_buf_desc_t* p_mem_buf_desc)
 	else {
 		m_curr_rx_wr++;
 	}
-
-	return 0;
 }
 
-int qp_mgr::post_recv_buffers(descq_t* p_buffers, size_t count)
+size_t qp_mgr::post_recv_buffers(descq_t* p_buffers, size_t count)
 {
 	qp_logfuncall("");
 	// Called from cq_mgr context under cq_mgr::LOCK!
-	int sum;
-	for (sum = 0; count > 0 ; sum++, count--) {
-		if (post_recv_buffer(p_buffers->get_and_pop_front()) < 0) {
-			break;
-		}
+	for (size_t i = 0; i < count ; i++) {
+		post_recv_buffer(p_buffers->get_and_pop_front());
 	}
 
-	return sum;
+	return count;
 }
 
 inline int qp_mgr::send_to_wire(vma_ibv_send_wr* p_send_wqe, vma_wr_tx_packet_attr attr, bool request_comp)

--- a/src/vma/dev/qp_mgr.cpp
+++ b/src/vma/dev/qp_mgr.cpp
@@ -524,15 +524,13 @@ void qp_mgr::post_recv_buffer(mem_buf_desc_t* p_mem_buf_desc)
 	}
 }
 
-size_t qp_mgr::post_recv_buffers(descq_t* p_buffers, size_t count)
+void qp_mgr::post_recv_buffers(descq_t* p_buffers, size_t count)
 {
 	qp_logfuncall("");
 	// Called from cq_mgr context under cq_mgr::LOCK!
-	for (size_t i = 0; i < count ; i++) {
+	while (count--) {
 		post_recv_buffer(p_buffers->get_and_pop_front());
 	}
-
-	return count;
 }
 
 inline int qp_mgr::send_to_wire(vma_ibv_send_wr* p_send_wqe, vma_wr_tx_packet_attr attr, bool request_comp)

--- a/src/vma/dev/qp_mgr.cpp
+++ b/src/vma/dev/qp_mgr.cpp
@@ -476,65 +476,68 @@ uint32_t qp_mgr::get_rx_max_wr_num()
 	return m_rx_num_wr;
 }
 
-int qp_mgr::post_recv(mem_buf_desc_t* p_mem_buf_desc)
+int qp_mgr::post_recv_buffer(mem_buf_desc_t* p_mem_buf_desc)
 {
-	qp_logfuncall("");
-	// Called from cq_mgr context under cq_mgr::LOCK!
-	mem_buf_desc_t *next;
-	while (p_mem_buf_desc) {
-		next = p_mem_buf_desc->p_next_desc;
-		p_mem_buf_desc->p_next_desc = NULL;
+	if (m_n_sysvar_rx_prefetch_bytes_before_poll) {
+		if (m_p_prev_rx_desc_pushed)
+			m_p_prev_rx_desc_pushed->p_prev_desc = p_mem_buf_desc;
+		m_p_prev_rx_desc_pushed = p_mem_buf_desc;
+	}
 
-		if (m_n_sysvar_rx_prefetch_bytes_before_poll) {
-			if (m_p_prev_rx_desc_pushed)
-				m_p_prev_rx_desc_pushed->p_prev_desc = p_mem_buf_desc;
-			m_p_prev_rx_desc_pushed = p_mem_buf_desc;
-		}
+	m_ibv_rx_wr_array[m_curr_rx_wr].wr_id  = (uintptr_t)p_mem_buf_desc;
+	m_ibv_rx_sg_array[m_curr_rx_wr].addr   = (uintptr_t)p_mem_buf_desc->p_buffer;
+	m_ibv_rx_sg_array[m_curr_rx_wr].length = p_mem_buf_desc->sz_buffer;
+	m_ibv_rx_sg_array[m_curr_rx_wr].lkey   = p_mem_buf_desc->lkey;
 
-		m_ibv_rx_wr_array[m_curr_rx_wr].wr_id  = (uintptr_t)p_mem_buf_desc;
-		m_ibv_rx_sg_array[m_curr_rx_wr].addr   = (uintptr_t)p_mem_buf_desc->p_buffer;
-		m_ibv_rx_sg_array[m_curr_rx_wr].length = p_mem_buf_desc->sz_buffer;
-		m_ibv_rx_sg_array[m_curr_rx_wr].lkey   = p_mem_buf_desc->lkey;
+	if (m_rq_wqe_idx_to_wrid) {
+		uint32_t index = m_rq_wqe_counter & (m_rx_num_wr - 1);
+		m_rq_wqe_idx_to_wrid[index] = (uintptr_t)p_mem_buf_desc;
+		++m_rq_wqe_counter;
+	}
 
-		if (m_rq_wqe_idx_to_wrid) {
-			uint32_t index = m_rq_wqe_counter & (m_rx_num_wr - 1);
-			m_rq_wqe_idx_to_wrid[index] = (uintptr_t)p_mem_buf_desc;
-			++m_rq_wqe_counter;
-		}
+	if (m_curr_rx_wr == m_n_sysvar_rx_num_wr_to_post_recv - 1) {
 
-		if (m_curr_rx_wr == m_n_sysvar_rx_num_wr_to_post_recv - 1) {
+		m_last_posted_rx_wr_id = (uintptr_t)p_mem_buf_desc;
 
-			m_last_posted_rx_wr_id = (uintptr_t)p_mem_buf_desc;
+		m_p_prev_rx_desc_pushed = NULL;
+		p_mem_buf_desc->p_prev_desc = NULL;
 
-			m_p_prev_rx_desc_pushed = NULL;
-			p_mem_buf_desc->p_prev_desc = NULL;
+		m_curr_rx_wr = 0;
+		struct ibv_recv_wr *bad_wr = NULL;
+		IF_VERBS_FAILURE(ibv_post_recv(m_qp, &m_ibv_rx_wr_array[0], &bad_wr)) {
+			uint32_t n_pos_bad_rx_wr = ((uint8_t*)bad_wr - (uint8_t*)m_ibv_rx_wr_array) / sizeof(struct ibv_recv_wr);
+			qp_logerr("failed posting list (errno=%d %m)", errno);
+			qp_logerr("bad_wr is %d in submitted list (bad_wr=%p, m_ibv_rx_wr_array=%p, size=%d)", n_pos_bad_rx_wr, bad_wr, m_ibv_rx_wr_array, sizeof(struct ibv_recv_wr));
+			qp_logerr("bad_wr info: wr_id=%#x, next=%p, addr=%#x, length=%d, lkey=%#x", bad_wr[0].wr_id, bad_wr[0].next, bad_wr[0].sg_list[0].addr, bad_wr[0].sg_list[0].length, bad_wr[0].sg_list[0].lkey);
+			qp_logerr("QP current state: %d", priv_ibv_query_qp_state(m_qp));
 
-			m_curr_rx_wr = 0;
-			struct ibv_recv_wr *bad_wr = NULL;
-			IF_VERBS_FAILURE(ibv_post_recv(m_qp, &m_ibv_rx_wr_array[0], &bad_wr)) {
-				uint32_t n_pos_bad_rx_wr = ((uint8_t*)bad_wr - (uint8_t*)m_ibv_rx_wr_array) / sizeof(struct ibv_recv_wr);
-				qp_logerr("failed posting list (errno=%d %m)", errno);
-				qp_logerr("bad_wr is %d in submitted list (bad_wr=%p, m_ibv_rx_wr_array=%p, size=%d)", n_pos_bad_rx_wr, bad_wr, m_ibv_rx_wr_array, sizeof(struct ibv_recv_wr));
-				qp_logerr("bad_wr info: wr_id=%#x, next=%p, addr=%#x, length=%d, lkey=%#x", bad_wr[0].wr_id, bad_wr[0].next, bad_wr[0].sg_list[0].addr, bad_wr[0].sg_list[0].length, bad_wr[0].sg_list[0].lkey);
-				qp_logerr("QP current state: %d", priv_ibv_query_qp_state(m_qp));
-
-				// Fix broken linked list of rx_wr
-				if (n_pos_bad_rx_wr != (m_n_sysvar_rx_num_wr_to_post_recv - 1)) {
-					m_ibv_rx_wr_array[n_pos_bad_rx_wr].next = &m_ibv_rx_wr_array[n_pos_bad_rx_wr+1];
-				}
-				throw;
-			} ENDIF_VERBS_FAILURE;
-			qp_logfunc("Successful ibv_post_recv");
-		}
-		else {
-			m_curr_rx_wr++;
-		}
-
-
-		p_mem_buf_desc = next;
+			// Fix broken linked list of rx_wr
+			if (n_pos_bad_rx_wr != (m_n_sysvar_rx_num_wr_to_post_recv - 1)) {
+				m_ibv_rx_wr_array[n_pos_bad_rx_wr].next = &m_ibv_rx_wr_array[n_pos_bad_rx_wr+1];
+			}
+			throw;
+		} ENDIF_VERBS_FAILURE;
+		qp_logfunc("Successful ibv_post_recv");
+	}
+	else {
+		m_curr_rx_wr++;
 	}
 
 	return 0;
+}
+
+int qp_mgr::post_recv_buffers(descq_t* p_buffers, size_t count)
+{
+	qp_logfuncall("");
+	// Called from cq_mgr context under cq_mgr::LOCK!
+	int sum;
+	for (sum = 0; count > 0 ; sum++, count--) {
+		if (post_recv_buffer(p_buffers->get_and_pop_front()) < 0) {
+			break;
+		}
+	}
+
+	return sum;
 }
 
 inline int qp_mgr::send_to_wire(vma_ibv_send_wr* p_send_wqe, vma_wr_tx_packet_attr attr, bool request_comp)

--- a/src/vma/dev/qp_mgr.h
+++ b/src/vma/dev/qp_mgr.h
@@ -108,7 +108,8 @@ public:
 	virtual void        up();
 	virtual void        down();
 
-	int                 post_recv(mem_buf_desc_t* p_mem_buf_desc); // Post for receive a list of mem_buf_desc
+	int                 post_recv_buffer(mem_buf_desc_t* p_mem_buf_desc); // Post for receive single mem_buf_desc
+	int                 post_recv_buffers(descq_t* p_buffers, size_t count); // Post for receive a list of mem_buf_desc
 	int                 send(vma_ibv_send_wr* p_send_wqe, vma_wr_tx_packet_attr attr);
 
 	uint32_t            get_max_inline_tx_data() const {return m_max_inline_data; }

--- a/src/vma/dev/qp_mgr.h
+++ b/src/vma/dev/qp_mgr.h
@@ -109,7 +109,7 @@ public:
 	virtual void        down();
 
 	void                post_recv_buffer(mem_buf_desc_t* p_mem_buf_desc); // Post for receive single mem_buf_desc
-	size_t              post_recv_buffers(descq_t* p_buffers, size_t count); // Post for receive a list of mem_buf_desc
+	void                post_recv_buffers(descq_t* p_buffers, size_t count); // Post for receive a list of mem_buf_desc
 	int                 send(vma_ibv_send_wr* p_send_wqe, vma_wr_tx_packet_attr attr);
 
 	uint32_t            get_max_inline_tx_data() const {return m_max_inline_data; }

--- a/src/vma/dev/qp_mgr.h
+++ b/src/vma/dev/qp_mgr.h
@@ -108,8 +108,8 @@ public:
 	virtual void        up();
 	virtual void        down();
 
-	int                 post_recv_buffer(mem_buf_desc_t* p_mem_buf_desc); // Post for receive single mem_buf_desc
-	int                 post_recv_buffers(descq_t* p_buffers, size_t count); // Post for receive a list of mem_buf_desc
+	void                post_recv_buffer(mem_buf_desc_t* p_mem_buf_desc); // Post for receive single mem_buf_desc
+	size_t              post_recv_buffers(descq_t* p_buffers, size_t count); // Post for receive a list of mem_buf_desc
 	int                 send(vma_ibv_send_wr* p_send_wqe, vma_wr_tx_packet_attr attr);
 
 	uint32_t            get_max_inline_tx_data() const {return m_max_inline_data; }

--- a/src/vma/dev/ring_simple.cpp
+++ b/src/vma/dev/ring_simple.cpp
@@ -1737,7 +1737,7 @@ bool ring_simple::request_more_tx_buffers(uint32_t count)
 {
 	ring_logfuncall("Allocating additional %d buffers for internal use", count);
 
-	bool res = g_buffer_pool_tx->get_buffers_thread_safe(&m_tx_pool, this, count, m_tx_lkey);
+	bool res = g_buffer_pool_tx->get_buffers_thread_safe(m_tx_pool, this, count, m_tx_lkey);
 	if (!res) {
 		ring_logfunc("Out of mem_buf_desc from TX free pool for internal object pool");
 		return false;

--- a/src/vma/dev/ring_simple.cpp
+++ b/src/vma/dev/ring_simple.cpp
@@ -1735,23 +1735,12 @@ bool ring_simple::is_available_qp_wr(bool b_block)
 //call under m_lock_ring_tx lock
 bool ring_simple::request_more_tx_buffers(uint32_t count)
 {
-	mem_buf_desc_t *p_temp_desc_list, *p_temp_buff;
-
 	ring_logfuncall("Allocating additional %d buffers for internal use", count);
 
-	//todo have get_buffers_thread_safe with given m_tx_pool as parameter, to save assembling and disassembling of buffer chain
-	p_temp_desc_list = g_buffer_pool_tx->get_buffers_thread_safe(count, m_tx_lkey);
-	if (p_temp_desc_list == NULL) {
+	bool res = g_buffer_pool_tx->get_buffers_thread_safe(&m_tx_pool, this, count, m_tx_lkey);
+	if (!res) {
 		ring_logfunc("Out of mem_buf_desc from TX free pool for internal object pool");
 		return false;
-	}
-
-	while (p_temp_desc_list) {
-		p_temp_buff = p_temp_desc_list;
-		p_temp_desc_list = p_temp_buff->p_next_desc;
-		p_temp_buff->p_desc_owner = this;
-		p_temp_buff->p_next_desc = NULL;
-		m_tx_pool.push_back(p_temp_buff);
 	}
 
 	return true;


### PR DESCRIPTION
During runtime, requesting buffers from the global buffer pool requires
double iteration over the buffers list, this should be optimize to a
single run.

Signed-off-by: Liran Oz <lirano@mellanox.com>