### PR TITLE
issue 1182150: Support HW RX timestamp in SocketXtreme

### DIFF
--- a/src/vma/sock/sockinfo_udp.cpp
+++ b/src/vma/sock/sockinfo_udp.cpp
@@ -2155,6 +2155,11 @@ inline void sockinfo_udp::fill_completion(mem_buf_desc_t* p_desc)
 	completion->src = p_desc->rx.src;
 	NOTIFY_ON_EVENTS(this, VMA_SOCKETXTREME_PACKET);
 
+	if (m_n_tsing_flags & (SOF_TIMESTAMPING_RAW_HARDWARE |
+			       SOF_TIMESTAMPING_RX_HARDWARE)) {
+		completion->packet.timestamp = p_desc->rx.udp.hw_timestamp;
+	}
+
 	m_socketxtreme_completion = NULL;
 	m_socketxtreme_last_buff_lst = NULL;
 }

--- a/src/vma/sock/sockinfo_udp.cpp
+++ b/src/vma/sock/sockinfo_udp.cpp
@@ -995,10 +995,13 @@ int sockinfo_udp::setsockopt(int __level, int __optname, __const void *__optval,
 
 					struct ip_mreqn mreqn;
 
+					memset(&mreqn, 0, sizeof(mreqn));
+
 					if (__optlen >= sizeof(struct ip_mreqn)) {
 						mreqn = *(struct ip_mreqn*)__optval;
+					} else if (__optlen == sizeof(struct ip_mreq)) {
+						mreqn.imr_address = ((struct ip_mreq*)__optval)->imr_interface;
 					} else {
-						memset(&mreqn, 0, sizeof(mreqn));
 						if (__optlen >= sizeof(struct in_addr)) {
 							mreqn.imr_address = *(struct in_addr*)__optval;
 						}

--- a/src/vma/vma_extra.h
+++ b/src/vma/vma_extra.h
@@ -96,6 +96,7 @@ struct vma_packet_desc_t {
 	size_t			num_bufs;	/* number of packet's buffers */
 	uint16_t		total_len;	/* total data length */
 	struct vma_buff_t*	buff_lst;	/* list of packet's buffers */
+	struct timespec 	timestamp;	/* packet timestamp */
 };
 
 /*


### PR DESCRIPTION
Adding HW timestamp reporting in the packet descriptor
which is returned to user.

Signed-off-by: Ariel Levkovich <lariel@mellanox.com>