### PR TITLE
issue: 1387232 Add vmad configurable notify dir

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -106,6 +106,7 @@ Example:
  VMA DETAILS: Log File                                                  [VMA_LOG_FILE]
  VMA DETAILS: Stats File                                                [VMA_STATS_FILE]
  VMA DETAILS: Stats shared memory directory  /tmp/                      [VMA_STATS_SHMEM_DIR]
+ VMA DETAILS: VMAD output directory          /tmp/vma/                  [VMA_VMAD_NOTIFY_DIR]
  VMA DETAILS: Stats FD Num (max)             100                        [VMA_STATS_FD_NUM]
  VMA DETAILS: Conf File                      /etc/libvma.conf           [VMA_CONFIG_FILE]
  VMA DETAILS: Application ID                 VMA_DEFAULT_APPLICATION_ID [VMA_APPLICATION_ID]
@@ -313,6 +314,11 @@ VMA_STATS_SHMEM_DIR
 Set the directory path for VMA to create the shared memory files for vma_stats.
 No files will be created when setting this value to empty string "".
 Default value is /tmp/
+
+VMA_VMAD_NOTIFY_DIR
+Set the directory path for VMA to write files used by vmad.
+Default value is /tmp/vma/
+note: when used vmad must be run with --notify-dir directing the same folder
 
 VMA_STATS_FD_NUM
 Max number of sockets monitored by VMA statistic mechanism.

--- a/README.txt
+++ b/README.txt
@@ -1,4 +1,4 @@
-Update: 25 Jan 2018
+Update: 20 Jun 2018
 
 Introduction
 ============
@@ -318,7 +318,7 @@ Default value is /tmp/
 VMA_VMAD_NOTIFY_DIR
 Set the directory path for VMA to write files used by vmad.
 Default value is /tmp/vma/
-note: when used vmad must be run with --notify-dir directing the same folder
+Note: when used vmad must be run with --notify-dir directing the same folder.
 
 VMA_STATS_FD_NUM
 Max number of sockets monitored by VMA statistic mechanism.

--- a/src/vma/main.cpp
+++ b/src/vma/main.cpp
@@ -442,6 +442,7 @@ void print_vma_global_settings()
 	VLOG_STR_PARAM_STRING("Log File", safe_mce_sys().log_filename, MCE_DEFAULT_LOG_FILE, SYS_VAR_LOG_FILENAME, safe_mce_sys().log_filename);
 	VLOG_STR_PARAM_STRING("Stats File", safe_mce_sys().stats_filename, MCE_DEFAULT_STATS_FILE, SYS_VAR_STATS_FILENAME, safe_mce_sys().stats_filename);
 	VLOG_STR_PARAM_STRING("Stats shared memory directory", safe_mce_sys().stats_shmem_dirname, MCE_DEFAULT_STATS_SHMEM_DIR, SYS_VAR_STATS_SHMEM_DIRNAME, safe_mce_sys().stats_shmem_dirname);
+	VLOG_STR_PARAM_STRING("VMAD output directory", safe_mce_sys().vmad_notify_dir, MCE_DEFAULT_VMAD_FOLDER, SYS_VAR_VMAD_DIR, safe_mce_sys().vmad_notify_dir);
 	VLOG_PARAM_NUMBER("Stats FD Num (max)", safe_mce_sys().stats_fd_num_max, MCE_DEFAULT_STATS_FD_NUM, SYS_VAR_STATS_FD_NUM);
 	VLOG_STR_PARAM_STRING("Conf File", safe_mce_sys().conf_filename, MCE_DEFAULT_CONF_FILE, SYS_VAR_CONF_FILENAME, safe_mce_sys().conf_filename);
 	VLOG_STR_PARAM_STRING("Application ID", safe_mce_sys().app_id, MCE_DEFAULT_APP_ID, SYS_VAR_APPLICATION_ID, safe_mce_sys().app_id);

--- a/src/vma/util/agent.cpp
+++ b/src/vma/util/agent.cpp
@@ -89,6 +89,7 @@ agent::agent() :
 	/* Fill free queue with empty messages */
 	i = m_msg_num;
 	m_msg_num = 0;
+	const char *path = safe_mce_sys().vmad_notify_dir;
 	while (i--) {
 		/* coverity[overwrite_var] */
 		msg = (agent_msg_t *)calloc(1, sizeof(*msg));
@@ -102,14 +103,14 @@ agent::agent() :
 		m_msg_num++;
 	}
 
-	if ((mkdir(VMA_AGENT_PATH, 0777) != 0) && (errno != EEXIST)) {
+	if ((mkdir(path, 0777) != 0) && (errno != EEXIST)) {
 		rc = -errno;
-		__log_dbg("failed create folder %s (rc = %d)\n", VMA_AGENT_PATH, rc);
+		__log_dbg("failed create folder %s (rc = %d)\n", path, rc);
 		goto err;
 	}
 
 	rc = snprintf(m_sock_file, sizeof(m_sock_file) - 1,
-			"%s/%s.%d.sock", VMA_AGENT_PATH, VMA_AGENT_BASE_NAME, getpid());
+			"%s/%s.%d.sock", path, VMA_AGENT_BASE_NAME, getpid());
 	if ((rc < 0 ) || (rc == (sizeof(m_sock_file) - 1) )) {
 		rc = -ENOMEM;
 		__log_dbg("failed allocate sock file (rc = %d)\n", rc);
@@ -117,7 +118,7 @@ agent::agent() :
 	}
 
 	rc = snprintf(m_pid_file, sizeof(m_pid_file) - 1,
-			"%s/%s.%d.pid", VMA_AGENT_PATH, VMA_AGENT_BASE_NAME, getpid());
+			"%s/%s.%d.pid", path, VMA_AGENT_BASE_NAME, getpid());
 	if ((rc < 0 ) || (rc == (sizeof(m_pid_file) - 1) )) {
 		rc = -ENOMEM;
 		__log_dbg("failed allocate pid file (rc = %d)\n", rc);

--- a/src/vma/util/agent_def.h
+++ b/src/vma/util/agent_def.h
@@ -65,7 +65,7 @@
 
 #define VMA_AGENT_BASE_NAME "vma_agent"
 #define VMA_AGENT_ADDR      "/var/run/" VMA_AGENT_BASE_NAME ".sock"
-#define VMA_AGENT_PATH      "/tmp/vma"
+#define VMA_AGENT_PATH      "/tmp/vma/"
 
 
 #pragma pack(push, 1)

--- a/src/vma/util/sys_vars.cpp
+++ b/src/vma/util/sys_vars.cpp
@@ -426,12 +426,14 @@ void mce_sys_var::get_env_params()
 	app_name[len-1] = '\0';
 	fclose(fp);
 
-	bzero(vma_time_measure_filename, sizeof(vma_time_measure_filename));
+	memset(vma_time_measure_filename, 0, sizeof(vma_time_measure_filename));
 	strcpy(vma_time_measure_filename, MCE_DEFAULT_TIME_MEASURE_DUMP_FILE);
-	bzero(log_filename, sizeof(log_filename));
-	bzero(stats_filename, sizeof(stats_filename));
-	bzero(stats_shmem_dirname, sizeof(stats_shmem_dirname));
+	memset(log_filename, 0, sizeof(log_filename));
+	memset(stats_filename, 0, sizeof(stats_filename));
+	memset(stats_shmem_dirname, 0, sizeof(stats_shmem_dirname));
+	memset(vmad_notify_dir, 0, sizeof(vmad_notify_dir));
 	strcpy(stats_filename, MCE_DEFAULT_STATS_FILE);
+	strcpy(vmad_notify_dir, MCE_DEFAULT_VMAD_FOLDER);
 	strcpy(stats_shmem_dirname, MCE_DEFAULT_STATS_SHMEM_DIR);
 	strcpy(conf_filename, MCE_DEFAULT_CONF_FILE);
 	strcpy(app_id, MCE_DEFAULT_APP_ID);
@@ -698,6 +700,10 @@ void mce_sys_var::get_env_params()
 
 	if ((env_ptr = getenv(SYS_VAR_CONF_FILENAME)) != NULL){
 		read_env_variable_with_pid(conf_filename, sizeof(conf_filename), env_ptr);
+	}
+
+	if ((env_ptr = getenv(SYS_VAR_VMAD_DIR)) != NULL){
+		read_env_variable_with_pid(vmad_notify_dir, sizeof(vmad_notify_dir), env_ptr);
 	}
 
 	if ((env_ptr = getenv(SYS_VAR_LOG_LEVEL)) != NULL)

--- a/src/vma/util/sys_vars.h
+++ b/src/vma/util/sys_vars.h
@@ -298,6 +298,7 @@ struct mce_sys_var {
 	char		stats_filename[PATH_MAX];
 	char		stats_shmem_dirname[PATH_MAX];
 	char 		conf_filename[PATH_MAX];
+	char		vmad_notify_dir[PATH_MAX];
 	bool		log_colors;
 	bool 		handle_sigintr;
 	bool		handle_segfault;
@@ -432,6 +433,7 @@ extern mce_sys_var & safe_mce_sys();
 #define SYS_VAR_LOG_DETAILS				"VMA_LOG_DETAILS"
 #define SYS_VAR_LOG_FILENAME				"VMA_LOG_FILE"
 #define SYS_VAR_STATS_FILENAME				"VMA_STATS_FILE"
+#define SYS_VAR_VMAD_DIR				"VMA_VMAD_NOTIFY_DIR"
 #define SYS_VAR_STATS_SHMEM_DIRNAME			"VMA_STATS_SHMEM_DIR"
 #define SYS_VAR_CONF_FILENAME				"VMA_CONFIG_FILE"
 #define SYS_VAR_LOG_COLORS				"VMA_LOG_COLORS"
@@ -543,6 +545,7 @@ extern mce_sys_var & safe_mce_sys();
 #define MCE_DEFAULT_LOG_FILE				("")
 #define MCE_DEFAULT_CONF_FILE				("/etc/libvma.conf")
 #define MCE_DEFAULT_STATS_FILE				("")
+#define MCE_DEFAULT_VMAD_FOLDER			(VMA_AGENT_PATH)
 #define MCE_DEFAULT_STATS_SHMEM_DIR			("/tmp/")
 #define MCE_DEFAULT_LOG_DETAILS				(0)
 #define MCE_DEFAULT_LOG_COLORS				(true)

--- a/tools/daemon/daemon.c
+++ b/tools/daemon/daemon.c
@@ -285,6 +285,7 @@ static int config_set(int argc, char **argv)
 	int rc = 0;
 	static struct option long_options[] = {
 		{"console",      no_argument,       &daemon_cfg.opt.mode,      1},
+		{"notify-dir",   required_argument, 0,                         'n'},
 		{"verbose",      required_argument, 0,                         'v'},
 		{"pid",          required_argument, 0,                         'p'},
 		{"fid",          required_argument, 0,                         'f'},
@@ -295,11 +296,18 @@ static int config_set(int argc, char **argv)
 	int op;
 	int option_index;
 
-	while ((op = getopt_long(argc, argv, "v:p:f:h", long_options, &option_index)) != -1) {
+	while ((op = getopt_long(argc, argv, "v:n:p:f:h", long_options, &option_index)) != -1) {
 		switch (op) {
 			case 'v':
 				errno = 0;
 				daemon_cfg.opt.log_level = strtol(optarg, NULL, 0);
+				if (0 != errno) {
+					rc = -EINVAL;
+				}
+				break;
+			case 'n':
+				errno = 0;
+				daemon_cfg.notify_dir = optarg;
 				if (0 != errno) {
 					rc = -EINVAL;
 				}
@@ -353,12 +361,14 @@ static void usage(void)
 {
 	printf("Usage: " MODULE_NAME " [options]\n"
 		"\t--console               Enable foreground mode (default: %s)\n"
+		"\t--notify-dir            Sets the outout dir used by vmad (default: %s)\n"
 		"\t--pid,-p <num>          Set prime number as maximum of processes per node. (default: %d).\n"
 		"\t--fid,-f <num>          Set prime number as maximum of sockets per process. (default: %d).\n"
 		"\t--force-rst             Force internal RST. (default: %s).\n"
 		"\t--verbose,-v <level>    Output verbose level (default: %d).\n"
 		"\t--help,-h               Print help and exit\n",
 			(daemon_cfg.opt.mode ? "on" : "off"),
+			VMA_AGENT_PATH,
 			daemon_cfg.opt.max_pid_num,
 			daemon_cfg.opt.max_fid_num,
 			(daemon_cfg.opt.force_rst ? "on" : "off"),

--- a/tools/daemon/loop.c
+++ b/tools/daemon/loop.c
@@ -60,9 +60,10 @@ int proc_loop(void)
 	int rc = 0;
 
 	log_debug("setting working directory ...\n");
-	if ((mkdir(VMA_AGENT_PATH, 0777) != 0) && (errno != EEXIST)) {
+	if ((mkdir(daemon_cfg.notify_dir, 0777) != 0) && (errno != EEXIST)) {
 		rc = -errno;
-		log_error("failed create folder %s (errno = %d)\n", VMA_AGENT_PATH, errno);
+		log_error("failed create folder %s (errno = %d)\n",
+			  daemon_cfg.notify_dir, errno);
 		goto err;
 	}
 

--- a/tools/daemon/notify.c
+++ b/tools/daemon/notify.c
@@ -585,7 +585,8 @@ static int open_fanotify(void)
 	}
 
 	rc = fanotify_mark(daemon_cfg.notify_fd, FAN_MARK_ADD,
-			FAN_CLOSE | FAN_EVENT_ON_CHILD, AT_FDCWD, VMA_AGENT_PATH);
+			FAN_CLOSE | FAN_EVENT_ON_CHILD, AT_FDCWD,
+			daemon_cfg.notify_dir);
 	if (rc < 0) {
 		rc = -errno;
 		log_error("Failed to add watch for directory %s errno %d (%s)\n",
@@ -643,7 +644,7 @@ static int proc_fanotify(void *buffer, int nbyte)
 					data->mask, data->pid, data->fd, pathname);
 
 			rc = snprintf(buf, sizeof(buf) - 1, "%s/%s.%d.pid",
-					VMA_AGENT_PATH, VMA_AGENT_BASE_NAME, data->pid);
+					daemon_cfg.notify_dir, VMA_AGENT_BASE_NAME, data->pid);
 			if ((rc < 0 ) || (rc == (sizeof(buf) - 1) )) {
 				rc = -ENOMEM;
 				log_error("failed allocate pid file errno %d (%s)\n", errno,
@@ -669,7 +670,7 @@ static int proc_fanotify(void *buffer, int nbyte)
 					strcpy(pathname, buf);
 					unlink(pathname);
 					if (snprintf(pathname, sizeof(pathname) - 1, "%s/%s.%d.sock",
-							VMA_AGENT_PATH, VMA_AGENT_BASE_NAME, data->pid) > 0) {
+							daemon_cfg.notify_dir, VMA_AGENT_BASE_NAME, data->pid) > 0) {
 						unlink(pathname);
 					}
 				} else if (-ESRCH == rc) {
@@ -707,7 +708,7 @@ static int open_inotify(void)
 	}
 
 	rc = inotify_add_watch(daemon_cfg.notify_fd,
-			VMA_AGENT_PATH,
+			daemon_cfg.notify_dir,
 			IN_CLOSE_WRITE | IN_CLOSE_NOWRITE | IN_DELETE);
 	if (rc < 0) {
 		rc = -errno;
@@ -741,7 +742,7 @@ static int proc_inotify(void *buffer, int nbyte)
 			memset(pathname, 0, sizeof(pathname));
 
 			rc = snprintf(pathname, sizeof(pathname) - 1, "%s/%s",
-					VMA_AGENT_PATH, data->name);
+					daemon_cfg.notify_dir, data->name);
 			if ((rc < 0 ) || (rc == (sizeof(pathname) - 1) )) {
 				rc = -ENOMEM;
 				log_error("failed allocate pid file errno %d (%s)\n", errno,
@@ -753,7 +754,7 @@ static int proc_inotify(void *buffer, int nbyte)
 					data->mask, pid, pathname);
 
 			rc = snprintf(buf, sizeof(buf) - 1, "%s/%s.%d.pid",
-					VMA_AGENT_PATH, VMA_AGENT_BASE_NAME, pid);
+					daemon_cfg.notify_dir, VMA_AGENT_BASE_NAME, pid);
 			if ((rc < 0 ) || (rc == (sizeof(buf) - 1) )) {
 				rc = -ENOMEM;
 				log_error("failed allocate pid file errno %d (%s)\n", errno,
@@ -777,7 +778,7 @@ static int proc_inotify(void *buffer, int nbyte)
 					log_debug("[%d] cleanup after unexpected termination\n", pid);
 					unlink(buf);
 					if (snprintf(buf, sizeof(buf) - 1, "%s/%s.%d.sock",
-							VMA_AGENT_PATH, VMA_AGENT_BASE_NAME, pid) > 0) {
+							daemon_cfg.notify_dir, VMA_AGENT_BASE_NAME, pid) > 0) {
 						unlink(buf);
 					}
 				} else if (-ESRCH == rc) {


### PR DESCRIPTION
By dafault VMA writes the fd output files to the folder
/tmp/vma/, and daemon reds them from there.
Now user can change this folder location,
VMA should be run with VMA_VMAD_NOTIFY_DIR and
vmad should be run with --notify-dir.
default folder remains /tmp/vma/

Signed-off-by: Rafi Wiener <rafiw@mellanox.com>