### PR TITLE
issue: 1403304 Fix duplicate UDP Tx packets w/o SRIOV

### DIFF
--- a/src/vma/proto/dst_entry_udp.cpp
+++ b/src/vma/proto/dst_entry_udp.cpp
@@ -326,12 +326,13 @@ ssize_t dst_entry_udp::slow_send(const iovec* p_iov, size_t sz_iov, bool is_dumm
 				 socket_fd_api* sock /*= 0*/, tx_call_t call_type /*= 0*/)
 {
 	NOT_IN_USE(is_rexmit);
+	NOT_IN_USE(rate_limit);
 
 	ssize_t ret_val = 0;
 
 	dst_udp_logdbg("In slow send");
 
-	prepare_to_send(rate_limit, false);
+	// prepare_to_send(rate_limit, false);
 
 	if (m_b_force_os || !m_b_is_offloaded) {
 		struct sockaddr_in to_saddr;

--- a/src/vma/sock/sockinfo_udp.cpp
+++ b/src/vma/sock/sockinfo_udp.cpp
@@ -1906,8 +1906,9 @@ ssize_t sockinfo_udp::tx(const tx_call_t call_type, const iovec* p_iov, const ss
 			ret = p_dst_entry->fast_send((iovec*)p_iov, sz_iov, is_dummy, b_blocking);
 		}
 		else {
-			// updates the dst_entry internal information and packet headers
-			ret = p_dst_entry->slow_send(p_iov, sz_iov, is_dummy, m_so_ratelimit, b_blocking, false, __flags, this, call_type);
+			// for resolve ring
+			p_dst_entry->prepare_to_send(m_so_ratelimit, false);
+
 			/* See comment
 			 * above related socket operation under NETVSC ring w/o SRIOV/VF
 			 */
@@ -1918,6 +1919,9 @@ ssize_t sockinfo_udp::tx(const tx_call_t call_type, const iovec* p_iov, const ss
 					goto tx_packet_to_os;
 				}
 			}
+
+			// updates the dst_entry internal information and packet headers
+			ret = p_dst_entry->slow_send(p_iov, sz_iov, is_dummy, m_so_ratelimit, b_blocking, false, __flags, this, call_type);
 		}
 
 		if (unlikely(p_dst_entry->try_migrate_ring(m_lock_snd))) {


### PR DESCRIPTION
This commit fix incorrect logic which might causes VMA to
send the first packet of each UDP flow twice.

Signed-off-by: Liran Oz <lirano@mellanox.com>