### PR TITLE
issue: 1398946 Fix issue with incorrect ring_eth_cb creation

### DIFF
--- a/contrib/valgrind/valgrind_vma.supp
+++ b/contrib/valgrind/valgrind_vma.supp
@@ -35,7 +35,7 @@
    match-leak-kinds: definite
    fun:_Znwm
    fun:_ZN13fd_collection17add_cq_channel_fdEiP4ring
-   fun:_ZN11ring_simple16create_resourcesEt
+   fun:_ZN11ring_simple16create_resourcesEv
 }
 {
    RM #1073005

--- a/src/vma/dev/ring_eth_cb.h
+++ b/src/vma/dev/ring_eth_cb.h
@@ -73,7 +73,6 @@ public:
 	int		cyclic_buffer_read(vma_completion_cb_t &completion,
 					   size_t min, size_t max, int flags);
 protected:
-	void		create_resources(uint16_t partition, vma_cyclic_buffer_ring_attr *cb_ring);
 	virtual		qp_mgr* create_qp_mgr(const ib_ctx_handler* ib_ctx,
 					      uint8_t port_num,
 					      struct ibv_comp_channel* p_rx_comp_event_channel);

--- a/src/vma/dev/ring_eth_direct.cpp
+++ b/src/vma/dev/ring_eth_direct.cpp
@@ -45,13 +45,10 @@ ring_eth_direct::ring_eth_direct(int if_index,
 					ring_eth(if_index,
 						parent, false)
 {
-	net_device_val_eth* p_ndev =
-			dynamic_cast<net_device_val_eth *>(g_p_net_device_table_mgr->get_net_device_val(if_index));
-
-	if (p_ndev) {
-		create_resources(p_ndev->get_vlan());
-	}
 	m_ring_attr.comp_mask = ext_ring_attr->comp_mask;
+
+	/* Complete resources initialization */
+	ring_simple::create_resources();
 }
 
 qp_mgr* ring_eth_direct::create_qp_mgr(const ib_ctx_handler* ib_ctx,

--- a/src/vma/dev/ring_simple.cpp
+++ b/src/vma/dev/ring_simple.cpp
@@ -154,7 +154,7 @@ ring_simple::ring_simple(int if_index, ring* parent /*=NULL*/):
 	, m_flow_tag_enabled(false)
 {
 	net_device_val* p_ndev = g_p_net_device_table_mgr->get_net_device_val(m_parent->get_if_index());
-	slave_data_t * p_slave = p_ndev->get_slave(get_if_index());
+	const slave_data_t * p_slave = p_ndev->get_slave(get_if_index());
 
 	ring_logdbg("new ring_simple()");
 


### PR DESCRIPTION
ring_eth_direct, ring_eth_cb have own approaches for qp creation
and they should call special create_qp_mgr() methods after
virtual table is configured.
It requires to delay ring_simple::create_resources() call.
At the same time few fields of ring_simple should be initialized
before logic of ring_eth_direct, ring_eth_cb constructors start.

Signed-off-by: Igor Ivanov <igor.ivanov.va@gmail.com>