### PR TITLE
issue: 1435293 Do not start daemon during package installation

### DIFF
--- a/build/libvma.spec.in
+++ b/build/libvma.spec.in
@@ -119,7 +119,6 @@ if [ $1 = 1 ]; then
     if type systemctl >/dev/null 2>&1; then
         systemctl --system daemon-reload
     fi
-    /etc/init.d/vma start
 fi
 
 %preun

--- a/debian/postinst
+++ b/debian/postinst
@@ -20,4 +20,3 @@ fi
 if type systemctl >/dev/null 2>&1; then
     systemctl --system daemon-reload
 fi
-/etc/init.d/vma start || true


### PR DESCRIPTION
Installations can be in changeroots, in an installer context, or
in other situations where you don't want the services started.
Like the debian package the RPM package is not started by default
after installation, you have to do this manually by entering
the following commands as
- systemD:
systemctl enable vma
systemctl start vma
- systemV
service vma start

Signed-off-by: Igor Ivanov <igor.ivanov.va@gmail.com>