### PR TITLE
issue: 1405041 Improve hypervisor type detection

### DIFF
--- a/src/vma/dev/allocator.cpp
+++ b/src/vma/dev/allocator.cpp
@@ -82,8 +82,7 @@ void* vma_allocator::alloc_and_reg_mr(size_t size, ib_ctx_handler *p_ib_ctx_h)
 		}
 		else {
 			__log_info_dbg("Huge pages allocation passed successfully");
-			if (g_p_ib_ctx_handler_collection->get_ib_cxt_list() &&
-					!register_memory(size, p_ib_ctx_h, access)) {
+			if (!register_memory(size, p_ib_ctx_h, access)) {
 				__log_info_dbg("failed registering huge pages data memory block");
 				throw_vma_exception("failed registering huge pages data memory"
 						" block");
@@ -94,7 +93,7 @@ void* vma_allocator::alloc_and_reg_mr(size_t size, ib_ctx_handler *p_ib_ctx_h)
 	// fallthrough
 	case ALLOC_TYPE_CONTIG:
 #ifdef VMA_IBV_ACCESS_ALLOCATE_MR
-		if (!safe_mce_sys().is_hypervisor && g_p_ib_ctx_handler_collection->get_ib_cxt_list()) {
+		if (mce_sys_var::HYPER_MSHV != safe_mce_sys().hypervisor) {
 			if (!register_memory(size, p_ib_ctx_h, (access | VMA_IBV_ACCESS_ALLOCATE_MR))) {
 				__log_info_dbg("Failed allocating contiguous pages");
 			}
@@ -117,8 +116,7 @@ void* vma_allocator::alloc_and_reg_mr(size_t size, ib_ctx_handler *p_ib_ctx_h)
 			throw_vma_exception("failed allocating data memory block");
 		}
 		BULLSEYE_EXCLUDE_BLOCK_END
-		if (g_p_ib_ctx_handler_collection->get_ib_cxt_list() &&
-				!register_memory(size, p_ib_ctx_h, access)) {
+		if (!register_memory(size, p_ib_ctx_h, access)) {
 			__log_info_dbg("failed registering data memory block");
 			throw_vma_exception("failed registering data memory block");
 		}

--- a/src/vma/dev/ring_simple.cpp
+++ b/src/vma/dev/ring_simple.cpp
@@ -139,7 +139,7 @@ ring_simple::ring_simple(int if_index, ring* parent /*=NULL*/):
 	m_lock_ring_rx("ring_simple:lock_rx"),
 	m_p_cq_mgr_tx(NULL),
 	m_lock_ring_tx("ring_simple:lock_tx"),
-	m_b_is_hypervisor(safe_mce_sys().is_hypervisor),
+	m_b_is_hypervisor(safe_mce_sys().hypervisor),
 	m_lock_ring_tx_buf_wait("ring:lock_tx_buf_wait"), m_tx_num_bufs(0), m_tx_num_wr(0), m_tx_num_wr_free(0),
 	m_b_qp_tx_first_flushed_completion_handled(false), m_missing_buf_ref_count(0),
 	m_tx_lkey(0),

--- a/src/vma/sock/sockinfo_udp.cpp
+++ b/src/vma/sock/sockinfo_udp.cpp
@@ -409,6 +409,8 @@ sockinfo_udp::sockinfo_udp(int fd):
 {
 	si_udp_logfunc("");
 
+	m_use_hyperv = (mce_sys_var::HYPER_MSHV == safe_mce_sys().hypervisor);
+
 	m_protocol = PROTO_UDP;
 	m_p_socket_stats->socket_type = SOCK_DGRAM;
 	m_p_socket_stats->b_is_offloaded = m_sock_offload;
@@ -1893,7 +1895,8 @@ ssize_t sockinfo_udp::tx(const tx_call_t call_type, const iovec* p_iov, const ss
 			 * The first packet is lost as far as slow_send() includes
 			 * ring creation and send operations
 			 */
-			if (safe_mce_sys().is_hypervisor && p_dst_entry->get_ring()) {
+			if (m_use_hyperv &&
+					p_dst_entry->get_ring()) {
 				ring_bond_netvsc* p_ring = dynamic_cast<ring_bond_netvsc*>(p_dst_entry->get_ring());
 				if (p_ring && !p_ring->is_vf_mode()) {
 					goto tx_packet_to_os;
@@ -1908,7 +1911,8 @@ ssize_t sockinfo_udp::tx(const tx_call_t call_type, const iovec* p_iov, const ss
 			/* See comment
 			 * above related socket operation under NETVSC ring w/o SRIOV/VF
 			 */
-			if (safe_mce_sys().is_hypervisor && p_dst_entry->get_ring()) {
+			if (m_use_hyperv &&
+					p_dst_entry->get_ring()) {
 				ring_bond_netvsc* p_ring = dynamic_cast<ring_bond_netvsc*>(p_dst_entry->get_ring());
 				if (p_ring && !p_ring->is_vf_mode()) {
 					goto tx_packet_to_os;

--- a/src/vma/sock/sockinfo_udp.h
+++ b/src/vma/sock/sockinfo_udp.h
@@ -246,6 +246,7 @@ private:
 	bool		m_sockopt_mapped; // setsockopt IPPROTO_UDP UDP_MAP_ADD
 	bool		m_is_connected; // to inspect for in_addr.src
 	bool		m_multicast; // true when socket set MC rule
+	bool		m_use_hyperv; // set in true for Hyper-V
 
 	int mc_change_membership(const mc_pending_pram *p_mc_pram);
 	int mc_change_membership_start_helper(in_addr_t mc_grp, int optname);

--- a/src/vma/util/agent.cpp
+++ b/src/vma/util/agent.cpp
@@ -64,13 +64,15 @@
 	} while (0)
 
 /* Print user notification */
-#define output_warn() \
-	vlog_printf(VLOG_DEBUG, "Peer notification functionality is not active.\n"); \
-	vlog_printf(VLOG_DEBUG, "Check daemon state\n");
-
 #define output_fatal() \
-	vlog_printf(VLOG_DEBUG, "Peer notification functionality is not supported.\n"); \
-	vlog_printf(VLOG_DEBUG, "Increase output level to see a reason\n");
+	do { \
+		vlog_levels_t _level = (mce_sys_var::HYPER_MSHV == safe_mce_sys().hypervisor ?          \
+						VLOG_WARNING : VLOG_DEBUG);                                             \
+		vlog_printf(_level, "*************************************************************\n"); \
+		vlog_printf(_level, "* Can not establish connection with the daemon (vmad).      *\n"); \
+		vlog_printf(_level, "* TCP connections are likely to be limited.                 *\n"); \
+		vlog_printf(_level, "*************************************************************\n"); \
+	} while (0)
 
 agent* g_p_agent = NULL;
 
@@ -147,10 +149,7 @@ agent::agent() :
 	rc = send_msg_init();
 	if (rc < 0) {
 		__log_dbg("failed establish connection with daemon (rc = %d)\n", rc);
-		output_warn();
-		if (rc != -ECONNREFUSED) {
-			goto err;
-		}
+		goto err;
 	}
 
 	/* coverity[leaked_storage] */

--- a/src/vma/util/sys_vars.h
+++ b/src/vma/util/sys_vars.h
@@ -283,6 +283,16 @@ struct mce_sys_var {
 		return the_instance;
 	}
 
+public:
+	enum hyper_t {
+		HYPER_NONE	= 0,
+		HYPER_XEN,
+		HYPER_KVM,
+		HYPER_MSHV,
+		HYPER_VMWARE
+	};
+
+public:
 	void		get_env_params();
 
 	char 		*app_name;
@@ -404,10 +414,8 @@ struct mce_sys_var {
 	char 		vma_time_measure_filename[PATH_MAX];
 	sysctl_reader_t & sysctl_reader;
 	bool		rx_poll_on_tx_tcp;
-	bool		is_hypervisor;
+	hyper_t		hypervisor;
 	bool		trigger_dummy_send_getsockname;
-
-	bool cpuid_hv();
 
 private:
 	void print_vma_load_failure_msg();
@@ -416,7 +424,9 @@ private:
 	int env_to_cpuset(char *orig_start, cpu_set_t *cpu_set);
 	void read_env_variable_with_pid(char* mce_sys_name, size_t mce_sys_max_size, char* env_ptr);
 	bool check_cpuinfo_flag(const char* flag);
+	bool cpuid_hv();
 	const char* cpuid_hv_vendor();
+	void read_hv();
 
 	// prevent unautothrized creation of objects
 	mce_sys_var () : sysctl_reader(sysctl_reader_t::instance()){


### PR DESCRIPTION
New changes allow to differentiate types of VMs and provide
specific code for them. Current code support just limited
number of VMs and x86_64 architecture.

Signed-off-by: Igor Ivanov <igor.ivanov.va@gmail.com>