### PR TITLE
issue: 854219 Improve rx ring creation flow

### DIFF
--- a/src/vma/sock/sockinfo.h
+++ b/src/vma/sock/sockinfo.h
@@ -135,13 +135,7 @@ public:
 	virtual int* get_rings_fds(int &res_length);
 	virtual int get_rings_num();
 	virtual int get_socket_network_ptr(void *ptr, uint16_t &len);
-#ifdef DEFINED_SOCKETXTREME
-
 	virtual bool check_rings() {return m_p_rx_ring ? true: false;}
-#else
-	virtual bool check_rings() {return true;}
-#endif
-
 
 #ifdef DEFINED_SOCKETXTREME
 	virtual int fast_nonblocking_rx(vma_packets_t *vma_pkts);

--- a/src/vma/sock/sockinfo_tcp.cpp
+++ b/src/vma/sock/sockinfo_tcp.cpp
@@ -2748,7 +2748,7 @@ err_t sockinfo_tcp::accept_lwip_cb(void *arg, struct tcp_pcb *child_pcb, err_t e
 	bool success = new_sock->attach_as_uc_receiver(role_t (NULL), true);
 	if (!success) {
 		/* we will get here if attach_as_uc_receiver failed */
-		__log_dbg("It should be wrong case");
+		__log_dbg("It should be unexpected case because attach_as_uc_receiver() returns failure");
 	}
 
 	if (new_sock->m_sysvar_tcp_ctl_thread > CTL_THREAD_DISABLE) {

--- a/src/vma/sock/sockinfo_tcp.cpp
+++ b/src/vma/sock/sockinfo_tcp.cpp
@@ -2110,12 +2110,6 @@ int sockinfo_tcp::connect(const sockaddr *__to, socklen_t __tolen)
 		return -1;
 	}
 
-#ifndef DEFINED_SOCKETXTREME	// if not defined
-	if (m_rx_ring_map.size() == 1) {
-		rx_ring_map_t::iterator rx_ring_iter = m_rx_ring_map.begin();
-		m_p_rx_ring = rx_ring_iter->first;
-	}
-#endif // DEFINED_SOCKETXTREME
 	in_addr_t peer_ip_addr = m_connected.get_in_addr();
 	fit_rcv_wnd(true);
 
@@ -2405,27 +2399,6 @@ int sockinfo_tcp::listen(int backlog)
 	tcp_clone_conn((struct tcp_pcb_listen*)(&m_pcb), sockinfo_tcp::clone_conn_cb);
 
 	bool success = attach_as_uc_receiver(ROLE_TCP_SERVER);
-#ifndef DEFINED_SOCKETXTREME // if not defiend
-/*TODO ALEXR
- *
- 	if (attach_as_uc_receiver(ROLE_TCP_SERVER)) {
-		si_tcp_logdbg("Fallback the connection to os");
-		setPassthrough();
-		return orig_os_api.listen(m_fd, orig_backlog);
-	}
-*/
-	if (m_rx_ring_map.size()) {
-		if (m_rx_ring_map.size() == 1) {
-			rx_ring_map_t::iterator rx_ring_iter = m_rx_ring_map.begin();
-			m_p_rx_ring = rx_ring_iter->first;
-		}
-		si_tcp_logdbg("sock state = %d success = %d", get_tcp_state(&m_pcb), success);
-		success = true;
-	} else {
-		success = false;
-	}
-#endif // DEFINED_SOCKETXTREME
-
 	if (!success) {
 		/* we will get here if attach_as_uc_receiver failed */
 		si_tcp_logdbg("Fallback the connection to os");
@@ -2772,14 +2745,11 @@ err_t sockinfo_tcp::accept_lwip_cb(void *arg, struct tcp_pcb *child_pcb, err_t e
 	
 	/* if attach failed, we should continue getting traffic through the listen socket */
 	// todo register as 3-tuple rule for the case the listener is gone?
-	new_sock->attach_as_uc_receiver(role_t (NULL), true);
-
-#ifndef DEFINED_SOCKETXTREME // if not defined
-	if (new_sock->m_rx_ring_map.size() == 1) {
-		rx_ring_map_t::iterator rx_ring_iter = new_sock->m_rx_ring_map.begin();
-		new_sock->m_p_rx_ring = rx_ring_iter->first;
+	bool success = new_sock->attach_as_uc_receiver(role_t (NULL), true);
+	if (!success) {
+		/* we will get here if attach_as_uc_receiver failed */
+		__log_dbg("It should be wrong case");
 	}
-#endif // DEFINED_SOCKETXTREME
 
 	if (new_sock->m_sysvar_tcp_ctl_thread > CTL_THREAD_DISABLE) {
 		new_sock->m_vma_thr = true;


### PR DESCRIPTION
Move rx ring creation/destroy inside netdevice.
m_p_rx_ring should be updated in following functions:
  - rx_add_ring_cb()
  - rx_del_ring_cb()
  - do_rings_migration()

Signed-off-by: Igor Ivanov <igor.ivanov.va@gmail.com>

See related PR https://github.com/Mellanox/libvma/pull/220