### PR TITLE
issue: 1475443 Fix getsockname/getpeername returned data

### DIFF
--- a/src/vma/sock/sockinfo_tcp.h
+++ b/src/vma/sock/sockinfo_tcp.h
@@ -377,11 +377,7 @@ private:
 	 *            ERR_RST: the connection was reset by the remote host
 	 */
 	static void 	err_lwip_cb(void *arg, err_t err);
-	/* (re)alloc sockaddr of desired len. old addr may be freed if new_len != old_len
-	 * old_len will be changed to new_len
-	 */
-	struct sockaddr *sockaddr_realloc(struct sockaddr *old_addr, socklen_t & old_len, socklen_t new_len);
-	inline void 	return_rx_buffs(ring *p_ring);
+
 	// TODO: it is misleading to declare inline in file that doesn't contain the implementation as it can't help callers
 	inline void 	return_pending_rx_buffs();
 	inline void 	return_pending_tx_buffs();

--- a/src/vma/util/sock_addr.h
+++ b/src/vma/util/sock_addr.h
@@ -64,14 +64,7 @@ public:
 	~sock_addr() {};
 
 	struct sockaddr* get_p_sa() { return &m_sa; }
-	void 		get_sa(struct sockaddr* p_sa) { memcpy(p_sa, &m_sa, get_socklen()); }
-#if _BullseyeCoverage
-    #pragma BullseyeCoverage off
-#endif
-	void 		get_sa(struct sockaddr& r_sa) { memcpy(&r_sa, &m_sa, get_socklen()); }
-#if _BullseyeCoverage
-    #pragma BullseyeCoverage on
-#endif
+	void 		get_sa(struct sockaddr* p_sa, size_t size) { memcpy(p_sa, &m_sa, std::min<size_t>(get_socklen(), size)); }
 	void 		get_sa(struct sockaddr_in& r_sa_in) { memcpy(&r_sa_in, &m_sa, get_socklen()); }
 
 	sa_family_t 	get_sa_family() { struct sockaddr_in* p_sa_in = (struct sockaddr_in*)&m_sa; return p_sa_in->sin_family; }


### PR DESCRIPTION
The returned address is truncated if the buffer provided is too small.
in this case, addrlen will return a value greater than was supplied to
the call.

Signed-off-by: Liran Oz <lirano@mellanox.com>