### PR TITLE
issue: 1264919 Improve vma.service unit for inbox

### DIFF
--- a/contrib/scripts/vma.service.in
+++ b/contrib/scripts/vma.service.in
@@ -1,7 +1,7 @@
 [Unit]
 Description=VMA Daemon. Version: @VERSION@-@VMA_LIBRARY_RELEASE@
-After=openibd.service network.target syslog.target
-Requires=network.target openibd.service
+After=network.target syslog.target
+Requires=network.target
 
 [Service]
 Type=forking


### PR DESCRIPTION
Upstream can be installed w/o openibd service. Remove one
from needed services for vma.service launch.

Signed-off-by: Igor Ivanov <igor.ivanov.va@gmail.com>