### PR TITLE
issue: 1264894 Resolve fd collection memory leaks

### DIFF
--- a/contrib/valgrind/valgrind_vma.supp
+++ b/contrib/valgrind/valgrind_vma.supp
@@ -13,8 +13,6 @@
    match-leak-kinds: definite
    fun:malloc
    fun:_ZN21event_handler_manager20register_timer_eventEiP13timer_handler16timer_req_type_tPvP12timers_group
-   fun:_ZN12sockinfo_tcp14register_timerEv
-   fun:_ZN12sockinfo_tcp7connectEPK8sockaddrj
 }
 ###########################################################
 # false positive librdmacm.so

--- a/contrib/valgrind/valgrind_vma.supp
+++ b/contrib/valgrind/valgrind_vma.supp
@@ -1,43 +1,5 @@
 # libvma issues to fix
 {
-   RM #1072426
-   Memcheck:Leak
-   match-leak-kinds: definite
-   ...
-   fun:_ZN20net_device_table_mgr16create_new_entryEj
-   fun:_ZN15cache_table_mgrI10ip_addressP14net_device_valE17register_observerES0_PK14cache_observerPP19cache_entry_subjectIS0_S2_E
-   fun:_ZN11route_entry22register_to_net_deviceEv
-}
-{
-   RM #1284069
-   Memcheck:Leak
-   match-leak-kinds: definite
-   ...
-   fun:_ZN20net_device_table_mgr16create_new_entryE10ip_addressPK8observer
-   fun:_ZN15cache_table_mgrI10ip_addressP14net_device_valE17register_observerES0_PK14cache_observerPP19cache_entry_subjectIS0_S2_E
-   fun:_ZN11route_entry22register_to_net_deviceEv
-}
-{
-   RM #1284069
-   Memcheck:Leak
-   match-leak-kinds: definite
-   ...
-   fun:_ZN15neigh_table_mgr16create_new_entryE9neigh_keyPK8observer
-   fun:register_observer
-   fun:_ZN15neigh_table_mgr17register_observerE9neigh_keyPK14cache_observerPP19cache_entry_subjectIS0_P9neigh_valE
-   fun:_ZN9dst_entry13resolve_neighEv
-   fun:_ZN9dst_entry15prepare_to_sendER16vma_rate_limit_tbb
-   ...
-}
-{
-   RM #1072427
-   Memcheck:Leak
-   match-leak-kinds: definite
-   fun:_Znwm
-   fun:_ZN13fd_collection17add_cq_channel_fdEiP4ring
-   fun:_ZN11ring_simple16create_resourcesEv
-}
-{
    RM #1073005
    Memcheck:Leak
    match-leak-kinds: definite

--- a/src/vma/event/event_handler_manager.h
+++ b/src/vma/event/event_handler_manager.h
@@ -206,7 +206,7 @@ private:
 	void	priv_prepare_ibverbs_async_event_queue(event_handler_map_t::iterator& i);
 
 	const char* reg_action_str(event_action_type_e	reg_action_type);
-	void    post_new_reg_action(reg_action_t& reg_action);
+	bool    post_new_reg_action(reg_action_t& reg_action);
 	void    handle_registration_action(reg_action_t& reg_action);
 	void	process_ibverbs_event(event_handler_map_t::iterator &i);
 	void	process_rdma_cm_event(event_handler_map_t::iterator &i);

--- a/src/vma/proto/neighbour.cpp
+++ b/src/vma/proto/neighbour.cpp
@@ -282,7 +282,7 @@ void neigh_entry::clean_obj()
 	set_cleaned();
 	m_timer_handle = NULL;
 	m_lock.unlock();
-
+	// Release lock before calling unregister_timers_event_and_delete.
 	g_p_event_handler_manager->unregister_timers_event_and_delete(this);
 }
 

--- a/src/vma/proto/neighbour.cpp
+++ b/src/vma/proto/neighbour.cpp
@@ -281,8 +281,9 @@ void neigh_entry::clean_obj()
 	m_lock.lock();
 	set_cleaned();
 	m_timer_handle = NULL;
-	g_p_event_handler_manager->unregister_timers_event_and_delete(this);
 	m_lock.unlock();
+
+	g_p_event_handler_manager->unregister_timers_event_and_delete(this);
 }
 
 int neigh_entry::send(neigh_send_info &s_info)

--- a/src/vma/sock/fd_collection.cpp
+++ b/src/vma/sock/fd_collection.cpp
@@ -162,6 +162,7 @@ void fd_collection::clear()
 				socket_fd_api *p_sfd_api = get_sockfd(fd);
 				if (p_sfd_api) {
 					p_sfd_api->statistics_print();
+					orig_os_api.close(p_sfd_api->get_fd()); // The user did not call close
 					if (!p_sfd_api->is_cleaned()) {
 						p_sfd_api->clean_obj();
 					}

--- a/src/vma/sock/fd_collection.cpp
+++ b/src/vma/sock/fd_collection.cpp
@@ -162,7 +162,6 @@ void fd_collection::clear()
 				socket_fd_api *p_sfd_api = get_sockfd(fd);
 				if (p_sfd_api) {
 					p_sfd_api->statistics_print();
-					orig_os_api.close(p_sfd_api->get_fd()); // The user did not call close
 					if (!p_sfd_api->is_cleaned()) {
 						p_sfd_api->clean_obj();
 					}

--- a/src/vma/sock/socket_fd_api.h
+++ b/src/vma/sock/socket_fd_api.h
@@ -261,13 +261,10 @@ protected:
 	// identification information <socket fd>
 	int m_fd;
 	const uint32_t	m_n_sysvar_select_poll_os_ratio;
+	epfd_info *m_econtext;
 
 	// Calling OS receive
 	ssize_t rx_os(const rx_call_t call_type, iovec* p_iov, ssize_t sz_iov,
 		      const int flags, sockaddr *__from, socklen_t *__fromlen, struct msghdr *__msg);
-
-
-private:
-	epfd_info *m_econtext;
 };
 #endif

--- a/src/vma/sock/sockinfo.cpp
+++ b/src/vma/sock/sockinfo.cpp
@@ -120,7 +120,7 @@ sockinfo::~sockinfo()
 		delete[] m_p_rings_fds;
 		m_p_rings_fds = NULL;
 	}
-        vma_stats_instance_remove_socket_block(m_p_socket_stats);
+	vma_stats_instance_remove_socket_block(m_p_socket_stats);
 }
 
 void sockinfo::set_blocking(bool is_blocked)

--- a/src/vma/sock/sockinfo_tcp.cpp
+++ b/src/vma/sock/sockinfo_tcp.cpp
@@ -488,6 +488,10 @@ bool sockinfo_tcp::prepare_to_close(bool process_shutdown /* = false */)
 
 	do_wakeup();
 
+	if (m_econtext) {
+		m_econtext->fd_closed(m_fd);
+	}
+
 	unlock_tcp_con();
 
 	return (is_closable());

--- a/src/vma/sock/sockinfo_tcp.cpp
+++ b/src/vma/sock/sockinfo_tcp.cpp
@@ -537,16 +537,6 @@ void sockinfo_tcp::force_close()
 	lock_tcp_con();
 	if (!is_closable()) abort_connection();
 	unlock_tcp_con();
-
-	//print the statistics of the socket to vma_stats file
-	vma_stats_instance_remove_socket_block(m_p_socket_stats);
-
-	BULLSEYE_EXCLUDE_BLOCK_START
-	if (m_call_orig_close_on_dtor) {
-		si_tcp_logdbg("calling orig_os_close on dup %d of %d",m_call_orig_close_on_dtor, m_fd);
-		orig_os_api.close(m_call_orig_close_on_dtor);
-	}
-	BULLSEYE_EXCLUDE_BLOCK_END
 }
 
 // This method will be on syn received on the passive side of a TCP connection

--- a/src/vma/sock/sockinfo_udp.cpp
+++ b/src/vma/sock/sockinfo_udp.cpp
@@ -2806,7 +2806,13 @@ void sockinfo_udp::push_back_m_rx_pkt_ready_list(mem_buf_desc_t* buff){
 bool sockinfo_udp::prepare_to_close(bool process_shutdown) {
 	m_lock_rcv.lock();
 	do_wakeup();
+
+	if (m_econtext) {
+		m_econtext->fd_closed(m_fd);
+	}
+
 	m_lock_rcv.unlock();
+
 	NOT_IN_USE(process_shutdown);
 	return is_closable();
 }


### PR DESCRIPTION
Socket objects are freed during fd collection cleanup process which done
by the internal thread using unregister_timers_event_and_delete().
Because the internal thread is stopped at this point, the sockets are
not deleted at all.

Signed-off-by: Liran Oz <lirano@mellanox.com>