### PR TITLE
issue: 1498320 Set RDMAV_ALLOW_DISASSOC_DESTROY env for upstream

### DIFF
--- a/src/vma/util/sys_vars.cpp
+++ b/src/vma/util/sys_vars.cpp
@@ -1251,13 +1251,14 @@ void set_env_params()
 	//setenv("MLX4_SINGLE_THREADED", "1", 0);
 
 	/*
-	 * MLX4_DEVICE_FATAL_CLEANUP/MLX5_DEVICE_FATAL_CLEANUP tells
-	 * ibv_destroy functions we want to get success errno value
+	 * MLX4_DEVICE_FATAL_CLEANUP/MLX5_DEVICE_FATAL_CLEANUP/RDMAV_ALLOW_DISASSOC_DESTROY
+	 * tells ibv_destroy functions we want to get success errno value
 	 * in case of calling them when the device was removed.
 	 * It helps to destroy resources in DEVICE_FATAL state
 	 */
 	setenv("MLX4_DEVICE_FATAL_CLEANUP", "1", 1);
 	setenv("MLX5_DEVICE_FATAL_CLEANUP", "1", 1);
+	setenv("RDMAV_ALLOW_DISASSOC_DESTROY", "1", 1);
 
 	if (safe_mce_sys().handle_bf) {
 		setenv("MLX4_POST_SEND_PREFER_BF", "1", 1);


### PR DESCRIPTION
RDMAV_ALLOW_DISASSOC_DESTROY tells ibv_destroy functions we
want to get success errno value in case of calling them
when the device was removed.

Signed-off-by: Liran Oz <lirano@mellanox.com>