### PR TITLE
issue: 1404279 Fix TCP sockets of secondary IPs are not offloaded

### DIFF
--- a/src/vma/dev/rfs.h
+++ b/src/vma/dev/rfs.h
@@ -203,9 +203,9 @@ typedef std::vector<attach_flow_data_t*> attach_flow_data_vector_t;
 class rfs_rule_filter
 {
 public:
-	rfs_rule_filter(rule_filter_map_t& map, uint32_t key, flow_tuple& flow_tuple) : m_map(map), m_key(key), m_flow_tuple(flow_tuple) {}
+	rfs_rule_filter(rule_filter_map_t& map, uint64_t key, flow_tuple& flow_tuple) : m_map(map), m_key(key), m_flow_tuple(flow_tuple) {}
 	rule_filter_map_t& m_map;
-	uint32_t m_key;
+	uint64_t m_key;
 	flow_tuple m_flow_tuple;
 };
 

--- a/src/vma/dev/ring_simple.cpp
+++ b/src/vma/dev/ring_simple.cpp
@@ -486,7 +486,8 @@ bool ring_simple::attach_flow(flow_tuple& flow_spec_5t, pkt_rcvr_sink *sink)
 			}
 		}
 	} else if (flow_spec_5t.is_tcp()) {
-		flow_spec_tcp_key_t key_tcp(flow_spec_5t.get_src_ip(), flow_spec_5t.get_dst_port(), flow_spec_5t.get_src_port());
+		flow_spec_tcp_key_t key_tcp(flow_spec_5t.get_dst_ip(), flow_spec_5t.get_src_ip(),
+				flow_spec_5t.get_dst_port(), flow_spec_5t.get_src_port());
 		rfs_rule_filter* tcp_dst_port_filter = NULL;
 		if (safe_mce_sys().tcp_3t_rules) {
 			rule_filter_map_t::iterator tcp_dst_port_iter = m_tcp_dst_port_attach_map.find(key_tcp.dst_port);
@@ -625,7 +626,8 @@ bool ring_simple::detach_flow(flow_tuple& flow_spec_5t, pkt_rcvr_sink* sink)
 		}
 	} else if (flow_spec_5t.is_tcp()) {
 		int keep_in_map = 1;
-		flow_spec_tcp_key_t key_tcp(flow_spec_5t.get_src_ip(), flow_spec_5t.get_dst_port(), flow_spec_5t.get_src_port());
+		flow_spec_tcp_key_t key_tcp(flow_spec_5t.get_dst_ip(), flow_spec_5t.get_src_ip(),
+				flow_spec_5t.get_dst_port(), flow_spec_5t.get_src_port());
 		if (safe_mce_sys().tcp_3t_rules) {
 			rule_filter_map_t::iterator tcp_dst_port_iter = m_tcp_dst_port_attach_map.find(key_tcp.dst_port);
 			BULLSEYE_EXCLUDE_BLOCK_START
@@ -1072,13 +1074,15 @@ bool ring_simple::rx_process_buffer(mem_buf_desc_t* p_rx_wc_buf_desc, void* pv_f
 		p_rx_wc_buf_desc->rx.tcp.p_tcp_h = p_tcp_h;
 
 		// Find the relevant hash map and pass the packet to the rfs for dispatching
-		p_rfs = m_flow_tcp_map.get(flow_spec_tcp_key_t(p_rx_wc_buf_desc->rx.src.sin_addr.s_addr,
-			p_rx_wc_buf_desc->rx.dst.sin_port, p_rx_wc_buf_desc->rx.src.sin_port), NULL);
+		p_rfs = m_flow_tcp_map.get(flow_spec_tcp_key_t(p_rx_wc_buf_desc->rx.dst.sin_addr.s_addr,
+				p_rx_wc_buf_desc->rx.src.sin_addr.s_addr, p_rx_wc_buf_desc->rx.dst.sin_port,
+				p_rx_wc_buf_desc->rx.src.sin_port), NULL);
 
 		p_rx_wc_buf_desc->rx.tcp.n_transport_header_len = transport_header_len;
 
 		if (unlikely(p_rfs == NULL)) {	// If we didn't find a match for TCP 5T, look for a match with TCP 3T
-			p_rfs = m_flow_tcp_map.get(flow_spec_tcp_key_t(0, p_rx_wc_buf_desc->rx.dst.sin_port, 0), NULL);
+			p_rfs = m_flow_tcp_map.get(flow_spec_tcp_key_t(p_rx_wc_buf_desc->rx.dst.sin_addr.s_addr, 0,
+					p_rx_wc_buf_desc->rx.dst.sin_port, 0), NULL);
 		}
 	}
 	break;

--- a/src/vma/dev/ring_simple.cpp
+++ b/src/vma/dev/ring_simple.cpp
@@ -488,13 +488,14 @@ bool ring_simple::attach_flow(flow_tuple& flow_spec_5t, pkt_rcvr_sink *sink)
 	} else if (flow_spec_5t.is_tcp()) {
 		flow_spec_tcp_key_t key_tcp(flow_spec_5t.get_dst_ip(), flow_spec_5t.get_src_ip(),
 				flow_spec_5t.get_dst_port(), flow_spec_5t.get_src_port());
+		rule_key_t rule_key(flow_spec_5t.get_dst_ip(), flow_spec_5t.get_dst_port());
 		rfs_rule_filter* tcp_dst_port_filter = NULL;
 		if (safe_mce_sys().tcp_3t_rules) {
-			rule_filter_map_t::iterator tcp_dst_port_iter = m_tcp_dst_port_attach_map.find(key_tcp.dst_port);
+			rule_filter_map_t::iterator tcp_dst_port_iter = m_tcp_dst_port_attach_map.find(rule_key.key);
 			if (tcp_dst_port_iter == m_tcp_dst_port_attach_map.end()) {
-				m_tcp_dst_port_attach_map[key_tcp.dst_port].counter = 1;
+				m_tcp_dst_port_attach_map[rule_key.key].counter = 1;
 			} else {
-				m_tcp_dst_port_attach_map[key_tcp.dst_port].counter = ((tcp_dst_port_iter->second.counter) + 1);
+				m_tcp_dst_port_attach_map[rule_key.key].counter = ((tcp_dst_port_iter->second.counter) + 1);
 			}
 		}
 
@@ -503,7 +504,7 @@ bool ring_simple::attach_flow(flow_tuple& flow_spec_5t, pkt_rcvr_sink *sink)
 			m_lock_ring_rx.unlock();
 			if (safe_mce_sys().tcp_3t_rules) {
 				flow_tuple tcp_3t_only(flow_spec_5t.get_dst_ip(), flow_spec_5t.get_dst_port(), 0, 0, flow_spec_5t.get_protocol());
-				tcp_dst_port_filter = new rfs_rule_filter(m_tcp_dst_port_attach_map, key_tcp.dst_port, tcp_3t_only);
+				tcp_dst_port_filter = new rfs_rule_filter(m_tcp_dst_port_attach_map, rule_key.key, tcp_3t_only);
 			}
 			if(safe_mce_sys().gro_streams_max && flow_spec_5t.is_5_tuple()) {
 				// When the gro mechanism is being used, packets must be processed in the rfs
@@ -628,14 +629,15 @@ bool ring_simple::detach_flow(flow_tuple& flow_spec_5t, pkt_rcvr_sink* sink)
 		int keep_in_map = 1;
 		flow_spec_tcp_key_t key_tcp(flow_spec_5t.get_dst_ip(), flow_spec_5t.get_src_ip(),
 				flow_spec_5t.get_dst_port(), flow_spec_5t.get_src_port());
+		rule_key_t rule_key(flow_spec_5t.get_dst_ip(), flow_spec_5t.get_dst_port());
 		if (safe_mce_sys().tcp_3t_rules) {
-			rule_filter_map_t::iterator tcp_dst_port_iter = m_tcp_dst_port_attach_map.find(key_tcp.dst_port);
+			rule_filter_map_t::iterator tcp_dst_port_iter = m_tcp_dst_port_attach_map.find(rule_key.key);
 			BULLSEYE_EXCLUDE_BLOCK_START
 			if (tcp_dst_port_iter == m_tcp_dst_port_attach_map.end()) {
 				ring_logdbg("Could not find matching counter for TCP src port!");
 				BULLSEYE_EXCLUDE_BLOCK_END
 			} else {
-				keep_in_map = m_tcp_dst_port_attach_map[key_tcp.dst_port].counter = MAX(0 , ((tcp_dst_port_iter->second.counter) - 1));
+				keep_in_map = m_tcp_dst_port_attach_map[rule_key.key].counter = MAX(0 , ((tcp_dst_port_iter->second.counter) - 1));
 			}
 		}
 		p_rfs = m_flow_tcp_map.get(key_tcp, NULL);
@@ -648,7 +650,7 @@ bool ring_simple::detach_flow(flow_tuple& flow_spec_5t, pkt_rcvr_sink* sink)
 
 		p_rfs->detach_flow(sink);
 		if(!keep_in_map){
-			m_tcp_dst_port_attach_map.erase(m_tcp_dst_port_attach_map.find(key_tcp.dst_port));
+			m_tcp_dst_port_attach_map.erase(m_tcp_dst_port_attach_map.find(rule_key.key));
 		}
 		if (p_rfs->get_num_of_sinks() == 0) {
 			BULLSEYE_EXCLUDE_BLOCK_START

--- a/src/vma/dev/ring_slave.h
+++ b/src/vma/dev/ring_slave.h
@@ -57,18 +57,20 @@ typedef struct __attribute__((packed)) flow_spec_udp_key_t {
 } flow_spec_udp_key_t;
 
 typedef struct __attribute__((packed)) flow_spec_tcp_key_t {
+  in_addr_t	dst_ip;
   in_addr_t	src_ip;
   in_port_t	dst_port;
   in_port_t	src_port;
 
   flow_spec_tcp_key_t () {
-  	flow_spec_tcp_key_helper (INADDR_ANY, INPORT_ANY, INPORT_ANY);
+  	flow_spec_tcp_key_helper (INADDR_ANY, INADDR_ANY, INPORT_ANY, INPORT_ANY);
   } //Default constructor
-  flow_spec_tcp_key_t (in_addr_t s_ip, in_addr_t d_port, in_addr_t s_port) {
-  	flow_spec_tcp_key_helper (s_ip, d_port, s_port);
+  flow_spec_tcp_key_t (in_addr_t d_ip, in_addr_t s_ip, in_addr_t d_port, in_addr_t s_port) {
+  	flow_spec_tcp_key_helper (d_ip, s_ip, d_port, s_port);
   }//Constructor
-  void flow_spec_tcp_key_helper(in_addr_t s_ip, in_addr_t d_port, in_addr_t s_port) {
+  void flow_spec_tcp_key_helper(in_addr_t d_ip, in_addr_t s_ip, in_addr_t d_port, in_addr_t s_port) {
     memset(this, 0, sizeof(*this));// Silencing coverity
+    dst_ip = d_ip;
     src_ip = s_ip;
     dst_port = d_port;
     src_port = s_port;
@@ -110,7 +112,8 @@ operator==(flow_spec_tcp_key_t const& key1, flow_spec_tcp_key_t const& key2)
 {
 	return	(key1.src_port == key2.src_port) &&
 		(key1.src_ip == key2.src_ip) &&
-		(key1.dst_port == key2.dst_port);
+		(key1.dst_port == key2.dst_port) &&
+		(key1.dst_ip == key2.dst_ip);
 }
 
 #if _BullseyeCoverage
@@ -124,6 +127,8 @@ operator<(flow_spec_tcp_key_t const& key1, flow_spec_tcp_key_t const& key2)
 	if (key1.src_ip > key2.src_ip)		return false;
 	if (key1.dst_port < key2.dst_port)	return true;
 	if (key1.dst_port > key2.dst_port)	return false;
+	if (key1.dst_ip < key2.dst_ip)		return true;
+	if (key1.dst_ip > key2.dst_ip)		return false;
 	if (key1.src_port < key2.src_port)	return true;
 	return false;
 }

--- a/src/vma/dev/ring_slave.h
+++ b/src/vma/dev/ring_slave.h
@@ -144,7 +144,19 @@ struct counter_and_ibv_flows {
 	std::vector<vma_ibv_flow*> ibv_flows;
 };
 
-typedef std::tr1::unordered_map<uint32_t, struct counter_and_ibv_flows> rule_filter_map_t;
+struct rule_key_t {
+	uint64_t key;
+
+	rule_key_t(in_addr_t addr, in_port_t port) {
+		memset(this, 0, sizeof(*this));// Silencing coverity
+
+		uint32_t* p_key = (uint32_t *)&key;
+		p_key[0] = addr;
+		p_key[1] = port;
+	}
+};
+
+typedef std::tr1::unordered_map<uint64_t, struct counter_and_ibv_flows> rule_filter_map_t;
 
 
 class ring_slave : public ring

--- a/src/vma/dev/ring_slave.h
+++ b/src/vma/dev/ring_slave.h
@@ -144,15 +144,12 @@ struct counter_and_ibv_flows {
 	std::vector<vma_ibv_flow*> ibv_flows;
 };
 
+// rule key based on ip and port
 struct rule_key_t {
 	uint64_t key;
 
 	rule_key_t(in_addr_t addr, in_port_t port) {
-		memset(this, 0, sizeof(*this));// Silencing coverity
-
-		uint32_t* p_key = (uint32_t *)&key;
-		p_key[0] = addr;
-		p_key[1] = port;
+		key = (uint64_t) addr << 32 | port;
 	}
 };
 

--- a/src/vma/dev/ring_tap.cpp
+++ b/src/vma/dev/ring_tap.cpp
@@ -261,7 +261,7 @@ bool ring_tap::attach_flow(flow_tuple& flow_spec_5t, pkt_rcvr_sink *sink)
 			}
 		}
 	} else if (flow_spec_5t.is_tcp()) {
-		flow_spec_tcp_key_t key_tcp(flow_spec_5t.get_src_ip(), flow_spec_5t.get_dst_port(), flow_spec_5t.get_src_port());
+		flow_spec_tcp_key_t key_tcp(flow_spec_5t.get_dst_ip(), flow_spec_5t.get_src_ip(), flow_spec_5t.get_dst_port(), flow_spec_5t.get_src_port());
 		rfs_rule_filter* tcp_dst_port_filter = NULL;
 		if (safe_mce_sys().tcp_3t_rules) {
 			rule_filter_map_t::iterator tcp_dst_port_iter = m_tcp_dst_port_attach_map.find(key_tcp.dst_port);
@@ -425,7 +425,7 @@ bool ring_tap::detach_flow(flow_tuple& flow_spec_5t, pkt_rcvr_sink* sink)
 		}
 	} else if (flow_spec_5t.is_tcp()) {
 		int keep_in_map = 1;
-		flow_spec_tcp_key_t key_tcp(flow_spec_5t.get_src_ip(), flow_spec_5t.get_dst_port(), flow_spec_5t.get_src_port());
+		flow_spec_tcp_key_t key_tcp(flow_spec_5t.get_dst_ip(), flow_spec_5t.get_src_ip(), flow_spec_5t.get_dst_port(), flow_spec_5t.get_src_port());
 		if (safe_mce_sys().tcp_3t_rules) {
 			rule_filter_map_t::iterator tcp_dst_port_iter = m_tcp_dst_port_attach_map.find(key_tcp.dst_port);
 			BULLSEYE_EXCLUDE_BLOCK_START
@@ -916,13 +916,14 @@ bool ring_tap::rx_process_buffer(mem_buf_desc_t* p_rx_wc_buf_desc, void* pv_fd_r
 		p_rx_wc_buf_desc->rx.tcp.p_tcp_h = p_tcp_h;
 
 		// Find the relevant hash map and pass the packet to the rfs for dispatching
-		p_rfs = m_flow_tcp_map.get(flow_spec_tcp_key_t(p_rx_wc_buf_desc->rx.src.sin_addr.s_addr,
-			p_rx_wc_buf_desc->rx.dst.sin_port, p_rx_wc_buf_desc->rx.src.sin_port), NULL);
+		p_rfs = m_flow_tcp_map.get(flow_spec_tcp_key_t(p_rx_wc_buf_desc->rx.dst.sin_addr.s_addr,
+				p_rx_wc_buf_desc->rx.src.sin_addr.s_addr, p_rx_wc_buf_desc->rx.dst.sin_port,
+				p_rx_wc_buf_desc->rx.src.sin_port), NULL);
 
 		p_rx_wc_buf_desc->rx.tcp.n_transport_header_len = transport_header_len;
 
 		if (unlikely(p_rfs == NULL)) {	// If we didn't find a match for TCP 5T, look for a match with TCP 3T
-			p_rfs = m_flow_tcp_map.get(flow_spec_tcp_key_t(0, p_rx_wc_buf_desc->rx.dst.sin_port, 0), NULL);
+			p_rfs = m_flow_tcp_map.get(flow_spec_tcp_key_t(p_rx_wc_buf_desc->rx.dst.sin_addr.s_addr, 0, p_rx_wc_buf_desc->rx.dst.sin_port, 0), NULL);
 		}
 	}
 	break;


### PR DESCRIPTION
As for UDP, from this release, ring can be share between several IPs.
hence, tcp-flow-map should be based also on dst_ip.

Signed-off-by: Liran Oz <lirano@mellanox.com>