### PR TITLE
issue: 1433896 Enhance ib_ctx handler debug information

### DIFF
--- a/src/vma/dev/ib_ctx_handler.cpp
+++ b/src/vma/dev/ib_ctx_handler.cpp
@@ -229,6 +229,14 @@ void ib_ctx_handler::set_str()
 	str_x[0] = '\0';
 	sprintf(str_x, " fw: %s", m_p_ibv_device_attr->fw_ver);
 	strcat(m_str, str_x);
+
+	str_x[0] = '\0';
+	sprintf(str_x, " max_qp_wr: %d", m_p_ibv_device_attr->max_qp_wr);
+	strcat(m_str, str_x);
+
+	str_x[0] = '\0';
+	sprintf(str_x, " on_device_memory: %zu", m_on_device_memory);
+	strcat(m_str, str_x);
 }
 
 void ib_ctx_handler::print_val()


### PR DESCRIPTION
Enhance ib_ctx handler debug information to include also
max_qp_wre and on_device_memory information.

Signed-off-by: Liran Oz <lirano@mellanox.com>