### PR TITLE
issue: 1178926 Remove VMA_RX_SW_CSUM control

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -136,7 +136,6 @@ Example:
  VMA DETAILS: Rx Poll Init Loops             0                          [VMA_RX_POLL_INIT]
  VMA DETAILS: Rx UDP Poll OS Ratio           100                        [VMA_RX_UDP_POLL_OS_RATIO]
  VMA DETAILS: HW TS Conversion               3                          [VMA_HW_TS_CONVERSION]
- VMA DETAILS: Rx SW CSUM                     1                          [VMA_RX_SW_CSUM]
  VMA DETAILS: Rx Poll Yield                  Disabled                   [VMA_RX_POLL_YIELD]
  VMA DETAILS: Rx Prefetch Bytes              256                        [VMA_RX_PREFETCH_BYTES]
  VMA DETAILS: Rx Prefetch Bytes Before Poll  0                          [VMA_RX_PREFETCH_BYTES_BEFORE_POLL]
@@ -755,23 +754,6 @@ Valid Values are:
 Use value of 0 to disable.
 Use value of 1 for enable.
 Default value is Disabled.
-
-VMA_RX_SW_CSUM
-This parameter enables/disables software checksum validation for ingress TCP/UDP IP packets.
-Most Mellanox HCAs support hardware offload checksum validation. If the hardware does not
-support checksum validation offload, software checksum validation is required.
-When this parameter is enabled, software checksum validation is calculated only if hardware
-offload checksum validation is not performed.
-Performance degradation might occur if hardware offload fails to validate checksum and
-software calculation is used.
-Note that disabling software calculation might cause corrupt packets to be
-processed by VMA and the application, when the hardware does not perform this action.
-For further details on which adapter card supports hardware offload checksum validation,
-please refer to the VMA Release Notes.
-Valid Values are:
-Use value of 0 to disable.
-Use value of 1 for enable.
-Default value is Enabled.
 
 VMA_EXCEPTION_HANDLING
 Mode for handling missing support or error cases in Socket API or functionality by VMA.

--- a/README.txt
+++ b/README.txt
@@ -1,4 +1,4 @@
-Update: 20 Jun 2018
+Update: 21 Jun 2018
 
 Introduction
 ============

--- a/src/vma/dev/cq_mgr.h
+++ b/src/vma/dev/cq_mgr.h
@@ -260,7 +260,6 @@ protected:
 	ib_ctx_handler*		m_p_ib_ctx_handler;
 private:
 	const uint32_t		m_n_sysvar_rx_num_wr_to_post_recv;
-	const bool		m_b_sysvar_is_rx_sw_csum_on;
 	struct ibv_comp_channel *m_comp_event_channel;
 	bool			m_b_notification_armed;
 	const uint32_t		m_n_sysvar_qp_compensation_level;

--- a/src/vma/main.cpp
+++ b/src/vma/main.cpp
@@ -503,7 +503,7 @@ void print_vma_global_settings()
 	}
 
 	VLOG_PARAM_NUMBER("HW TS Conversion", safe_mce_sys().hw_ts_conversion_mode, MCE_DEFAULT_HW_TS_CONVERSION_MODE, SYS_VAR_HW_TS_CONVERSION_MODE);
-	VLOG_PARAM_NUMBER("Rx SW CSUM", safe_mce_sys().rx_sw_csum, MCE_DEFUALT_RX_SW_CSUM, SYS_VAR_RX_SW_CSUM);
+
 	if (safe_mce_sys().rx_poll_yield_loops) {
 		VLOG_PARAM_NUMBER("Rx Poll Yield", safe_mce_sys().rx_poll_yield_loops, MCE_DEFAULT_RX_POLL_YIELD, SYS_VAR_RX_POLL_YIELD);
 	}

--- a/src/vma/util/sys_vars.cpp
+++ b/src/vma/util/sys_vars.cpp
@@ -548,7 +548,6 @@ void mce_sys_var::get_env_params()
 	rx_poll_num_init        = MCE_DEFAULT_RX_NUM_POLLS_INIT;
 	rx_udp_poll_os_ratio    = MCE_DEFAULT_RX_UDP_POLL_OS_RATIO;
 	hw_ts_conversion_mode   = MCE_DEFAULT_HW_TS_CONVERSION_MODE;
-	rx_sw_csum         	= MCE_DEFUALT_RX_SW_CSUM;
 	rx_poll_yield_loops     = MCE_DEFAULT_RX_POLL_YIELD;
 	select_handle_cpu_usage_stats   = MCE_DEFAULT_SELECT_CPU_USAGE_STATS;
 	rx_ready_byte_min_limit = MCE_DEFAULT_RX_BYTE_MIN_LIMIT;
@@ -916,10 +915,6 @@ void mce_sys_var::get_env_params()
 			vlog_printf(VLOG_WARNING,"HW TS conversion size out of range [%d] (min=%d, max=%d). using default [%d]\n", hw_ts_conversion_mode, TS_CONVERSION_MODE_DISABLE , TS_CONVERSION_MODE_LAST - 1, MCE_DEFAULT_HW_TS_CONVERSION_MODE);
 			hw_ts_conversion_mode = MCE_DEFAULT_HW_TS_CONVERSION_MODE;
 		}
-	}
-
-	if ((env_ptr = getenv(SYS_VAR_RX_SW_CSUM)) != NULL) {
-		rx_sw_csum = atoi(env_ptr) ? true : false;
 	}
 
 	//The following 2 params were replaced by SYS_VAR_RX_UDP_POLL_OS_RATIO

--- a/src/vma/util/sys_vars.h
+++ b/src/vma/util/sys_vars.h
@@ -341,7 +341,6 @@ public:
 	int32_t		rx_poll_num_init;
 	uint32_t 	rx_udp_poll_os_ratio;
 	ts_conversion_mode_t	hw_ts_conversion_mode;
-	bool 		rx_sw_csum;
 	uint32_t 	rx_poll_yield_loops;
 	uint32_t 	rx_ready_byte_min_limit;
 	uint32_t 	rx_prefetch_bytes;
@@ -477,7 +476,6 @@ extern mce_sys_var & safe_mce_sys();
 #define SYS_VAR_RX_NUM_POLLS				"VMA_RX_POLL"
 #define SYS_VAR_RX_NUM_POLLS_INIT			"VMA_RX_POLL_INIT"
 #define SYS_VAR_RX_UDP_POLL_OS_RATIO			"VMA_RX_UDP_POLL_OS_RATIO"
-#define SYS_VAR_RX_SW_CSUM				"VMA_RX_SW_CSUM"
 #define SYS_VAR_HW_TS_CONVERSION_MODE			"VMA_HW_TS_CONVERSION"
 // The following 2 params were replaced by VMA_RX_UDP_POLL_OS_RATIO
 #define SYS_VAR_RX_POLL_OS_RATIO			"VMA_RX_POLL_OS_RATIO"
@@ -598,7 +596,6 @@ extern mce_sys_var & safe_mce_sys();
 #define MCE_DEFAULT_RX_NUM_POLLS_INIT			(0)
 #define MCE_DEFAULT_RX_UDP_POLL_OS_RATIO		(100)
 #define MCE_DEFAULT_HW_TS_CONVERSION_MODE		(TS_CONVERSION_MODE_SYNC)
-#define MCE_DEFUALT_RX_SW_CSUM				(true)
 #define MCE_DEFAULT_RX_POLL_YIELD			(0)
 #define MCE_DEFAULT_RX_BYTE_MIN_LIMIT			(65536)
 #define MCE_DEFAULT_RX_PREFETCH_BYTES			(256)


### PR DESCRIPTION
    Managing software checksum validation for ingress TCP/UDP IP packets
    is helpless as far as VMA is able to fallback to SW check if HW possibility
    is not detected. In addition SW check does performance degradation.


