### PR TITLE
issue: 1416963 Improve device removing in plugout case

### DIFF
--- a/src/vma/dev/ib_ctx_handler.cpp
+++ b/src/vma/dev/ib_ctx_handler.cpp
@@ -170,6 +170,7 @@ err:
 ib_ctx_handler::~ib_ctx_handler()
 {
 	g_p_event_handler_manager->unregister_ibverbs_event(m_p_ibv_context->async_fd, this);
+
 	// must delete ib_ctx_handler only after freeing all resources that
 	// are still associated with the PD m_p_ibv_pd
 	BULLSEYE_EXCLUDE_BLOCK_START
@@ -332,7 +333,6 @@ void ib_ctx_handler::handle_event_ibverbs_cb(void *ev_data, void *ctx)
 void ib_ctx_handler::handle_event_device_fatal()
 {
 	m_removed = true;
-	g_p_event_handler_manager->unregister_ibverbs_event(m_p_ibv_context->async_fd, this);
 }
 
 bool ib_ctx_handler::post_umr_wr(struct ibv_exp_send_wr &wr)


### PR DESCRIPTION
There is unpredicatble duration between getting RTM_NEWLINK event
from netlink (about interface removing) and IBV_EVENT_DEVICE_FATAL
event from ib kernel. After getting IBV_EVENT_DEVICE_FATAL usual
logic can meet issue with calling ibv functions and different
incorrect flows can start.

Signed-off-by: Igor Ivanov <igor.ivanov.va@gmail.com>