### PR TITLE
issue: 1263120  fix compilation if libibverbs doesn't use libnl

### DIFF
--- a/config/m4/nl.m4
+++ b/config/m4/nl.m4
@@ -43,7 +43,7 @@ if test "$use_libnl3" == yes; then
 	AC_SUBST([LIBNL_LIBS], "$LIBNL3_LIBS")
 	AC_SUBST([LIBNL_CFLAGS], "$LIBNL3_CFLAGS")
 	AC_SUBST([LIBNLX_DEVEL], "libnl3-devel")
-	AC_DEFINE([HAVE_LIBNL3], [1], [Use libnl-route-3.0])
+	AC_DEFINE([HAVE_LIBNL3], [1], [Use libnl-3])
 elif test "$use_libnl1" == yes; then
 	AC_SUBST([LIBNL_LIBS], "$LIBNL1_LIBS")
 	AC_SUBST([LIBNL_CFLAGS], "$LIBNL1_CFLAGS")


### PR DESCRIPTION
You can compile libibverbs so it won't use libnl at all. In
those cases vma should pick any libnl that is installed.

Signed-off-by: Rafi Wiener <rafiw@mellanox.com>