### PR TITLE
issue: 1435682 Fix incorrect TCP seqno after zero-wnd-probe

### DIFF
--- a/src/vma/lwip/tcp.c
+++ b/src/vma/lwip/tcp.c
@@ -746,7 +746,10 @@ tcp_slowtmr(struct tcp_pcb* pcb)
 		  if (pcb->persist_backoff < sizeof(tcp_persist_backoff)) {
 			pcb->persist_backoff++;
 		  }
-		  tcp_zero_window_probe(pcb);
+		  /* Use tcp_keepalive() instead of tcp_zero_window_probe() to probe for window update
+		   * without sending any data (which will force us to split the segment).
+		   * tcp_zero_window_probe(pcb); */
+		  tcp_keepalive(pcb);
 		}
 	  } else {
 		/* Increase the retransmission timer if it is running */

--- a/src/vma/lwip/tcp_out.c
+++ b/src/vma/lwip/tcp_out.c
@@ -1588,8 +1588,7 @@ tcp_zero_window_probe(struct tcp_pcb *pcb)
   len = is_fin ? 0 : 1;
 
  /**
-  * There is no support for partial acknolemgnet of segments is the unacked list.
-  * Hence, while sending 1 bytes probe me must split the segment.
+  * While sending probe of 1 byte we must split the first unsent segment.
   * This change is commented out because tcp_zero_window_probe() was replaced
   * with tcp_keepalive().
   * if (len > 0 && seg->len != 1) {

--- a/src/vma/lwip/tcp_out.c
+++ b/src/vma/lwip/tcp_out.c
@@ -1587,6 +1587,17 @@ tcp_zero_window_probe(struct tcp_pcb *pcb)
   /* we want to send one seqno: either FIN or data (no options) */
   len = is_fin ? 0 : 1;
 
+ /**
+  * There is no support for partial acknolemgnet of segments is the unacked list.
+  * Hence, while sending 1 bytes probe me must split the segment.
+  * This change is commented out because tcp_zero_window_probe() was replaced
+  * with tcp_keepalive().
+  * if (len > 0 && seg->len != 1) {
+  *   tcp_split_segment(pcb, seg, seg->seqno - pcb->lastack + 1);
+  *   seg = pcb->unsent;
+  * }
+  */
+
   p = tcp_output_alloc_header(pcb, 0, len, seg->tcphdr->seqno);
   if(p == NULL) {
     LWIP_DEBUGF(TCP_DEBUG, ("tcp_zero_window_probe: no memory for pbuf\n"));


### PR DESCRIPTION
Use tcp_keepalive() instead of tcp_zero_window_probe() to
probe for window update without sending any data (which
will force us to split the segment).

Signed-off-by: Liran Oz <lirano@mellanox.com>