### PR TITLE
issue: 1387232 Fix issue with vmad default path mismatch

### DIFF
--- a/src/vma/util/agent_def.h
+++ b/src/vma/util/agent_def.h
@@ -65,7 +65,7 @@
 
 #define VMA_AGENT_BASE_NAME "vma_agent"
 #define VMA_AGENT_ADDR      "/var/run/" VMA_AGENT_BASE_NAME ".sock"
-#define VMA_AGENT_PATH      "/tmp/vma/"
+#define VMA_AGENT_PATH      "/tmp/vma"
 
 
 #pragma pack(push, 1)


### PR DESCRIPTION
Path for temporary files used by daemon set by VMA process
in VMA_VMAD_NOTIFY_DIR environment variable and path passed
in --notify-dir should be absolutelly identical.

Signed-off-by: Igor Ivanov <igor.ivanov.va@gmail.com>