### PR TITLE
issue: 1322103 Replace sockaddr_in struct in mem_buff_desc_t

### DIFF
--- a/src/vma/dev/ring_simple.cpp
+++ b/src/vma/dev/ring_simple.cpp
@@ -780,11 +780,9 @@ bool ring_simple::rx_process_buffer(mem_buf_desc_t* p_rx_wc_buf_desc, void* pv_f
 				struct tcphdr* p_tcp_h = (struct tcphdr*)((uint8_t*)p_ip_h + ip_hdr_len);
 
 				// Update the L3 and L4 info
-				p_rx_wc_buf_desc->rx.src.sin_family      = AF_INET;
 				p_rx_wc_buf_desc->rx.src.sin_port        = p_tcp_h->source;
 				p_rx_wc_buf_desc->rx.src.sin_addr.s_addr = p_ip_h->saddr;
 
-				p_rx_wc_buf_desc->rx.dst.sin_family      = AF_INET;
 				p_rx_wc_buf_desc->rx.dst.sin_port        = p_tcp_h->dest;
 				p_rx_wc_buf_desc->rx.dst.sin_addr.s_addr = p_ip_h->daddr;
 				// Update packet descriptor with datagram base address and length
@@ -811,11 +809,9 @@ bool ring_simple::rx_process_buffer(mem_buf_desc_t* p_rx_wc_buf_desc, void* pv_f
 				p_udp_h = (struct udphdr*)((uint8_t*)p_ip_h + ip_hdr_len);
 
 				// Update the L3 and L4 info
-				p_rx_wc_buf_desc->rx.src.sin_family      = AF_INET;
 				p_rx_wc_buf_desc->rx.src.sin_port        = p_udp_h->source;
 				p_rx_wc_buf_desc->rx.src.sin_addr.s_addr = p_ip_h->saddr;
 
-				p_rx_wc_buf_desc->rx.dst.sin_family      = AF_INET;
 				p_rx_wc_buf_desc->rx.dst.sin_port        = p_udp_h->dest;
 				p_rx_wc_buf_desc->rx.dst.sin_addr.s_addr = p_ip_h->daddr;
 				// Update packet descriptor with datagram base address and length
@@ -1005,9 +1001,7 @@ bool ring_simple::rx_process_buffer(mem_buf_desc_t* p_rx_wc_buf_desc, void* pv_f
 	rfs* p_rfs = NULL;
 
 	// Update the L3 info
-	p_rx_wc_buf_desc->rx.src.sin_family      = AF_INET;
 	p_rx_wc_buf_desc->rx.src.sin_addr.s_addr = p_ip_h->saddr;
-	p_rx_wc_buf_desc->rx.dst.sin_family      = AF_INET;
 	p_rx_wc_buf_desc->rx.dst.sin_addr.s_addr = p_ip_h->daddr;
 
 	switch (p_ip_h->protocol) {

--- a/src/vma/dev/ring_tap.cpp
+++ b/src/vma/dev/ring_tap.cpp
@@ -762,11 +762,9 @@ bool ring_tap::rx_process_buffer(mem_buf_desc_t* p_rx_wc_buf_desc, void* pv_fd_r
 				struct tcphdr* p_tcp_h = (struct tcphdr*)((uint8_t*)p_ip_h + ip_hdr_len);
 
 				// Update the L3 and L4 info
-				p_rx_wc_buf_desc->rx.src.sin_family      = AF_INET;
 				p_rx_wc_buf_desc->rx.src.sin_port        = p_tcp_h->source;
 				p_rx_wc_buf_desc->rx.src.sin_addr.s_addr = p_ip_h->saddr;
 
-				p_rx_wc_buf_desc->rx.dst.sin_family      = AF_INET;
 				p_rx_wc_buf_desc->rx.dst.sin_port        = p_tcp_h->dest;
 				p_rx_wc_buf_desc->rx.dst.sin_addr.s_addr = p_ip_h->daddr;
 				// Update packet descriptor with datagram base address and length
@@ -793,11 +791,9 @@ bool ring_tap::rx_process_buffer(mem_buf_desc_t* p_rx_wc_buf_desc, void* pv_fd_r
 				p_udp_h = (struct udphdr*)((uint8_t*)p_ip_h + ip_hdr_len);
 
 				// Update the L3 and L4 info
-				p_rx_wc_buf_desc->rx.src.sin_family      = AF_INET;
 				p_rx_wc_buf_desc->rx.src.sin_port        = p_udp_h->source;
 				p_rx_wc_buf_desc->rx.src.sin_addr.s_addr = p_ip_h->saddr;
 
-				p_rx_wc_buf_desc->rx.dst.sin_family      = AF_INET;
 				p_rx_wc_buf_desc->rx.dst.sin_port        = p_udp_h->dest;
 				p_rx_wc_buf_desc->rx.dst.sin_addr.s_addr = p_ip_h->daddr;
 				// Update packet descriptor with datagram base address and length
@@ -990,9 +986,7 @@ bool ring_tap::rx_process_buffer(mem_buf_desc_t* p_rx_wc_buf_desc, void* pv_fd_r
 	rfs* p_rfs = NULL;
 
 	// Update the L3 info
-	p_rx_wc_buf_desc->rx.src.sin_family      = AF_INET;
 	p_rx_wc_buf_desc->rx.src.sin_addr.s_addr = p_ip_h->saddr;
-	p_rx_wc_buf_desc->rx.dst.sin_family      = AF_INET;
 	p_rx_wc_buf_desc->rx.dst.sin_addr.s_addr = p_ip_h->daddr;
 
 	switch (p_ip_h->protocol) {

--- a/src/vma/proto/mem_buf_desc.h
+++ b/src/vma/proto/mem_buf_desc.h
@@ -37,6 +37,7 @@
 #include <netinet/in.h>
 #include "utils/atomic.h"
 #include "vma/util/vma_list.h"
+#include "vma/util/sock_addr.h"
 #include "vma/lwip/pbuf.h"
 
 class ring_slave;
@@ -73,8 +74,8 @@ public:
 
 	union {
 		struct {
-			sockaddr_in	src; // L3 info
-			sockaddr_in	dst; // L3 info
+			vma_sockaddr_in	src; // L3 info
+			vma_sockaddr_in	dst; // L3 info
 
 			iovec 		frag; // Datagram part base address and length
 			size_t		sz_payload; // This is the total amount of data of the packet, if (sz_payload>sz_data) means fragmented packet.

--- a/src/vma/sock/sockinfo.h
+++ b/src/vma/sock/sockinfo.h
@@ -336,9 +336,11 @@ protected:
 	//TODO need to copy this function from util
 	//int validate_ipoib_prop(char* ifname, unsigned int ifflags, const char param_file[], const char *val, int size, char *filename, char * base_ifname);
 
-	inline void fetch_peer_info(sockaddr_in *p_peer_addr, sockaddr_in *__from, socklen_t *__fromlen)
+	inline void fetch_peer_info(vma_sockaddr_in *p_peer_addr, sockaddr_in *__from, socklen_t *__fromlen)
 	{
-		*__from = *p_peer_addr;
+		__from->sin_addr = p_peer_addr->sin_addr;
+		__from->sin_port = p_peer_addr->sin_port;
+		__from->sin_family = AF_INET;
 		*__fromlen = sizeof(sockaddr_in);
 	}
 

--- a/src/vma/sock/sockinfo_udp.cpp
+++ b/src/vma/sock/sockinfo_udp.cpp
@@ -2106,12 +2106,16 @@ inline void sockinfo_udp::process_timestamps(mem_buf_desc_t* p_desc)
  */
 inline vma_recv_callback_retval_t sockinfo_udp::inspect_by_user_cb(mem_buf_desc_t* p_desc)
 {
+	struct sockaddr_in src, dst;
 	vma_info_t pkt_info;
+
+	set_sockaddr_in(src, p_desc->rx.src);
+	set_sockaddr_in(dst, p_desc->rx.dst);
 
 	pkt_info.struct_sz = sizeof(pkt_info);
 	pkt_info.packet_id = (void*)p_desc;
-	pkt_info.src = &p_desc->rx.src;
-	pkt_info.dst = &p_desc->rx.dst;
+	pkt_info.src = &src;
+	pkt_info.dst = &dst;
 	pkt_info.socket_ready_queue_pkt_count = m_p_socket_stats->n_rx_ready_pkt_count;
 	pkt_info.socket_ready_queue_byte_count = m_p_socket_stats->n_rx_ready_byte_count;
 
@@ -2153,7 +2157,7 @@ inline void sockinfo_udp::fill_completion(mem_buf_desc_t* p_desc)
 
 	completion->packet.num_bufs = p_desc->rx.n_frags;
 	completion->packet.total_len = 0;
-	completion->src = p_desc->rx.src;
+	set_sockaddr_in(completion->src, p_desc->rx.src);
 
 	if (m_n_tsing_flags & SOF_TIMESTAMPING_RAW_HARDWARE) {
 		completion->packet.hw_timestamp = p_desc->rx.udp.hw_timestamp;

--- a/src/vma/util/sock_addr.h
+++ b/src/vma/util/sock_addr.h
@@ -39,6 +39,12 @@
 #include <netinet/in.h>
 #include "vma/util/vtypes.h"
 
+/* Structure describing an Internet socket address.  */
+struct vma_sockaddr_in {
+       in_port_t sin_port;         /* Port number.  */
+       struct in_addr sin_addr;    /* Internet address.  */
+};
+
 class sock_addr
 {
 public:
@@ -201,5 +207,12 @@ static inline in_port_t get_sa_port(const struct sockaddr& addr)
 #if _BullseyeCoverage
     #pragma BullseyeCoverage on
 #endif
+
+static inline void set_sockaddr_in(struct sockaddr_in& dst_addr, const vma_sockaddr_in& src_addr)
+{
+       dst_addr.sin_family = AF_INET;
+       dst_addr.sin_port = src_addr.sin_port;
+       dst_addr.sin_addr = src_addr.sin_addr;
+}
 
 #endif /*SOCK_ADDR_H*/


### PR DESCRIPTION
sockaddr_in struct can be replace with in_port_t and in_addr_t.
This can reduce mem_buff_desc size by 16 bytes (src and dst).

Signed-off-by: Liran Oz <lirano@mellanox.com>