### PR TITLE
issue: 1330652 get rate limit as KBit per sec in new interface

### DIFF
--- a/src/vma/sock/sockinfo.cpp
+++ b/src/vma/sock/sockinfo.cpp
@@ -281,15 +281,19 @@ int sockinfo::getsockopt(int __level, int __optname, void *__optval, socklen_t *
 #endif // DEFINED_SOCKETXTREME
 
 		case SO_MAX_PACING_RATE:
-			if (*__optlen >= sizeof(struct vma_rate_limit_t)) {
+			if (*__optlen == sizeof(struct vma_rate_limit_t)) {
 				*(struct vma_rate_limit_t*)__optval = m_so_ratelimit;
-				(*(struct vma_rate_limit_t*)__optval).rate = KB_TO_BYTE(m_so_ratelimit.rate);
+				(*(struct vma_rate_limit_t*)__optval).rate = m_so_ratelimit.rate;
 				*__optlen = sizeof(struct vma_rate_limit_t);
-				si_logdbg("(SO_MAX_PACING_RATE) value: %d, %d, %d", (*(struct vma_rate_limit_t*)__optval).rate, (*(struct vma_rate_limit_t*)__optval).max_burst_sz, (*(struct vma_rate_limit_t*)__optval).typical_pkt_sz);
-			} else if (*__optlen >= sizeof(uint32_t)) {
+				si_logdbg("(SO_MAX_PACING_RATE) value: %d, %d, %d",
+					  (*(struct vma_rate_limit_t*)__optval).rate,
+					  (*(struct vma_rate_limit_t*)__optval).max_burst_sz,
+					  (*(struct vma_rate_limit_t*)__optval).typical_pkt_sz);
+			} else if (*__optlen == sizeof(uint32_t)) {
 				*(uint32_t*)__optval = KB_TO_BYTE(m_so_ratelimit.rate);
 				*__optlen = sizeof(uint32_t);
-				si_logdbg("(SO_MAX_PACING_RATE) value: %d", *(int *)__optval);
+				si_logdbg("(SO_MAX_PACING_RATE) value: %d",
+					  *(int *)__optval);
 				ret = 0;
 			} else {
 				errno = EINVAL;

--- a/src/vma/sock/sockinfo.h
+++ b/src/vma/sock/sockinfo.h
@@ -57,7 +57,7 @@
 #define BASE_SOCKINFO_H
 
 #define SI_RX_EPFD_EVENT_MAX		16
-#define BYTE_TO_KB(BYTEVALUE)		(((BYTEVALUE) * 8) / 1000)
+#define BYTE_TO_KB(BYTEVALUE)		((uint64_t)((uint64_t)((uint64_t)BYTEVALUE) * 8) / 1000)
 #define KB_TO_BYTE(BYTEVALUE)		(((BYTEVALUE) * 1000) / 8)
 
 struct buff_info_t {

--- a/src/vma/sock/sockinfo_tcp.cpp
+++ b/src/vma/sock/sockinfo_tcp.cpp
@@ -3654,10 +3654,11 @@ int sockinfo_tcp::setsockopt(int __level, int __optname,
 				errno = EINVAL;
 				break;
 			}
-			if (sizeof(struct vma_rate_limit_t) <= __optlen) {
-				rate_limit = *(struct vma_rate_limit_t*)__optval; // value is in bytes per second
-			} else if (sizeof(uint32_t) <= __optlen) {
-				rate_limit.rate = *(uint32_t*)__optval; // value is in bytes per second
+			if (sizeof(struct vma_rate_limit_t) == __optlen) {
+				rate_limit = *(struct vma_rate_limit_t*)__optval; // value is in Kbits per second
+			} else if (sizeof(uint32_t) == __optlen) {
+				// value is in bytes per second
+				rate_limit.rate = BYTE_TO_KB(*(uint32_t*)__optval); // value is in bytes per second
 				rate_limit.max_burst_sz = 0;
 				rate_limit.typical_pkt_sz = 0;
 			} else {
@@ -3665,7 +3666,7 @@ int sockinfo_tcp::setsockopt(int __level, int __optname,
 				break;
 			}
 
-			rate_limit.rate = BYTE_TO_KB(rate_limit.rate); // value is in bytes per second
+
 
 			lock_tcp_con();
 			ret = modify_ratelimit(m_p_connected_dst_entry, rate_limit);

--- a/src/vma/sock/sockinfo_udp.cpp
+++ b/src/vma/sock/sockinfo_udp.cpp
@@ -922,10 +922,11 @@ int sockinfo_udp::setsockopt(int __level, int __optname, __const void *__optval,
 				if (__optval) {
 					struct vma_rate_limit_t val;
 
-					if (sizeof(struct vma_rate_limit_t) <= __optlen) {
-						val = *(struct vma_rate_limit_t*)__optval; // value is in bytes per second
-					} else if (sizeof(uint32_t) <= __optlen) {
-						val.rate = *(uint32_t*)__optval; // value is in bytes per second
+					if (sizeof(struct vma_rate_limit_t) == __optlen) {
+						val = *(struct vma_rate_limit_t*)__optval; // value is in Kbits per second
+					} else if (sizeof(uint32_t) == __optlen) {
+						// value is in bytes per second
+						val.rate = BYTE_TO_KB(*(uint32_t*)__optval); // value is in bytes per second
 						val.max_burst_sz = 0;
 						val.typical_pkt_sz = 0;
 					} else {
@@ -933,8 +934,6 @@ int sockinfo_udp::setsockopt(int __level, int __optname, __const void *__optval,
 							      setsockopt_so_opt_to_str(__optname), __optlen);
 						return -1;
 					}
-
-					val.rate = BYTE_TO_KB(val.rate); // value is in bytes per second
 
 					if (modify_ratelimit(m_p_connected_dst_entry, val) < 0) {
 						si_udp_logdbg("error setting setsockopt SO_MAX_PACING_RATE for connected dst_entry %p: %d bytes/second ", m_p_connected_dst_entry, val.rate);


### PR DESCRIPTION
When setting vma_rate_limit_t expect rate as kbit instead
of bytes. This is needed since uint32 is not big enough for
big values of bytes per second

Signed-off-by: Rafi Wiener <rafiw@mellanox.com>