### PR TITLE
issue: 1449421 Suppress warning in case flow attach is interrupted

### DIFF
--- a/src/vma/dev/ring_tap.cpp
+++ b/src/vma/dev/ring_tap.cpp
@@ -132,7 +132,9 @@ bool ring_tap::attach_flow(flow_tuple& flow_spec_5t, pkt_rcvr_sink *sink)
 
 		rc = g_p_agent->send_msg_flow(&data);
 		if (rc != 0) {
-			ring_logwarn("Add TC rule failed with error=%d", rc);
+			if (!g_b_exit) {
+				ring_logwarn("Add TC rule failed with error=%d", rc);
+			}
 			return false;
 		}
 	}
@@ -363,7 +365,9 @@ bool ring_tap::detach_flow(flow_tuple& flow_spec_5t, pkt_rcvr_sink* sink)
 
 		rc = g_p_agent->send_msg_flow(&data);
 		if (rc != 0) {
-			ring_logwarn("Del TC rule failed with error=%d", rc);
+			if (!g_b_exit) {
+				ring_logwarn("Del TC rule failed with error=%d", rc);
+			}
 			return false;
 		}
 	}


### PR DESCRIPTION
Attach process can spend time but process can be terminated in the
middle. So no needs in reporting warning.

Signed-off-by: Igor Ivanov <igor.ivanov.va@gmail.com>