### PR TITLE
issue: 1178933 Print warning while RoCE lag is enabled

### DIFF
--- a/src/vma/dev/net_device_val.cpp
+++ b/src/vma/dev/net_device_val.cpp
@@ -1530,6 +1530,7 @@ bool net_device_val::verify_ipoib_mode()
 bool net_device_val::verify_eth_qp_creation(const char* ifname)
 {
 	bool success = false;
+	char bond_roce_lag_path[256] = {0};
 	struct ibv_cq* cq = NULL;
 	struct ibv_comp_channel *channel = NULL;
 	struct ibv_qp* qp = NULL;
@@ -1555,6 +1556,14 @@ bool net_device_val::verify_eth_qp_creation(const char* ifname)
 
 	if (!p_ib_ctx) {
 		nd_logdbg("Cant find ib_ctx for interface %s", base_ifname);
+		if (m_bond != NO_BOND && check_bond_roce_lag_exist(bond_roce_lag_path, sizeof(bond_roce_lag_path), get_ifname_link(), ifname)) {
+			vlog_printf(VLOG_WARNING,"*******************************************************************************************************\n");
+			vlog_printf(VLOG_WARNING,"* Interface %s will not be offloaded.\n", get_ifname_link());
+			vlog_printf(VLOG_WARNING,"* VMA cannot offload the device while RoCE LAG is enabled.\n");
+			vlog_printf(VLOG_WARNING,"* In order to disable RoCE LAG please use:\n", get_ifname_link());
+			vlog_printf(VLOG_WARNING,"* echo 0 > %s\n", bond_roce_lag_path);
+			vlog_printf(VLOG_WARNING,"******************************************************************************************************\n");
+		}
 		goto release_resources;
 	}
 

--- a/src/vma/util/sys_vars.h
+++ b/src/vma/util/sys_vars.h
@@ -703,6 +703,7 @@ extern mce_sys_var & safe_mce_sys();
 #define BONDING_ACTIVE_SLAVE_PARAM_FILE			"/sys/class/net/%s/bonding/active_slave"
 #define BONDING_FAILOVER_MAC_PARAM_FILE			"/sys/class/net/%s/bonding/fail_over_mac"
 #define BONDING_XMIT_HASH_POLICY_PARAM_FILE		"/sys/class/net/%s/bonding/xmit_hash_policy"
+#define BONDING_ROCE_LAG_FILE				"/sys/class/net/%s/slave_%s/device/roce_lag_enable"
 /* BONDING_SLAVE_STATE_PARAM_FILE is for kernel  > 3.14 or RH7.2 and higher */
 #define BONDING_SLAVE_STATE_PARAM_FILE			"/sys/class/net/%s/bonding_slave/state"
 #define L2_ADDR_FILE_FMT                                "/sys/class/net/%.*s/address"

--- a/src/vma/util/utils.cpp
+++ b/src/vma/util/utils.cpp
@@ -774,6 +774,20 @@ bool get_bond_active_slave_name(IN const char* bond_name, OUT char* active_slave
 	return true;
 }
 
+bool check_bond_roce_lag_exist(OUT char* bond_roce_lag_path, int sz, IN const char* bond_name, IN const char* slave_name)
+{
+	char sys_res[1024] = {0};
+	snprintf(bond_roce_lag_path, sz, BONDING_ROCE_LAG_FILE, bond_name, slave_name);
+	BULLSEYE_EXCLUDE_BLOCK_START
+	if (priv_read_file(bond_roce_lag_path, sys_res, 1024, VLOG_FUNC) > 0) {
+		if (strtol(sys_res, NULL,10)) {
+			return true;
+		}
+	}
+
+	return false;
+}
+
 bool get_netvsc_slave(IN const char* ifname, OUT char* slave_name, OUT unsigned int &slave_flags)
 {
 	char netvsc_path[256];

--- a/src/vma/util/utils.cpp
+++ b/src/vma/util/utils.cpp
@@ -778,9 +778,8 @@ bool check_bond_roce_lag_exist(OUT char* bond_roce_lag_path, int sz, IN const ch
 {
 	char sys_res[1024] = {0};
 	snprintf(bond_roce_lag_path, sz, BONDING_ROCE_LAG_FILE, bond_name, slave_name);
-	BULLSEYE_EXCLUDE_BLOCK_START
 	if (priv_read_file(bond_roce_lag_path, sys_res, 1024, VLOG_FUNC) > 0) {
-		if (strtol(sys_res, NULL,10)) {
+		if (strtol(sys_res, NULL,10) > 0 && errno != ERANGE) {
 			return true;
 		}
 	}

--- a/src/vma/util/utils.h
+++ b/src/vma/util/utils.h
@@ -301,6 +301,7 @@ size_t get_local_ll_addr(const char* ifname, unsigned char* addr, int addr_len, 
 bool get_bond_active_slave_name(IN const char* bond_name, OUT char* active_slave_name, IN int sz);
 bool get_bond_slave_state(IN const char* slave_name, OUT char* curr_state, IN int sz);
 bool get_bond_slaves_name_list(IN const char* bond_name, OUT char* slaves_list, IN int sz);
+bool check_bond_roce_lag_exist(OUT char* bond_roce_lag_path, int sz, IN const char* bond_name, IN const char* slave_name);
 bool check_device_exist(const char* ifname, const char *path);
 bool check_netvsc_device_exist(const char* ifname);
 bool get_netvsc_slave(IN const char* ifname, OUT char* slave_name, OUT unsigned int &slave_flags);


### PR DESCRIPTION
RiCE lag is not supported by VMA. while enabled, VMA should
print a relevant warning in addition to instructions of how
to disable it.

Signed-off-by: Liran Oz <lirano@mellanox.com>