### PR TITLE
issue: 1423819 Enable Blue Flame send for NetVSC interface

### DIFF
--- a/src/vma/dev/ring_bond.cpp
+++ b/src/vma/dev/ring_bond.cpp
@@ -581,6 +581,15 @@ bool ring_bond::reclaim_recv_buffers(descq_t *rx_reuse)
 	return true;
 }
 
+void ring_bond::update_max_tx_inline(ring_slave *slave)
+{
+	if (m_min_devices_tx_inline < 0) {
+		m_min_devices_tx_inline = slave->get_max_tx_inline();
+	} else {
+		m_min_devices_tx_inline = min(m_min_devices_tx_inline, slave->get_max_tx_inline());
+	}
+}
+
 void ring_bond::devide_buffers_helper(descq_t *rx_reuse, descq_t* buffer_per_ring)
 {
 	int last_found_index = 0;
@@ -816,11 +825,7 @@ void ring_bond_eth::slave_create(int if_index)
 	ring_slave *cur_slave = NULL;
 
 	cur_slave = new ring_eth(if_index, this);
-	if (m_min_devices_tx_inline < 0) {
-		m_min_devices_tx_inline = cur_slave->get_max_tx_inline();
-	} else {
-		m_min_devices_tx_inline = min(m_min_devices_tx_inline, cur_slave->get_max_tx_inline());
-	}
+	update_max_tx_inline(cur_slave);
 	m_bond_rings.push_back(cur_slave);
 
 	if (m_bond_rings.size() > MAX_NUM_RING_RESOURCES) {
@@ -836,11 +841,7 @@ void ring_bond_ib::slave_create(int if_index)
 	ring_slave *cur_slave = NULL;
 
 	cur_slave = new ring_ib(if_index, this);
-	if (m_min_devices_tx_inline < 0) {
-		m_min_devices_tx_inline = cur_slave->get_max_tx_inline();
-	} else {
-		m_min_devices_tx_inline = min(m_min_devices_tx_inline, cur_slave->get_max_tx_inline());
-	}
+	update_max_tx_inline(cur_slave);
 	m_bond_rings.push_back(cur_slave);
 
 	if (m_bond_rings.size() > MAX_NUM_RING_RESOURCES) {
@@ -867,12 +868,9 @@ void ring_bond_netvsc::slave_create(int if_index)
 	} else {
 		cur_slave = new ring_eth(if_index, this);
 		m_vf_ring = cur_slave;
+		update_max_tx_inline(cur_slave);
 	}
-	if (m_min_devices_tx_inline < 0) {
-		m_min_devices_tx_inline = cur_slave->get_max_tx_inline();
-	} else {
-		m_min_devices_tx_inline = min(m_min_devices_tx_inline, cur_slave->get_max_tx_inline());
-	}
+
 	m_bond_rings.push_back(cur_slave);
 
 	if (m_bond_rings.size() > 2) {

--- a/src/vma/dev/ring_bond.h
+++ b/src/vma/dev/ring_bond.h
@@ -88,6 +88,7 @@ public:
 	virtual void    slave_create(int if_index) = 0;
 	virtual void    slave_destroy(int if_index);
 protected:
+	void			update_max_tx_inline(ring_slave *slave);
 	void			update_rx_channel_fds();
 	void			popup_active_rings();
 	ring_slave_vector_t     m_bond_rings;


### PR DESCRIPTION
Max inline size should be based only on SRIOV rings.

Signed-off-by: Liran Oz <lirano@mellanox.com>