### PR TITLE
issue: 1311399 Remove cq_type parameter from ring functions

### DIFF
--- a/src/vma/dev/net_device_table_mgr.cpp
+++ b/src/vma/dev/net_device_table_mgr.cpp
@@ -636,7 +636,7 @@ int net_device_table_mgr::global_ring_wait_for_notification_and_process_element(
 			if (p_cq_ch_info) {
 				ring* p_ready_ring = p_cq_ch_info->get_ring();
 				// Handle the CQ notification channel
-				int ret = p_ready_ring->wait_for_notification_and_process_element(CQT_RX, fd, p_poll_sn, pv_fd_ready_array);
+				int ret = p_ready_ring->wait_for_notification_and_process_element(fd, p_poll_sn, pv_fd_ready_array);
 				if (ret < 0) {
 					if (errno == EAGAIN || errno == EBUSY) {
 						ndtm_logdbg("Error in ring[%d]->wait_for_notification_and_process_element() of %p (errno=%d %m)", event_idx, p_ready_ring, errno);

--- a/src/vma/dev/net_device_val.cpp
+++ b/src/vma/dev/net_device_val.cpp
@@ -750,7 +750,7 @@ int net_device_val::ring_drain_and_proccess()
 	auto_unlocker lock(m_lock);
 	rings_hash_map_t::iterator ring_iter;
 	for (ring_iter = m_h_ring_map.begin(); ring_iter != m_h_ring_map.end(); ring_iter++) {
-		int ret = THE_RING->drain_and_proccess(CQT_RX);
+		int ret = THE_RING->drain_and_proccess();
 		if (ret < 0)
 			return ret;
 		if (ret > 0)

--- a/src/vma/dev/ring.h
+++ b/src/vma/dev/ring.h
@@ -306,8 +306,8 @@ public:
 	virtual bool 		get_hw_dummy_send_support(ring_user_id_t id, vma_ibv_send_wr* p_send_wqe) = 0;
 	virtual int		request_notification(cq_type_t cq_type, uint64_t poll_sn) = 0;
 	virtual bool		reclaim_recv_buffers(descq_t *rx_reuse) = 0;
-	virtual int		drain_and_proccess(cq_type_t cq_type) = 0;
-	virtual int		wait_for_notification_and_process_element(cq_type_t cq_type, int cq_channel_fd, uint64_t* p_cq_poll_sn, void* pv_fd_ready_array = NULL) = 0;
+	virtual int		drain_and_proccess() = 0;
+	virtual int		wait_for_notification_and_process_element(int cq_channel_fd, uint64_t* p_cq_poll_sn, void* pv_fd_ready_array = NULL) = 0;
 	virtual int		poll_and_process_element_rx(uint64_t* p_cq_poll_sn, void* pv_fd_ready_array = NULL) = 0;
 	virtual void		adapt_cq_moderation() = 0;
 	virtual void		mem_buf_desc_completion_with_error_rx(mem_buf_desc_t* p_rx_wc_buf_desc) = 0; // Assume locked...
@@ -321,7 +321,7 @@ public:
 	virtual bool		is_member(mem_buf_desc_owner* rng) = 0;
 	virtual bool		is_active_member(mem_buf_desc_owner* rng, ring_user_id_t id) = 0;
 	ring*			get_parent() { return m_parent; };
-	virtual ring_user_id_t	generate_id() = 0;
+	ring_user_id_t	generate_id() { return 0; };
 	virtual ring_user_id_t	generate_id(const address_t src_mac, const address_t dst_mac, uint16_t eth_proto, uint16_t encap_proto, uint32_t src_ip, uint32_t dst_ip, uint16_t src_port, uint16_t dst_port) = 0;
 	uint32_t		get_mtu() { return m_mtu; }
 	bool			is_mp_ring() {return m_is_mp_ring;};

--- a/src/vma/dev/ring.h
+++ b/src/vma/dev/ring.h
@@ -321,7 +321,7 @@ public:
 	virtual bool		is_member(mem_buf_desc_owner* rng) = 0;
 	virtual bool		is_active_member(mem_buf_desc_owner* rng, ring_user_id_t id) = 0;
 	ring*			get_parent() { return m_parent; };
-	ring_user_id_t	generate_id() { return 0; };
+	ring_user_id_t		generate_id() { return 0; };
 	virtual ring_user_id_t	generate_id(const address_t src_mac, const address_t dst_mac, uint16_t eth_proto, uint16_t encap_proto, uint32_t src_ip, uint32_t dst_ip, uint16_t src_port, uint16_t dst_port) = 0;
 	uint32_t		get_mtu() { return m_mtu; }
 	bool			is_mp_ring() {return m_is_mp_ring;};

--- a/src/vma/dev/ring_bond.h
+++ b/src/vma/dev/ring_bond.h
@@ -48,8 +48,8 @@ public:
 	virtual int		poll_and_process_element_rx(uint64_t* p_cq_poll_sn, void* pv_fd_ready_array = NULL);
 	virtual void		adapt_cq_moderation();
 	virtual bool		reclaim_recv_buffers(descq_t *rx_reuse);
-	virtual int		drain_and_proccess(cq_type_t cq_type);
-	virtual int		wait_for_notification_and_process_element(cq_type_t cq_type, int cq_channel_fd, uint64_t* p_cq_poll_sn, void* pv_fd_ready_array = NULL);
+	virtual int		drain_and_proccess();
+	virtual int		wait_for_notification_and_process_element(int cq_channel_fd, uint64_t* p_cq_poll_sn, void* pv_fd_ready_array = NULL);
 	virtual void		mem_buf_desc_completion_with_error_rx(mem_buf_desc_t* p_rx_wc_buf_desc); // Assume locked...
 	// Tx completion handling at the qp_mgr level is just re listing the desc+data buffer in the free lists
 	virtual void		mem_buf_desc_completion_with_error_tx(mem_buf_desc_t* p_tx_wc_buf_desc); // Assume locked...
@@ -68,7 +68,6 @@ public:
 	virtual void		mem_buf_desc_return_single_to_owner_tx(mem_buf_desc_t* p_mem_buf_desc);
 	virtual bool		is_member(mem_buf_desc_owner* rng);
 	virtual bool		is_active_member(mem_buf_desc_owner* rng, ring_user_id_t id);
-	virtual ring_user_id_t	generate_id();
 	virtual ring_user_id_t	generate_id(const address_t src_mac, const address_t dst_mac, uint16_t eth_proto, uint16_t encap_proto, uint32_t src_ip, uint32_t dst_ip, uint16_t src_port, uint16_t dst_port);
 	virtual bool 		get_hw_dummy_send_support(ring_user_id_t id, vma_ibv_send_wr* p_send_wqe);
 	virtual int		modify_ratelimit(struct vma_rate_limit_t &rate_limit);

--- a/src/vma/dev/ring_eth_cb.cpp
+++ b/src/vma/dev/ring_eth_cb.cpp
@@ -396,9 +396,8 @@ void ring_eth_cb::remove_umr_res()
 	ring_logdbg("UMR resources removed\n");
 }
 
-int ring_eth_cb::drain_and_proccess(cq_type_t cq_type)
+int ring_eth_cb::drain_and_proccess()
 {
-	NOT_IN_USE(cq_type);
 	return 0;
 }
 

--- a/src/vma/dev/ring_eth_cb.h
+++ b/src/vma/dev/ring_eth_cb.h
@@ -71,7 +71,7 @@ public:
 	uint8_t		get_single_stride_log_num_of_bytes() const {return m_single_stride_log_num_of_bytes;};
 	uint32_t	get_stride_size() const {return m_stride_size;};
 	uint32_t	get_mem_lkey(ib_ctx_handler* ib_ctx) const {return m_alloc.find_lkey_by_ib_ctx(ib_ctx);}
-	virtual int	drain_and_proccess(cq_type_t cq_type);
+	virtual int	drain_and_proccess();
 	virtual int	poll_and_process_element_rx(uint64_t* p_cq_poll_sn, void* pv_fd_ready_array = NULL);
 	int		cyclic_buffer_read(vma_completion_cb_t &completion,
 					   size_t min, size_t max, int flags);

--- a/src/vma/dev/ring_eth_direct.cpp
+++ b/src/vma/dev/ring_eth_direct.cpp
@@ -80,9 +80,8 @@ mem_buf_desc_t* ring_eth_direct::mem_buf_tx_get(ring_user_id_t id, bool b_block,
 	return NULL;
 }
 
-int ring_eth_direct::drain_and_proccess(cq_type_t cq_type)
+int ring_eth_direct::drain_and_proccess()
 {
-	NOT_IN_USE(cq_type);
 	return 0;
 }
 

--- a/src/vma/dev/ring_eth_direct.h
+++ b/src/vma/dev/ring_eth_direct.h
@@ -71,7 +71,7 @@ public:
 	// dummy functions to block memory usage and internal thread
 	virtual void	init_tx_buffers(uint32_t count);
 	virtual mem_buf_desc_t* mem_buf_tx_get(ring_user_id_t id, bool b_block, int n_num_mem_bufs = 1);
-	virtual int	drain_and_proccess(cq_type_t cq_type);
+	virtual int	drain_and_proccess();
 	virtual int	poll_and_process_element_rx(uint64_t* p_cq_poll_sn,
 					void* pv_fd_ready_array);
 private:

--- a/src/vma/dev/ring_simple.h
+++ b/src/vma/dev/ring_simple.h
@@ -47,7 +47,6 @@ public:
 	virtual int		request_notification(cq_type_t cq_type, uint64_t poll_sn);
 	virtual int		poll_and_process_element_rx(uint64_t* p_cq_poll_sn, void* pv_fd_ready_array = NULL);
 	virtual void		adapt_cq_moderation();
-	bool			reclaim_recv_buffers_no_lock(descq_t *rx_reuse); // No locks
 	bool			reclaim_recv_buffers_no_lock(mem_buf_desc_t* rx_reuse_lst); // No locks
 #ifdef DEFINED_SOCKETXTREME	
 	virtual int 		socketxtreme_poll(struct vma_completion_t *vma_completions, unsigned int ncompletions, int flags);	
@@ -55,8 +54,8 @@ public:
 	virtual void		socketxtreme_reclaim_recv_buffers(mem_buf_desc_t* rx_reuse_lst); // No locks
 #endif // DEFINED_SOCKETXTREME
 	virtual bool		reclaim_recv_buffers(descq_t *rx_reuse);
-	virtual int		drain_and_proccess(cq_type_t cq_type);
-	virtual int		wait_for_notification_and_process_element(cq_type_t cq_type, int cq_channel_fd, uint64_t* p_cq_poll_sn, void* pv_fd_ready_array = NULL);
+	virtual int		drain_and_proccess();
+	virtual int		wait_for_notification_and_process_element(int cq_channel_fd, uint64_t* p_cq_poll_sn, void* pv_fd_ready_array = NULL);
 	virtual void		mem_buf_desc_completion_with_error_rx(mem_buf_desc_t* p_rx_wc_buf_desc); // Assume locked...
 	// Tx completion handling at the qp_mgr level is just re listing the desc+data buffer in the free lists
 	virtual void		mem_buf_desc_completion_with_error_tx(mem_buf_desc_t* p_tx_wc_buf_desc); // Assume locked...
@@ -78,7 +77,6 @@ public:
 	virtual void		mem_buf_desc_return_single_to_owner_tx(mem_buf_desc_t* p_mem_buf_desc);
 	virtual bool		is_member(mem_buf_desc_owner* rng);
 	virtual bool		is_active_member(mem_buf_desc_owner* rng, ring_user_id_t id);
-	virtual ring_user_id_t	generate_id();
 	virtual ring_user_id_t	generate_id(const address_t src_mac, const address_t dst_mac, uint16_t eth_proto, uint16_t encap_proto, uint32_t src_ip, uint32_t dst_ip, uint16_t src_port, uint16_t dst_port);
 	transport_type_t	get_transport_type() const { return m_transport_type; }
 	virtual bool 		get_hw_dummy_send_support(ring_user_id_t id, vma_ibv_send_wr* p_send_wqe);
@@ -106,8 +104,6 @@ protected:
 	inline void 		socketxtreme_process_recv_buffer(mem_buf_desc_t* p_rx_wc_buf_desc);
 #endif // DEFINED_SOCKETXTREME	
 	bool			rx_process_buffer(mem_buf_desc_t* p_rx_wc_buf_desc, void* pv_fd_ready_array);
-	void			print_flow_to_rfs_udp_uc_map(flow_spec_udp_uc_map_t *p_flow_map);
-	void			print_flow_to_rfs_tcp_map(flow_spec_tcp_map_t *p_flow_map);
 	//	void	print_ring_flow_to_rfs_map(flow_spec_map_t *p_flow_map);
 	void			flow_udp_uc_del_all();
 	void			flow_udp_mc_del_all();

--- a/src/vma/iomux/epfd_info.cpp
+++ b/src/vma/iomux/epfd_info.cpp
@@ -682,7 +682,7 @@ int epfd_info::ring_wait_for_notification_and_process_element(uint64_t *p_poll_s
 		if (p_cq_ch_info) {
 			ring* p_ready_ring = p_cq_ch_info->get_ring();
 			// Handle the CQ notification channel
-			int ret = p_ready_ring->wait_for_notification_and_process_element(CQT_RX, fd, p_poll_sn, pv_fd_ready_array);
+			int ret = p_ready_ring->wait_for_notification_and_process_element(fd, p_poll_sn, pv_fd_ready_array);
 			if (ret < 0) {
 				if (errno == EAGAIN || errno == EBUSY) {
 					__log_dbg("Error in ring->wait_for_notification_and_process_element() of %p (errno=%d %m)", p_ready_ring, errno);

--- a/src/vma/sock/sockinfo.cpp
+++ b/src/vma/sock/sockinfo.cpp
@@ -397,7 +397,7 @@ int sockinfo::rx_wait_helper(int &poll_count, bool is_blocking)
 		if (p_cq_ch_info) {
 			ring* p_ring = p_cq_ch_info->get_ring();
 			if (p_ring) {
-				p_ring->wait_for_notification_and_process_element(CQT_RX, cq_channel_fd, &poll_sn);
+				p_ring->wait_for_notification_and_process_element(cq_channel_fd, &poll_sn);
 			}
 		}
 

--- a/src/vma/sock/sockinfo_tcp.cpp
+++ b/src/vma/sock/sockinfo_tcp.cpp
@@ -4090,7 +4090,7 @@ int sockinfo_tcp::rx_wait_helper(int &poll_count, bool is_blocking)
 		if (p_cq_ch_info) {
 			ring* p_ring = p_cq_ch_info->get_ring();
 			if (p_ring) {
-				p_ring->wait_for_notification_and_process_element(CQT_RX, fd, &poll_sn);
+				p_ring->wait_for_notification_and_process_element(fd, &poll_sn);
 			}
 		}
 	}

--- a/src/vma/sock/sockinfo_udp.cpp
+++ b/src/vma/sock/sockinfo_udp.cpp
@@ -299,7 +299,7 @@ inline int sockinfo_udp::rx_wait(bool blocking)
 				if (p_cq_ch_info) {
 					ring* p_ring = p_cq_ch_info->get_ring();
 					if (p_ring) {
-						p_ring->wait_for_notification_and_process_element(CQT_RX, fd, &poll_sn);
+						p_ring->wait_for_notification_and_process_element(fd, &poll_sn);
 					}
 				}
 			}


### PR DESCRIPTION
wait_for_notification_and_process_element() and drain_and_proccess()
always call with CQT_RX.

Signed-off-by: Liran Oz <lirano@mellanox.com>