### PR TITLE
issue: 915305 Add connection with daemon on the fly

### DIFF
--- a/contrib/jenkins_tests/cppcheck.sh
+++ b/contrib/jenkins_tests/cppcheck.sh
@@ -36,7 +36,6 @@ if [ $rc -gt 0 ]; then
     do_err "cppcheck" "${cppcheck_dir}/cppcheck.err"
     info="cppcheck found $nerrors errors"
     status="error"
-    do_err "$1" "${5}.err"
 else
     echo ok 1 cppcheck found no issues >> $cppcheck_tap
     info="cppcheck found no issues"

--- a/src/vma/sock/sockinfo_tcp.cpp
+++ b/src/vma/sock/sockinfo_tcp.cpp
@@ -701,6 +701,11 @@ void sockinfo_tcp::put_agent_msg(void *arg)
 	sockinfo_tcp *p_si_tcp = (sockinfo_tcp *)arg;
 	struct vma_msg_state data;
 
+	/* Ignore listen socket at the moment */
+	if (p_si_tcp->is_server() || get_tcp_state(&p_si_tcp->m_pcb) == LISTEN) {
+		return ;
+	}
+
 	data.hdr.code = VMA_MSG_STATE;
 	data.hdr.ver = VMA_AGENT_VER;
 	data.hdr.pid = getpid();

--- a/src/vma/sock/sockinfo_tcp.cpp
+++ b/src/vma/sock/sockinfo_tcp.cpp
@@ -306,6 +306,7 @@ sockinfo_tcp::sockinfo_tcp(int fd):
 	}
 
 	si_tcp_logdbg("TCP PCB FLAGS: 0x%x", m_pcb.flags);
+	g_p_agent->register_cb((agent_cb_t)&sockinfo_tcp::put_agent_msg, (void *)this);
 	si_tcp_logfunc("done");
 }
 
@@ -352,6 +353,8 @@ sockinfo_tcp::~sockinfo_tcp()
 	if (m_n_rx_pkt_ready_list_count || m_rx_ready_byte_count || m_rx_pkt_ready_list.size() || m_rx_ring_map.size() || m_rx_reuse_buff.n_buff_num || m_rx_reuse_buff.rx_reuse.size() || m_rx_cb_dropped_list.size() || m_rx_ctl_packets_list.size() || m_rx_peer_packets.size() || m_rx_ctl_reuse_list.size())
 		si_tcp_logerr("not all buffers were freed. protocol=TCP. m_n_rx_pkt_ready_list_count=%d, m_rx_ready_byte_count=%d, m_rx_pkt_ready_list.size()=%d, m_rx_ring_map.size()=%d, m_rx_reuse_buff.n_buff_num=%d, m_rx_reuse_buff.rx_reuse.size=%d, m_rx_cb_dropped_list.size=%d, m_rx_ctl_packets_list.size=%d, m_rx_peer_packets.size=%d, m_rx_ctl_reuse_list.size=%d",
 				m_n_rx_pkt_ready_list_count, m_rx_ready_byte_count, (int)m_rx_pkt_ready_list.size() ,(int)m_rx_ring_map.size(), m_rx_reuse_buff.n_buff_num, m_rx_reuse_buff.rx_reuse.size(), m_rx_cb_dropped_list.size(), m_rx_ctl_packets_list.size(), m_rx_peer_packets.size(), m_rx_ctl_reuse_list.size());
+
+	g_p_agent->unregister_cb((agent_cb_t)&sockinfo_tcp::put_agent_msg, (void *)this);
 
 	si_tcp_logdbg("sock closed");
 }
@@ -693,6 +696,25 @@ bool sockinfo_tcp::check_dummy_send_conditions(const int flags, const iovec* p_i
 		(p_iov->iov_len + m_pcb.snd_lbb - m_pcb.lastack) <= wnd; // Window allows the dummy packet it to be sent
 }
 
+void sockinfo_tcp::put_agent_msg(void *arg)
+{
+	sockinfo_tcp *p_si_tcp = (sockinfo_tcp *)arg;
+	struct vma_msg_state data;
+
+	data.hdr.code = VMA_MSG_STATE;
+	data.hdr.ver = VMA_AGENT_VER;
+	data.hdr.pid = getpid();
+	data.fid = p_si_tcp->get_fd();
+	data.state = get_tcp_state(&p_si_tcp->m_pcb);
+	data.type = SOCK_STREAM;
+	data.src_ip = p_si_tcp->m_bound.get_in_addr();
+	data.src_port = p_si_tcp->m_bound.get_in_port();
+	data.dst_ip = p_si_tcp->m_connected.get_in_addr();
+	data.dst_port = p_si_tcp->m_connected.get_in_port();
+
+	g_p_agent->put((const void*)&data, sizeof(data), (intptr_t)data.fid);
+}
+
 ssize_t sockinfo_tcp::tx(const tx_call_t call_type, const iovec* p_iov, const ssize_t sz_iov, const int flags, const struct sockaddr *__to, const socklen_t __tolen)
 {
 	int total_tx = 0;
@@ -1006,28 +1028,8 @@ err_t sockinfo_tcp::ip_output_syn_ack(struct pbuf *p, void* v_p_conn, int is_rex
 	p_si_tcp->m_p_socket_stats->tcp_state = new_state;
 
 	/* Update daemon about actual state for offloaded connection */
-	if (likely((p_si_tcp->m_sock_offload == TCP_SOCK_LWIP) &&
-			(AGENT_ACTIVE == g_p_agent->state()))) {
-		agent_msg_t *msg = NULL;
-
-		msg = g_p_agent->get_msg();
-		if (msg) {
-			struct vma_msg_state *data = NULL;
-
-			msg->length = sizeof(*data);
-			data = (struct vma_msg_state*)&msg->data;
-			data->hdr.code = VMA_MSG_STATE;
-			data->hdr.ver = VMA_AGENT_VER;
-			data->hdr.pid = getpid();
-			data->fid = p_si_tcp->get_fd();
-			data->state = new_state;
-			data->type = SOCK_STREAM;
-			data->src_ip = p_si_tcp->m_bound.get_in_addr();
-			data->src_port = p_si_tcp->m_bound.get_in_port();
-			data->dst_ip = p_si_tcp->m_connected.get_in_addr();
-			data->dst_port = p_si_tcp->m_connected.get_in_port();
-			g_p_agent->put_msg(msg);
-		}
+	if (likely(p_si_tcp->m_sock_offload == TCP_SOCK_LWIP)) {
+		p_si_tcp->put_agent_msg((void *)p_si_tcp);
 	}
 }
 
@@ -4548,9 +4550,7 @@ void tcp_timers_collection::handle_timer_expired(void* user_data)
 	m_n_location = (m_n_location + 1) % m_n_intervals_size;
 
 	/* Processing all messages for the daemon */
-	if (AGENT_ACTIVE == g_p_agent->state()) {
-		g_p_agent->progress();
-	}
+	g_p_agent->progress();
 }
 
 void tcp_timers_collection::add_new_timer(timer_node_t* node, timer_handler* handler, void* user_data)

--- a/src/vma/sock/sockinfo_tcp.h
+++ b/src/vma/sock/sockinfo_tcp.h
@@ -413,6 +413,7 @@ private:
 	void process_reuse_ctl_packets();
 	void process_rx_ctl_packets();
 	bool check_dummy_send_conditions(const int flags, const iovec* p_iov, const ssize_t sz_iov);
+	static void put_agent_msg(void *arg);
 };
 typedef struct tcp_seg tcp_seg;
 

--- a/src/vma/util/agent.cpp
+++ b/src/vma/util/agent.cpp
@@ -453,7 +453,7 @@ int agent::send(agent_msg_t *msg)
 				errno, strerror(errno));
 		rc = -errno;
 		m_state = AGENT_INACTIVE;
-		__log_dbg("Agent is inactivated. state = %d\n", m_state);
+		__log_dbg("Agent is inactivated. state = %d", m_state);
 		goto err;
 	}
 
@@ -535,7 +535,7 @@ int agent::send_msg_init(void)
 	}
 
 	m_state = AGENT_ACTIVE;
-	__log_dbg("Agent is activated. state = %d\n", m_state);
+	__log_dbg("Agent is activated. state = %d", m_state);
 
 err:
 	return rc;
@@ -555,7 +555,7 @@ int agent::send_msg_exit(void)
 	}
 
 	m_state = AGENT_INACTIVE;
-	__log_dbg("Agent is inactivated. state = %d\n", m_state);
+	__log_dbg("Agent is inactivated. state = %d", m_state);
 
 	memset(&data, 0, sizeof(data));
 	data.hdr.code = VMA_MSG_EXIT;
@@ -703,9 +703,9 @@ void agent::check_link(void)
 	sys_call(rc, connect, m_sock_fd, (struct sockaddr *)&server_addr,
 			sizeof(struct sockaddr_un));
 	if (rc < 0) {
-		__log_dbg("Failed to connect() errno %d (%s)\n",
+		__log_dbg("Failed to connect() errno %d (%s)",
 				errno, strerror(errno));
 		m_state = AGENT_INACTIVE;
-		__log_dbg("Agent is inactivated. state = %d\n", m_state);
+		__log_dbg("Agent is inactivated. state = %d", m_state);
 	}
 }

--- a/src/vma/util/agent.h
+++ b/src/vma/util/agent.h
@@ -35,65 +35,64 @@
 
 #include "vma/util/agent_def.h"
 
+/**
+ * @struct agent_msg_t
+ * @brief Agent message resource descriptor.
+ *
+ * This structure describes a internal message object.
+ */
 typedef struct agent_msg {
-	struct list_head item;
-	int length;
+	struct list_head item;             /**< link element */
+	int length;                        /**< actual length of valuable data */
+	intptr_t tag;                      /**< unique identifier of the message */
 	union {
 		struct vma_msg_state state;
 		char raw[1];
-	} data;
+	} data;                            /**< data to be sent to daemon */
 } agent_msg_t;
 
+#define AGENT_MSG_TAG_INVALID (-1)
+
+/**
+ * @enum agent_state_t
+ * @brief List of possible Agent states.
+ */
 typedef enum {
 	AGENT_INACTIVE,
 	AGENT_ACTIVE,
 	AGENT_CLOSED
 } agent_state_t;
 
-class agent : lock_spin {
+typedef void (*agent_cb_t)(void *arg);
+
+/**
+ * @struct agent_msg_t
+ * @brief Callback queue element.
+ *
+ * This structure describes function call that is
+ * done in case Agent change the state
+ */
+typedef struct agent_callback {
+	struct list_head item;             /**< link element */
+	agent_cb_t cb;                     /**< Callback function */
+    void *arg;                         /**< Function argument */
+} agent_callback_t;
+
+
+class agent {
 public:
 	agent();
 	virtual ~agent();
-
-	void progress(void);
 
 	inline agent_state_t state(void) const
 	{
 		return m_state;
 	}
 
-	inline void put_msg(agent_msg_t *msg)
-	{
-		lock();
-		list_add_tail(&msg->item, &m_wait_queue);
-		unlock();
-	}
-
-	inline agent_msg_t* get_msg(void)
-	{
-		agent_msg_t *msg = NULL;
-		int i = 0;
-
-		lock();
-		if (list_empty(&m_free_queue)) {
-			for (i = 0; i < m_msg_grow; i++) {
-				/* coverity[overwrite_var] */
-				msg = (agent_msg_t *)calloc(1, sizeof(*msg));
-				if (NULL == msg) {
-					break;
-				}
-				msg->length = 0;
-				list_add_tail(&msg->item, &m_free_queue);
-				m_msg_num++;
-			}
-		}
-		/* coverity[overwrite_var] */
-		msg = list_first_entry(&m_free_queue, agent_msg_t, item);
-		msg->length = 0;
-		list_del_init(&msg->item);
-		unlock();
-		return msg;
-	}
+	void register_cb(agent_cb_t fn, void *arg);
+	void unregister_cb(agent_cb_t fn, void *arg);
+	int put(const void *data, size_t length, intptr_t tag);
+	void progress(void);
 	int send_msg_flow(struct vma_msg_flow *data);
 
 private:
@@ -114,15 +113,31 @@ private:
 	/* name of pid file */
 	char m_pid_file[100];
 
+	/* queue of callback elements
+	 * this queue stores function calls activated during
+	 * state change
+	 */
+	struct list_head         m_cb_queue;
+
+	/* thread-safe lock to protect operations
+	 * under the callback queue
+	 */
+	lock_spin                m_cb_lock;
+
 	/* queue of message elements
 	 * this queue stores unused messages
 	 */
 	struct list_head         m_free_queue;
 
 	/* queue of message elements
-	 * this queue stores messages from different sockinfo (sockets)
+	 * this queue stores messages from different sockets
 	 */
 	struct list_head         m_wait_queue;
+
+	/* thread-safe lock to protect operations
+	 * under the message wait and free queues
+	 */
+	lock_spin                m_msg_lock;
 
 	/* total number of allocated messages
 	 * some amount of messages are allocated during initialization
@@ -133,13 +148,18 @@ private:
 	/* number of messages to grow */
 	int m_msg_grow;
 
+	/* periodic time for establishment connection attempts (in sec) */
+	int m_inactive_treshold;
+
+	/* periodic time for alive check (in sec) */
+	int m_alive_treshold;
+
 	int create_agent_socket(void);
 	int send(agent_msg_t *msg);
 	int send_msg_init(void);
 	int send_msg_exit(void);
-	int send_msg_state(uint32_t fid, uint8_t st, uint8_t type,
-			uint32_t src_ip, uint16_t src_port,
-			uint32_t dst_ip, uint16_t dst_port);
+	void progress_cb(void);
+	void check_link(void);
 };
 
 extern agent* g_p_agent;

--- a/src/vma/util/agent.h
+++ b/src/vma/util/agent.h
@@ -145,15 +145,6 @@ private:
 	 */
 	int m_msg_num;
 
-	/* number of messages to grow */
-	int m_msg_grow;
-
-	/* periodic time for establishment connection attempts (in sec) */
-	int m_inactive_treshold;
-
-	/* periodic time for alive check (in sec) */
-	int m_alive_treshold;
-
 	int create_agent_socket(void);
 	int send(agent_msg_t *msg);
 	int send_msg_init(void);


### PR DESCRIPTION
See issue: 768398 for peer notification capability (see PR: https://github.com/Mellanox/libvma/pull/270)

This changes allow to cache state update in case lost connection
with vma daemon and notify daemon about cached state after
establishing connection.

Agent is able to detect connection lost and attemp to set it
again. After setting connection Agent send information about
TCP sockets state to daemon.

Signed-off-by: Igor Ivanov <igori@mellanox.com>