### PR TITLE
issue: 1172298 Compile sockperf for jenkins against actual libvma

### DIFF
--- a/contrib/jenkins_tests/test.sh
+++ b/contrib/jenkins_tests/test.sh
@@ -19,7 +19,7 @@ do_cmd "wget -O sockperf_v2.zip https://github.com/Mellanox/sockperf/archive/soc
 cd sockperf
 
 ./autogen.sh
-./configure --prefix=$PWD/install
+./configure --prefix=$PWD/install CPPFLAGS="-I${install_dir}/include"
 make install
 test_app="$PWD/install/bin/sockperf"
 


### PR DESCRIPTION
As far as sockperf is compiled with VMA API by default actual
location to libvma should be set.

Signed-off-by: Igor Ivanov <igor.ivanov.va@gmail.com>