### PR TITLE
issue: 1413587 Modify warning while log_num_mgm_entry_size != -1

### DIFF
--- a/src/vma/main.cpp
+++ b/src/vma/main.cpp
@@ -319,8 +319,7 @@ void check_flow_steering_log_num_mgm_entry_size()
 		vlog_printf(VLOG_WARNING, "* the following:                                                                      *\n");
 		vlog_printf(VLOG_WARNING, "* For your information the following steps will restart your network interface        *\n");
 		vlog_printf(VLOG_WARNING, "* 1. \"echo options mlx4_core log_num_mgm_entry_size=-1 > /etc/modprobe.d/mlnx.conf\" *\n");
-		vlog_printf(VLOG_WARNING, "* 2. \"modprobe -r mlx4_ib mlx4_en mlx4_core\"                                        *\n");
-		vlog_printf(VLOG_WARNING, "* 5. \"modprobe mlx4_core\"                                                           *\n");
+		vlog_printf(VLOG_WARNING, "* 2. \"/etc/init.d/openibd restart\"                                                  *\n");
 		vlog_printf(VLOG_WARNING, "* Read more about the Flow Steering support in the VMA's User Manual                  *\n");
 		vlog_printf(VLOG_WARNING, "***************************************************************************************\n");
 	}


### PR DESCRIPTION
Restart mlx4_core modules should be done using "openibd restart"
and not using modprobe.

Signed-off-by: Liran Oz <lirano@mellanox.com>