### PR TITLE
issue: 1254846 Align burst control with libibverbs new API

### DIFF
--- a/config/m4/verbs.m4
+++ b/config/m4/verbs.m4
@@ -151,8 +151,8 @@ AC_CHECK_DECLS([IBV_EXP_QP_RATE_LIMIT],
 	[AC_DEFINE(DEFINED_IBV_EXP_QP_RATE_LIMIT, 1, [Define to 1 if IBV_EXP_QP_RATE_LIMIT defined])],
 	[], [[#include <infiniband/verbs_exp.h>]])
 
-AC_CHECK_DECLS([IBV_EXP_QP_BURST_INFO],
-	[AC_DEFINE(DEFINED_IBV_EXP_QP_BURST_INFO, 1, [Define to 1 if IBV_EXP_QP_BURST_INFO defined])],
+AC_CHECK_DECLS([IBV_EXP_QP_SUPPORT_BURST],
+	[AC_DEFINE(DEFINED_IBV_EXP_QP_SUPPORT_BURST, 1, [Define to 1 if IBV_EXP_QP_SUPPORT_BURST defined])],
 	[], [[#include <infiniband/verbs_exp.h>]])
 
 have_mp_rq=yes

--- a/src/vma/sock/sockinfo.cpp
+++ b/src/vma/sock/sockinfo.cpp
@@ -285,7 +285,7 @@ int sockinfo::getsockopt(int __level, int __optname, void *__optval, socklen_t *
 				*(struct vma_rate_limit_t*)__optval = m_so_ratelimit;
 				(*(struct vma_rate_limit_t*)__optval).rate = KB_TO_BYTE(m_so_ratelimit.rate);
 				*__optlen = sizeof(struct vma_rate_limit_t);
-				si_logdbg("(SO_MAX_PACING_RATE) value: %d, %d, %d", (*(struct vma_rate_limit_t*)__optval).rate, (*(struct vma_rate_limit_t*)__optval).upper_bound_sz, (*(struct vma_rate_limit_t*)__optval).typical_pkt_sz);
+				si_logdbg("(SO_MAX_PACING_RATE) value: %d, %d, %d", (*(struct vma_rate_limit_t*)__optval).rate, (*(struct vma_rate_limit_t*)__optval).max_burst_sz, (*(struct vma_rate_limit_t*)__optval).typical_pkt_sz);
 			} else if (*__optlen >= sizeof(uint32_t)) {
 				*(uint32_t*)__optval = KB_TO_BYTE(m_so_ratelimit.rate);
 				*__optlen = sizeof(uint32_t);

--- a/src/vma/sock/sockinfo_tcp.cpp
+++ b/src/vma/sock/sockinfo_tcp.cpp
@@ -3653,7 +3653,7 @@ int sockinfo_tcp::setsockopt(int __level, int __optname,
 				rate_limit = *(struct vma_rate_limit_t*)__optval; // value is in bytes per second
 			} else if (sizeof(uint32_t) <= __optlen) {
 				rate_limit.rate = *(uint32_t*)__optval; // value is in bytes per second
-				rate_limit.upper_bound_sz = 0;
+				rate_limit.max_burst_sz = 0;
 				rate_limit.typical_pkt_sz = 0;
 			} else {
 				errno = EINVAL;

--- a/src/vma/sock/sockinfo_udp.cpp
+++ b/src/vma/sock/sockinfo_udp.cpp
@@ -926,7 +926,7 @@ int sockinfo_udp::setsockopt(int __level, int __optname, __const void *__optval,
 						val = *(struct vma_rate_limit_t*)__optval; // value is in bytes per second
 					} else if (sizeof(uint32_t) <= __optlen) {
 						val.rate = *(uint32_t*)__optval; // value is in bytes per second
-						val.upper_bound_sz = 0;
+						val.max_burst_sz = 0;
 						val.typical_pkt_sz = 0;
 					} else {
 						si_udp_logdbg("SOL_SOCKET, %s=\"???\" - bad length got %d",

--- a/src/vma/util/verbs_extra.cpp
+++ b/src/vma/util/verbs_extra.cpp
@@ -345,11 +345,11 @@ int priv_ibv_modify_qp_ratelimit(struct ibv_qp *qp, struct vma_rate_limit_t &rat
 		qp_attr.rate_limit = rate_limit.rate;
 		exp_attr_mask |= IBV_EXP_QP_RATE_LIMIT;
 	}
-#ifdef DEFINED_IBV_EXP_QP_BURST_INFO
-	if (rate_limit.upper_bound_sz && rate_limit.typical_pkt_sz && (rl_changes & (RL_BURST_SIZE | RL_PKT_SIZE))) {
-		qp_attr.burst_info.upper_bound_sz = rate_limit.upper_bound_sz;
+#ifdef DEFINED_IBV_EXP_QP_SUPPORT_BURST
+	if (rate_limit.max_burst_sz && rate_limit.typical_pkt_sz && (rl_changes & (RL_BURST_SIZE | RL_PKT_SIZE))) {
+		qp_attr.burst_info.max_burst_sz = rate_limit.max_burst_sz;
 		qp_attr.burst_info.typical_pkt_sz = rate_limit.typical_pkt_sz;
-		exp_attr_mask |= IBV_EXP_QP_BURST_INFO;
+		qp_attr.comp_mask |= IBV_EXP_QP_ATTR_BURST_INFO;
 	}
 #endif
 	BULLSEYE_EXCLUDE_BLOCK_START
@@ -358,9 +358,9 @@ int priv_ibv_modify_qp_ratelimit(struct ibv_qp *qp, struct vma_rate_limit_t &rat
 		return -2;
 	} ENDIF_VERBS_FAILURE;
 	BULLSEYE_EXCLUDE_BLOCK_END
-#ifdef DEFINED_IBV_EXP_QP_BURST_INFO
+#ifdef DEFINED_IBV_EXP_QP_SUPPORT_BURST
 	vlog_printf(VLOG_DEBUG, "qp was set to rate limit %d, burst size %d, packet size %d\n",
-			rate_limit.rate, rate_limit.upper_bound_sz, rate_limit.typical_pkt_sz);
+			rate_limit.rate, rate_limit.max_burst_sz, rate_limit.typical_pkt_sz);
 #else
 	vlog_printf(VLOG_DEBUG, "qp was set to rate limit %d\n", rate_limit.rate);
 #endif

--- a/src/vma/vma_extra.h
+++ b/src/vma/vma_extra.h
@@ -173,7 +173,7 @@ struct __attribute__ ((packed)) vma_info_t {
 
 struct vma_rate_limit_t {
 	uint32_t rate;				/* rate limit in Kbps */
-	uint32_t upper_bound_sz;		/* maximum burst size in bytes */
+	uint32_t max_burst_sz;			/* maximum burst size in bytes */
 	uint16_t typical_pkt_sz;		/* typical packet size in bytes */
 };
 


### PR DESCRIPTION
The burst control was developed and introduced in a previous commit
while the feature was still under development in libibverbs.
The final version in libibverbs has some API changes which this change
accommodates for.

Signed-off-by: Ilan Smith <ilansm@mellanox.com>