### PR TITLE
issue: 1284069 Set MLX5_DEVICE_FATAL_CLEANUP env for mlx5 device

### DIFF
--- a/src/vma/util/sys_vars.cpp
+++ b/src/vma/util/sys_vars.cpp
@@ -1250,12 +1250,14 @@ void set_env_params()
 	//setenv("MLX4_SINGLE_THREADED", "1", 0);
 
 	/*
-	 * MLX4_DEVICE_FATAL_CLEANUP tells ibv_destroy functions we
+	 * MLX4_DEVICE_FATAL_CLEANUP/MLX5_DEVICE_FATAL_CLEANUP tells
+	 * ibv_destroy functions we
 	 * want to get success errno value in case of calling them
 	 * when the device was removed.
 	 * It helps to destroy resources in DEVICE_FATAL state
 	 */
 	setenv("MLX4_DEVICE_FATAL_CLEANUP", "1", 1);
+	setenv("MLX5_DEVICE_FATAL_CLEANUP", "1", 1);
 
 	if (safe_mce_sys().handle_bf) {
 		setenv("MLX4_POST_SEND_PREFER_BF", "1", 1);

--- a/src/vma/util/sys_vars.cpp
+++ b/src/vma/util/sys_vars.cpp
@@ -1251,9 +1251,8 @@ void set_env_params()
 
 	/*
 	 * MLX4_DEVICE_FATAL_CLEANUP/MLX5_DEVICE_FATAL_CLEANUP tells
-	 * ibv_destroy functions we
-	 * want to get success errno value in case of calling them
-	 * when the device was removed.
+	 * ibv_destroy functions we want to get success errno value
+	 * in case of calling them when the device was removed.
 	 * It helps to destroy resources in DEVICE_FATAL state
 	 */
 	setenv("MLX4_DEVICE_FATAL_CLEANUP", "1", 1);


### PR DESCRIPTION
MLX5_DEVICE_FATAL_CLEANUP tells ibv_destroy functions we
want to get success errno value in case of calling them
when the device was removed.
It is actual for OFED 4.x but planned to avoid such usage.

Signed-off-by: Igor Ivanov <igor.ivanov.va@gmail.com>