### PR TITLE
issue: 1248968 Add sesockopt for IP_TOS

### DIFF
--- a/src/vma/dev/rfs_uc_tcp_gro.cpp
+++ b/src/vma/dev/rfs_uc_tcp_gro.cpp
@@ -48,7 +48,7 @@ rfs_uc_tcp_gro::rfs_uc_tcp_gro(flow_tuple *flow_spec_5t, ring_simple *p_ring, rf
 	m_p_gro_mgr(&(p_ring->m_gro_mgr)), m_b_active(false), m_b_reserved(false)
 {
 	m_n_buf_max = m_p_gro_mgr->get_buf_max();
-	uint32_t mtu = p_ring->get_mtu(route_rule_table_key(flow_spec_5t->get_dst_ip(), flow_spec_5t->get_src_ip(), 0));
+	uint32_t mtu = p_ring->get_mtu();
 	m_n_byte_max = m_p_gro_mgr->get_byte_max() - mtu;
 	memset(&m_gro_desc, 0, sizeof(m_gro_desc));
 }

--- a/src/vma/dev/ring.cpp
+++ b/src/vma/dev/ring.cpp
@@ -50,16 +50,6 @@ ring::ring(int count, uint32_t mtu) :
 #endif // DEFINED_SOCKETXTREME	
 }
 
-uint32_t ring::get_mtu(const route_rule_table_key &key)
-{
-	route_result res;
-
-	g_p_route_table_mgr->route_resolve(key, res);
-	if (res.mtu) {
-		return res.mtu;
-	}
-	return m_mtu;
-}
 
 int ring::get_rx_channel_fds_index(uint32_t index) const {
 	if (index < m_n_num_resources)

--- a/src/vma/dev/ring.h
+++ b/src/vma/dev/ring.h
@@ -323,7 +323,7 @@ public:
 	ring*			get_parent() { return m_parent; };
 	virtual ring_user_id_t	generate_id() = 0;
 	virtual ring_user_id_t	generate_id(const address_t src_mac, const address_t dst_mac, uint16_t eth_proto, uint16_t encap_proto, uint32_t src_ip, uint32_t dst_ip, uint16_t src_port, uint16_t dst_port) = 0;
-	uint32_t		get_mtu(const route_rule_table_key &key);
+	uint32_t		get_mtu() { return m_mtu; }
 	bool			is_mp_ring() {return m_is_mp_ring;};
 	virtual int		modify_ratelimit(const uint32_t ratelimit_kbps) = 0;
 	virtual bool		is_ratelimit_supported(uint32_t rate) = 0;

--- a/src/vma/infra/sender.h
+++ b/src/vma/infra/sender.h
@@ -47,7 +47,9 @@ class event;
 class send_info : tostr
 {
 public:
-	send_info(): m_p_iov(NULL),m_sz_iov(0){};
+	send_info(iovec *iov, size_t sz):
+		m_p_iov(iov),
+		m_sz_iov(sz){};
 	virtual ~send_info(){};
 
 	iovec  *m_p_iov;
@@ -57,30 +59,32 @@ public:
 class neigh_send_info : public send_info
 {
 public:
-	neigh_send_info(): send_info(), m_p_header(NULL), m_protocol(0){};
-
-	header  *m_p_header;
+	neigh_send_info(iovec *iov, size_t sz, header *hdr, uint8_t proto,
+			uint32_t mtu, uint8_t tos):
+		send_info(iov, sz), m_p_header(hdr),m_mtu(mtu), m_tos(tos), m_protocol(proto){};
+	header *m_p_header;
+	uint32_t m_mtu;
+	uint8_t m_tos;
 	uint8_t m_protocol;
 };
 
 class send_data
 {
 public:
-	send_data(){};
 	send_data(const send_info *si);
 	virtual ~send_data();
-
 	iovec m_iov;
 };
 
 class neigh_send_data : public send_data
 {
 public:
-	neigh_send_data(): m_header(NULL){};
-
-	neigh_send_data(const neigh_send_info *nsi): send_data((const send_info*)nsi), m_protocol(nsi->m_protocol)
+	neigh_send_data(const neigh_send_info *nsi): send_data((const send_info*)nsi),
+			m_header(new header(*(nsi->m_p_header))),
+			m_mtu(nsi->m_mtu),
+			m_tos(nsi->m_tos),
+			m_protocol(nsi->m_protocol)
 	{
-		m_header = new header(*(nsi->m_p_header));
 	};
 
 	virtual ~neigh_send_data()
@@ -91,6 +95,8 @@ public:
 	};
 
 	header  *m_header;
+	uint32_t m_mtu;
+	uint8_t m_tos;
 	uint8_t m_protocol;
 };
 

--- a/src/vma/proto/dst_entry.cpp
+++ b/src/vma/proto/dst_entry.cpp
@@ -53,7 +53,7 @@ dst_entry::dst_entry(in_addr_t dst_ip, uint16_t dst_port, uint16_t src_port, soc
 	m_so_bindtodevice_ip(0), m_route_src_ip(0), m_pkt_src_ip(0),
 	m_ring_alloc_logic(sock_data.fd, ring_alloc_logic, this),
 	m_p_tx_mem_buf_desc_list(NULL), m_b_tx_mem_buf_desc_list_pending(false),
-	m_pcp(sock_data.pcp), m_id(0)
+	m_tos(sock_data.tos), m_pcp(sock_data.pcp), m_id(0)
 {
 	dst_logdbg("dst:%s:%d src: %d", m_dst_ip.to_str().c_str(), ntohs(m_dst_port), ntohs(m_src_port));
 	init_members();
@@ -119,7 +119,6 @@ void dst_entry::init_members()
 	memset(&m_fragmented_send_wqe, 0, sizeof(m_not_inline_send_wqe));
 	m_p_send_wqe_handler = NULL;
 	memset(&m_sge, 0, sizeof(m_sge));
-	m_tos = 0;
 	m_ttl = 64;
 	m_b_is_offloaded = true;
 	m_b_is_initialized = false;
@@ -704,17 +703,16 @@ uint16_t dst_entry::get_dst_port()
 ssize_t dst_entry::pass_buff_to_neigh(const iovec * p_iov, size_t & sz_iov, uint16_t packet_id)
 {
 	ssize_t ret_val = 0;
-	neigh_send_info n_send_info;
 
 	dst_logdbg("");
 
 	configure_ip_header(&m_header_neigh, packet_id);
 
 	if (m_p_neigh_entry) {
-		n_send_info.m_p_iov = const_cast<iovec *>(p_iov);
-		n_send_info.m_sz_iov = sz_iov;
-		n_send_info.m_protocol = get_protocol_type();
-		n_send_info.m_p_header = &m_header_neigh;
+		neigh_send_info n_send_info(const_cast<iovec *>(p_iov),
+				sz_iov, &m_header_neigh,
+				get_protocol_type(), get_route_mtu(),
+				m_tos);
 		ret_val = m_p_neigh_entry->send(n_send_info);
 	}
 

--- a/src/vma/proto/dst_entry.h
+++ b/src/vma/proto/dst_entry.h
@@ -58,6 +58,7 @@
 
 struct socket_data {
 	int	fd;
+	uint8_t	tos;
 	uint8_t	pcp;
 };
 

--- a/src/vma/proto/neighbour.h
+++ b/src/vma/proto/neighbour.h
@@ -359,9 +359,9 @@ private:
 	resource_allocation_key	*m_res_key;
 	event_t 		rdma_event_mapping(struct rdma_cm_event* p_event);
 	void 			empty_unsent_queue();
-	bool 			post_send_packet(uint8_t protocol, iovec * iov, header *h);
-	bool			post_send_udp(iovec * iov, header *h);
-	bool			post_send_tcp(iovec * iov, header *h);
+	bool 			post_send_packet(neigh_send_data *n_send_data);
+	bool			post_send_udp(neigh_send_data *n_send_data);
+	bool			post_send_tcp(neigh_send_data *n_send_data);
 };
 
 class neigh_ib : public neigh_entry, public event_handler_ibverbs

--- a/src/vma/proto/route_table_mgr.cpp
+++ b/src/vma/proto/route_table_mgr.cpp
@@ -377,6 +377,7 @@ bool route_table_mgr::route_resolve(IN route_rule_table_key key, OUT route_resul
 			return true;
 		}
 	}
+	memset(&res, 0, sizeof(route_result));
 	return false;
 }
 

--- a/src/vma/proto/route_table_mgr.cpp
+++ b/src/vma/proto/route_table_mgr.cpp
@@ -377,6 +377,7 @@ bool route_table_mgr::route_resolve(IN route_rule_table_key key, OUT route_resul
 			return true;
 		}
 	}
+	/* prevent usage on false return */
 	memset(&res, 0, sizeof(route_result));
 	return false;
 }

--- a/src/vma/sock/sockinfo_tcp.cpp
+++ b/src/vma/sock/sockinfo_tcp.cpp
@@ -3486,7 +3486,7 @@ int sockinfo_tcp::setsockopt(int __level, int __optname,
 
 	if (__level == IPPROTO_IP) {
 		switch(__optname) {
-		case IP_TOS:
+		case IP_TOS: /* might be missing ECN logic */
 			if (__optlen <= sizeof(int)) {
 				val = *(int *)__optval;
 				val &= ~INET_ECN_MASK;
@@ -3802,15 +3802,8 @@ int sockinfo_tcp::getsockopt_offload(int __level, int __optname, void *__optval,
 		break;
 	case IPPROTO_IP:
 		switch (__optname) {
-		case IP_TOS:
-			if (*__optlen > 0) {
-				*(uint8_t *)__optval = m_pcb.tos;
-				*__optlen = 1;
-			} else {
-				errno = EINVAL;
-			}
-			break;
 		default:
+			ret = SOCKOPT_HANDLE_BY_OS;
 			break;
 		}
 		break;

--- a/src/vma/sock/sockinfo_tcp.cpp
+++ b/src/vma/sock/sockinfo_tcp.cpp
@@ -577,7 +577,7 @@ void sockinfo_tcp::force_close()
 void sockinfo_tcp::create_dst_entry()
 {
 	if (!m_p_connected_dst_entry) {
-		socket_data data = { m_fd, m_pcp};
+		socket_data data = { m_fd, m_pcb.tos, m_pcp};
 		m_p_connected_dst_entry = new dst_entry_tcp(m_connected.get_in_addr(),
 					m_connected.get_in_port(),
 					m_bound.get_in_port(),
@@ -1032,8 +1032,8 @@ uint16_t sockinfo_tcp::get_route_mtu(struct tcp_pcb *pcb)
 		return tcp_sock->m_p_connected_dst_entry->get_route_mtu();
 	}
 	route_result res;
-	// m_tos is always 0 in VMA
-	g_p_route_table_mgr->route_resolve(route_rule_table_key(pcb->local_ip.addr, pcb->remote_ip.addr, 0), res);
+
+	g_p_route_table_mgr->route_resolve(route_rule_table_key(pcb->local_ip.addr, pcb->remote_ip.addr, pcb->tos), res);
 
 	if (res.mtu) {
 		vlog_printf(VLOG_DEBUG, "Using route mtu %u\n", res.mtu);
@@ -3484,6 +3484,22 @@ int sockinfo_tcp::setsockopt(int __level, int __optname,
 	}
 #endif // DEFINED_SOCKETXTREME
 
+	if (__level == IPPROTO_IP) {
+		switch(__optname) {
+		case IP_TOS:
+			if (__optlen <= sizeof(int)) {
+				val = *(int *)__optval;
+				val &= ~INET_ECN_MASK;
+				m_pcb.tos |= val & INET_ECN_MASK;
+			}
+			ret = SOCKOPT_HANDLE_BY_OS;
+		break;
+		default:
+			ret = SOCKOPT_HANDLE_BY_OS;
+			supported = false;
+			break;
+		}
+	}
 	if (__level == IPPROTO_TCP) {
 		switch(__optname) {
 		case TCP_NODELAY:
@@ -3786,8 +3802,15 @@ int sockinfo_tcp::getsockopt_offload(int __level, int __optname, void *__optval,
 		break;
 	case IPPROTO_IP:
 		switch (__optname) {
+		case IP_TOS:
+			if (*__optlen > 0) {
+				*(uint8_t *)__optval = m_pcb.tos;
+				*__optlen = 1;
+			} else {
+				errno = EINVAL;
+			}
+			break;
 		default:
-			ret = SOCKOPT_HANDLE_BY_OS;
 			break;
 		}
 		break;

--- a/src/vma/sock/sockinfo_tcp.h
+++ b/src/vma/sock/sockinfo_tcp.h
@@ -89,6 +89,14 @@ typedef std::map<tcp_pcb*, int>		ready_pcb_map_t;
 typedef std::map<flow_tuple, tcp_pcb*>	syn_received_map_t;
 typedef std::map<peer_key, vma_desc_list_t> peer_map_t;
 
+/* taken from inet_ecn.h in kernel */
+enum inet_ecns {
+	INET_ECN_NOT_ECT = 0,
+	INET_ECN_ECT_1 = 1,
+	INET_ECN_ECT_0 = 2,
+	INET_ECN_CE = 3,
+	INET_ECN_MASK = 3,
+};
 
 class sockinfo_tcp : public sockinfo, public timer_handler
 {

--- a/src/vma/sock/sockinfo_udp.cpp
+++ b/src/vma/sock/sockinfo_udp.cpp
@@ -387,6 +387,7 @@ sockinfo_udp::sockinfo_udp(int fd):
 	,m_b_rcvtstamp(false)
 	,m_b_rcvtstampns(false)
 	,m_n_tsing_flags(0)
+	,m_tos(0)
 	,m_n_sysvar_rx_poll_yield_loops(safe_mce_sys().rx_poll_yield_loops)
 	,m_n_sysvar_rx_udp_poll_os_ratio(safe_mce_sys().rx_udp_poll_os_ratio)
 	,m_n_sysvar_rx_ready_byte_min_limit(safe_mce_sys().rx_ready_byte_min_limit)
@@ -608,7 +609,7 @@ int sockinfo_udp::connect(const struct sockaddr *__to, socklen_t __tolen)
 			setPassthrough();
 			return 0;
 		}
-		socket_data data = { m_fd, m_pcp};
+		socket_data data = { m_fd, m_tos, m_pcp};
 		// Create the new dst_entry
 		if (IN_MULTICAST_N(dst_ip)) {
 			m_p_connected_dst_entry = new dst_entry_udp_mc(dst_ip, dst_port, src_port,
@@ -1125,7 +1126,6 @@ int sockinfo_udp::setsockopt(int __level, int __optname, __const void *__optval,
 					if (INADDR_ANY == mc_if) {
 						in_addr_t dst_ip	= mc_grp;
 						in_addr_t src_ip	= 0;
-						uint8_t tos		= 0;
 
 						if ((!m_bound.is_anyaddr()) && (!m_bound.is_mc())) {
 							src_ip = m_bound.get_in_addr();
@@ -1133,8 +1133,8 @@ int sockinfo_udp::setsockopt(int __level, int __optname, __const void *__optval,
 							src_ip = m_so_bindtodevice_ip;
 						}
 						// Find local if for this MC ADD/DROP
-						struct route_result res;
-						g_p_route_table_mgr->route_resolve(route_rule_table_key(dst_ip, src_ip, tos), res);
+						route_result res;
+						g_p_route_table_mgr->route_resolve(route_rule_table_key(dst_ip, src_ip, m_tos), res);
 						mc_if = res.p_src;
 						si_udp_logdbg("IPPROTO_IP, %s=%d.%d.%d.%d, mc_if:INADDR_ANY (resolved to: %d.%d.%d.%d)", setsockopt_ip_opt_to_str(__optname), NIPQUAD(mc_grp), NIPQUAD(mc_if));
 					}
@@ -1191,6 +1191,11 @@ int sockinfo_udp::setsockopt(int __level, int __optname, __const void *__optval,
 						m_b_pktinfo = true;
 					else
 						m_b_pktinfo = false;
+				}
+				break;
+			case IP_TOS:
+				if (__optlen <= sizeof(int)) {
+					m_tos =(uint8_t) *(int *)__optval;
 				}
 				break;
 			default:
@@ -1286,7 +1291,6 @@ int sockinfo_udp::getsockopt(int __level, int __optname, void *__optval, socklen
 
 	bool supported = true;
 	switch (__level) {
-
 	case SOL_SOCKET:
 		{
 			switch (__optname) {
@@ -1814,7 +1818,7 @@ ssize_t sockinfo_udp::tx(const tx_call_t call_type, const iovec* p_iov, const ss
 					}
 				}
 				in_port_t src_port = m_bound.get_in_port();
-				socket_data data = { m_fd, m_pcp};
+				socket_data data = { m_fd, m_tos, m_pcp};
 				// Create the new dst_entry
 				if (dst.is_mc()) {
 					p_dst_entry = new dst_entry_udp_mc(
@@ -2489,7 +2493,6 @@ int sockinfo_udp::mc_change_membership(const mc_pending_pram *p_mc_pram)
 	if (mc_if == INADDR_ANY) {
 		in_addr_t dst_ip	= mc_grp;
 		in_addr_t src_ip	= 0;
-		uint8_t tos		= 0;
 		
 		if (!m_bound.is_anyaddr() && !m_bound.is_mc()) {
 			src_ip = m_bound.get_in_addr();
@@ -2498,7 +2501,7 @@ int sockinfo_udp::mc_change_membership(const mc_pending_pram *p_mc_pram)
 		}
 		// Find local if for this MC ADD/DROP
 		route_result res;
-		g_p_route_table_mgr->route_resolve(route_rule_table_key(dst_ip, src_ip, tos), res);
+		g_p_route_table_mgr->route_resolve(route_rule_table_key(dst_ip, src_ip, m_tos), res);
 		mc_if = res.p_src;
 	}
 

--- a/src/vma/sock/sockinfo_udp.h
+++ b/src/vma/sock/sockinfo_udp.h
@@ -232,6 +232,7 @@ private:
 	bool		m_b_rcvtstamp;
 	bool		m_b_rcvtstampns;
 	uint8_t		m_n_tsing_flags;
+	uint8_t		m_tos;
 
 	const uint32_t	m_n_sysvar_rx_poll_yield_loops;
 	const uint32_t	m_n_sysvar_rx_udp_poll_os_ratio;


### PR DESCRIPTION
This commit adds support for IP_TOS attribute in setsockopt,
witch is written inside the IP TOS field.

VMA had a lack of usage in the tos when resolving the route
and used the route mtu in places it shouldn't had.
This commit adds the TOS and PCP and alignes all the tos
usage

Signed-off-by: Rafi Wiener <rafiw@mellanox.com>