### PR TITLE
issue: 1491767 Inrease SO_RCVTIMEO for agent socket

### DIFF
--- a/src/vma/util/agent.cpp
+++ b/src/vma/util/agent.cpp
@@ -508,10 +508,10 @@ int agent::create_agent_socket(void)
 		goto err;
 	}
 
-	/* Sets the timeout value as 1 sec that specifies the maximum amount of time
+	/* Sets the timeout value as 3 sec that specifies the maximum amount of time
 	 * an input function waits until it completes.
 	 */
-	opttv.tv_sec = 1;
+	opttv.tv_sec = 3;
 	opttv.tv_usec = 0;
 	sys_call(rc, setsockopt, m_sock_fd, SOL_SOCKET, SO_RCVTIMEO,
 			(const void *)&opttv, sizeof(opttv));


### PR DESCRIPTION
During stressfull scenario when mass of sockets are opened/closed
daemon processes income message slower. Increasing wait timeout
during recieve of daemon`s answer allows to issues during
communication agent/daemon.
Another way: to avoid using blocking operations on agent side.

Signed-off-by: Igor Ivanov <igor.ivanov.va@gmail.com>