### PR TITLE
issue: 1365423 Use mmap to allocate huge pages

### DIFF
--- a/src/vma/dev/allocator.h
+++ b/src/vma/dev/allocator.h
@@ -51,9 +51,13 @@ public:
 	bool register_memory(size_t size, ib_ctx_handler *p_ib_ctx_h, uint64_t access);
 	void deregister_memory();
 private:
+	void align_simple_malloc(size_t sz_bytes);
 	bool hugetlb_alloc(size_t sz_bytes);
+	bool hugetlb_mmap_alloc();
+	bool hugetlb_sysv_alloc();
 	lkey_map_ib_ctx_map_t m_lkey_map_ib_ctx;
 	int m_shmid;
+	size_t m_length;
 	void *m_data_block;
 	alloc_mode_t m_mem_alloc_type;
 };


### PR DESCRIPTION
This commit replaces the huge page technique used by VMA
to allocte huge pages to mmap.
mmap allocation is cleaner and kernel handles it better when
calling madvise on that memory segment.

Signed-off-by: Rafi Wiener <rafiw@mellanox.com>