### PR TITLE
issue: 1182150 Support HW RX timestamp in SocketXtreme

### DIFF
--- a/src/vma/dev/cq_mgr.cpp
+++ b/src/vma/dev/cq_mgr.cpp
@@ -772,6 +772,7 @@ int cq_mgr::socketxtreme_and_process_element_rx(mem_buf_desc_t **p_desc_lst)
 		++m_n_wce_counter;
 		++m_qp->m_mlx5_hw_qp->rq.tail;
 		m_rx_hot_buff->sz_data = ntohl(cqe->byte_cnt);
+		m_rx_hot_buff->rx.hw_raw_timestamp = ntohll(cqe->timestamp);
 		m_rx_hot_buff->rx.flow_tag_id = vma_get_flow_tag(cqe);
 
 		if (unlikely(++m_qp_rec.debt >= (int)m_n_sysvar_rx_num_wr_to_post_recv)) {

--- a/src/vma/sock/sockinfo_udp.cpp
+++ b/src/vma/sock/sockinfo_udp.cpp
@@ -2144,6 +2144,11 @@ inline void sockinfo_udp::fill_completion(mem_buf_desc_t* p_desc)
 
 	completion->packet.num_bufs = p_desc->rx.n_frags;
 	completion->packet.total_len = 0;
+	completion->src = p_desc->rx.src;
+
+	if (m_n_tsing_flags & SOF_TIMESTAMPING_RAW_HARDWARE) {
+		completion->packet.hw_timestamp = p_desc->rx.udp.hw_timestamp;
+	}
 
 	for(mem_buf_desc_t *tmp_p=p_desc; tmp_p; tmp_p=tmp_p->p_next_desc) {
 		completion->packet.total_len        += tmp_p->rx.sz_payload;
@@ -2152,13 +2157,8 @@ inline void sockinfo_udp::fill_completion(mem_buf_desc_t* p_desc)
 		completion->packet.buff_lst->payload = p_desc->rx.frag.iov_base;
 		completion->packet.buff_lst->len     = p_desc->rx.frag.iov_len;
 	}
-	completion->src = p_desc->rx.src;
-	NOTIFY_ON_EVENTS(this, VMA_SOCKETXTREME_PACKET);
 
-	if (m_n_tsing_flags & (SOF_TIMESTAMPING_RAW_HARDWARE |
-			       SOF_TIMESTAMPING_RX_HARDWARE)) {
-		completion->packet.timestamp = p_desc->rx.udp.hw_timestamp;
-	}
+	NOTIFY_ON_EVENTS(this, VMA_SOCKETXTREME_PACKET);
 
 	m_socketxtreme_completion = NULL;
 	m_socketxtreme_last_buff_lst = NULL;

--- a/src/vma/sock/sockinfo_udp.cpp
+++ b/src/vma/sock/sockinfo_udp.cpp
@@ -2155,6 +2155,11 @@ inline void sockinfo_udp::fill_completion(mem_buf_desc_t* p_desc)
 	completion->src = p_desc->rx.src;
 	NOTIFY_ON_EVENTS(this, VMA_SOCKETXTREME_PACKET);
 
+	if (m_n_tsing_flags & (SOF_TIMESTAMPING_RAW_HARDWARE |
+			       SOF_TIMESTAMPING_RX_HARDWARE)) {
+		completion->packet.timestamp = p_desc->rx.udp.hw_timestamp;
+	}
+
 	m_socketxtreme_completion = NULL;
 	m_socketxtreme_last_buff_lst = NULL;
 }

--- a/src/vma/vma_extra.h
+++ b/src/vma/vma_extra.h
@@ -96,7 +96,7 @@ struct vma_packet_desc_t {
 	size_t			num_bufs;	/* number of packet's buffers */
 	uint16_t		total_len;	/* total data length */
 	struct vma_buff_t*	buff_lst;	/* list of packet's buffers */
-	struct timespec 	timestamp;	/* packet timestamp */
+	struct timespec 	hw_timestamp;	/* packet hw_timestamp */
 };
 
 /*

--- a/src/vma/vma_extra.h
+++ b/src/vma/vma_extra.h
@@ -96,6 +96,7 @@ struct vma_packet_desc_t {
 	size_t			num_bufs;	/* number of packet's buffers */
 	uint16_t		total_len;	/* total data length */
 	struct vma_buff_t*	buff_lst;	/* list of packet's buffers */
+	struct timespec 	timestamp;	/* packet timestamp */
 };
 
 /*


### PR DESCRIPTION
Adding HW timestamp reporting in the packet descriptor
which is returned to user.

Signed-off-by: Ariel Levkovich <lariel@mellanox.com>