### PR TITLE
issue: 1403118 Fix incorrect release memory of TX buffers

### DIFF
--- a/src/vma/dev/ring.h
+++ b/src/vma/dev/ring.h
@@ -107,6 +107,7 @@ public:
 	virtual int		wait_for_notification_and_process_element(int cq_channel_fd, uint64_t* p_cq_poll_sn, void* pv_fd_ready_array = NULL) = 0;
 	virtual int		poll_and_process_element_rx(uint64_t* p_cq_poll_sn, void* pv_fd_ready_array = NULL) = 0;
 	virtual void		adapt_cq_moderation() = 0;
+	virtual void		mem_buf_desc_return_single_to_owner_tx(mem_buf_desc_t* p_mem_buf_desc) = 0;
 
 	virtual void		inc_tx_retransmissions(ring_user_id_t id) = 0;
 	virtual bool		is_member(mem_buf_desc_owner* rng) = 0;

--- a/src/vma/dev/ring_bond.cpp
+++ b/src/vma/dev/ring_bond.cpp
@@ -366,6 +366,11 @@ int ring_bond::mem_buf_tx_release(mem_buf_desc_t* p_mem_buf_desc_list, bool b_ac
 	return ret;
 }
 
+void ring_bond::mem_buf_desc_return_single_to_owner_tx(mem_buf_desc_t* p_mem_buf_desc)
+{
+	((ring_slave*)p_mem_buf_desc->p_desc_owner)->mem_buf_desc_return_single_to_owner_tx(p_mem_buf_desc);
+}
+
 void ring_bond::send_ring_buffer(ring_user_id_t id, vma_ibv_send_wr* p_send_wqe, vma_wr_tx_packet_attr attr)
 {
 	mem_buf_desc_t* p_mem_buf_desc = (mem_buf_desc_t*)(p_send_wqe->wr_id);

--- a/src/vma/dev/ring_bond.h
+++ b/src/vma/dev/ring_bond.h
@@ -76,6 +76,7 @@ public:
 	virtual void		inc_tx_retransmissions(ring_user_id_t id);
 	virtual void		send_ring_buffer(ring_user_id_t id, vma_ibv_send_wr* p_send_wqe, vma_wr_tx_packet_attr attr);
 	virtual void		send_lwip_buffer(ring_user_id_t id, vma_ibv_send_wr* p_send_wqe, vma_wr_tx_packet_attr attr);
+	virtual void		mem_buf_desc_return_single_to_owner_tx(mem_buf_desc_t* p_mem_buf_desc);
 	virtual bool		is_member(mem_buf_desc_owner* rng);
 	virtual bool		is_active_member(mem_buf_desc_owner* rng, ring_user_id_t id);
 	virtual ring_user_id_t	generate_id(const address_t src_mac, const address_t dst_mac, uint16_t eth_proto, uint16_t encap_proto, uint32_t src_ip, uint32_t dst_ip, uint16_t src_port, uint16_t dst_port);

--- a/src/vma/dev/ring_simple.h
+++ b/src/vma/dev/ring_simple.h
@@ -93,6 +93,7 @@ public:
 	virtual int		mem_buf_tx_release(mem_buf_desc_t* p_mem_buf_desc_list, bool b_accounting, bool trylock = false);
 	virtual void		send_ring_buffer(ring_user_id_t id, vma_ibv_send_wr* p_send_wqe, vma_wr_tx_packet_attr attr);
 	virtual void		send_lwip_buffer(ring_user_id_t id, vma_ibv_send_wr* p_send_wqe, vma_wr_tx_packet_attr attr);
+	virtual void		mem_buf_desc_return_single_to_owner_tx(mem_buf_desc_t* p_mem_buf_desc);
 	virtual bool 		get_hw_dummy_send_support(ring_user_id_t id, vma_ibv_send_wr* p_send_wqe);
 	inline void 		convert_hw_time_to_system_time(uint64_t hwtime, struct timespec* systime) { m_p_ib_ctx->convert_hw_time_to_system_time(hwtime, systime); }
 	inline uint32_t		get_qpn() const { return (m_p_l2_addr ? ((IPoIB_addr *)m_p_l2_addr)->get_qpn() : 0); }
@@ -136,6 +137,8 @@ private:
 	inline void		send_status_handler(int ret, vma_ibv_send_wr* p_send_wqe);
 	inline mem_buf_desc_t*	get_tx_buffers(uint32_t n_num_mem_bufs);
 	inline int		put_tx_buffers(mem_buf_desc_t* buff_list);
+	inline int		put_tx_single_buffer(mem_buf_desc_t* buff);
+	inline void		return_to_global_pool();
 	bool			is_available_qp_wr(bool b_block);
 	void			modify_cq_moderation(uint32_t period, uint32_t count);
 	void			save_l2_address(const L2_address* p_l2_addr) { delete_l2_address(); m_p_l2_addr = p_l2_addr->clone(); };

--- a/src/vma/dev/ring_tap.cpp
+++ b/src/vma/dev/ring_tap.cpp
@@ -1111,6 +1111,38 @@ mem_buf_desc_t* ring_tap::mem_buf_tx_get(ring_user_id_t id, bool b_block, int n_
 	return head;
 }
 
+inline void ring_tap::return_to_global_pool()
+{
+	if (m_tx_pool.size() >= m_sysvar_qp_compensation_level * 2) {
+		int return_bufs = m_tx_pool.size() - m_sysvar_qp_compensation_level;
+		g_buffer_pool_tx->put_buffers_thread_safe(&m_tx_pool, return_bufs);
+	}
+}
+
+void ring_tap::mem_buf_desc_return_single_to_owner_tx(mem_buf_desc_t* p_mem_buf_desc)
+{
+	auto_unlocker lock(m_lock_ring_tx);
+
+	int count = 0;
+
+	if (likely(p_mem_buf_desc)) {
+		//potential race, ref is protected here by ring_tx lock, and in dst_entry_tcp & sockinfo_tcp by tcp lock
+		if (likely(p_mem_buf_desc->lwip_pbuf.pbuf.ref))
+			p_mem_buf_desc->lwip_pbuf.pbuf.ref--;
+		else
+			ring_logerr("ref count of %p is already zero, double free??", p_mem_buf_desc);
+
+		if (p_mem_buf_desc->lwip_pbuf.pbuf.ref == 0) {
+			p_mem_buf_desc->p_next_desc = NULL;
+			free_lwip_pbuf(&p_mem_buf_desc->lwip_pbuf);
+			m_tx_pool.push_back(p_mem_buf_desc);
+			count++;
+		}
+	}
+
+	return_to_global_pool();
+}
+
 int ring_tap::mem_buf_tx_release(mem_buf_desc_t* buff_list, bool b_accounting, bool trylock)
 {
 	int count = 0, freed=0;
@@ -1145,11 +1177,7 @@ int ring_tap::mem_buf_tx_release(mem_buf_desc_t* buff_list, bool b_accounting, b
 	}
 	ring_logfunc("buf_list: %p count: %d freed: %d\n", buff_list, count, freed);
 
-	if (m_tx_pool.size() >= m_sysvar_qp_compensation_level * 2) {
-		int buff_to_rel = m_tx_pool.size() - m_sysvar_qp_compensation_level;
-
-		g_buffer_pool_tx->put_buffers_thread_safe(&m_tx_pool, buff_to_rel);
-	}
+	return_to_global_pool();
 
 	m_lock_ring_tx.unlock();
 

--- a/src/vma/dev/ring_tap.h
+++ b/src/vma/dev/ring_tap.h
@@ -59,6 +59,7 @@ public:
 
 	virtual void send_ring_buffer(ring_user_id_t id, vma_ibv_send_wr* p_send_wqe, vma_wr_tx_packet_attr attr);
 	virtual void send_lwip_buffer(ring_user_id_t id, vma_ibv_send_wr* p_send_wqe, vma_wr_tx_packet_attr attr);
+	virtual void mem_buf_desc_return_single_to_owner_tx(mem_buf_desc_t* p_mem_buf_desc);
 	virtual mem_buf_desc_t* mem_buf_tx_get(ring_user_id_t id, bool b_block, int n_num_mem_bufs = 1);
 	virtual int mem_buf_tx_release(mem_buf_desc_t* p_mem_buf_desc_list, bool b_accounting, bool trylock = false);
 
@@ -114,6 +115,7 @@ public:
 protected:
 
 private:
+	inline void return_to_global_pool();
 	void prepare_flow_message(vma_msg_flow& data,
 			flow_tuple& flow_spec_5t, msg_flow_t flow_action);
 	int process_element_rx(void* pv_fd_ready_array);

--- a/src/vma/proto/dst_entry_tcp.cpp
+++ b/src/vma/proto/dst_entry_tcp.cpp
@@ -275,7 +275,7 @@ void dst_entry_tcp::put_buffer(mem_buf_desc_t * p_desc)
 		return;
 
 	if (likely(m_p_ring->is_member(p_desc->p_desc_owner))) {
-		p_desc->p_desc_owner->mem_buf_desc_return_to_owner_tx(p_desc);
+		m_p_ring->mem_buf_desc_return_single_to_owner_tx(p_desc);
 	} else {
 
 		//potential race, ref is protected here by tcp lock, and in ring by ring_tx lock


### PR DESCRIPTION
dst_entry_tcp::get_buffer should release only the first buffer - even
if the next elment exists.
This commit partially reverts "issue: 1331577 Remove dead
code from_ring simple".

Signed-off-by: Liran Oz <lirano@mellanox.com>