### PR TITLE
issue: 1522964 Fix epoll_wait() can't be interrupted

### DIFF
--- a/src/vma/event/event_handler_manager.cpp
+++ b/src/vma/event/event_handler_manager.cpp
@@ -77,6 +77,10 @@ event_handler_manager* g_p_event_handler_manager = NULL;
 
 pthread_t g_n_internal_thread_id = 0;
 
+static void update_global_exit(int sig) {
+        evh_logdbg("Catch Signal: SIGINT (%d)", sig);
+        g_b_exit = true;
+}
 
 void* event_handler_manager::register_timer_event(int timeout_msec, timer_handler* handler, 
 						  timer_req_type_t req_type, void* user_data,
@@ -871,7 +875,6 @@ void event_handler_manager::process_rdma_cm_event(event_handler_map_t::iterator 
 	evh_logdbg("[%d] Completed rdma_cm event %s (%d)", cma_channel->fd, priv_rdma_cm_event_type_str(cma_event.event), cma_event.event);
 }
 
-
 /*
 The main loop actions:
 	1) update timeout + handle registers that theire timeout expiered
@@ -894,6 +897,8 @@ void* event_handler_manager::thread_loop()
 	}
 	BULLSEYE_EXCLUDE_BLOCK_END
 	
+	signal(SIGINT, update_global_exit);
+
 	poll_fd.events  = POLLIN | POLLPRI;
 	poll_fd.revents = 0;
 	while (m_b_continue_running) {

--- a/src/vma/event/event_handler_manager.cpp
+++ b/src/vma/event/event_handler_manager.cpp
@@ -897,7 +897,9 @@ void* event_handler_manager::thread_loop()
 	}
 	BULLSEYE_EXCLUDE_BLOCK_END
 	
-	signal(SIGINT, update_global_exit);
+	if (signal(SIGINT, update_global_exit) == SIG_ERR){
+		evh_logdbg("Failed to register signal function");
+	}
 
 	poll_fd.events  = POLLIN | POLLPRI;
 	poll_fd.revents = 0;

--- a/src/vma/event/event_handler_manager.cpp
+++ b/src/vma/event/event_handler_manager.cpp
@@ -77,10 +77,6 @@ event_handler_manager* g_p_event_handler_manager = NULL;
 
 pthread_t g_n_internal_thread_id = 0;
 
-static void update_global_exit(int sig) {
-        evh_logdbg("Catch Signal: SIGINT (%d)", sig);
-        g_b_exit = true;
-}
 
 void* event_handler_manager::register_timer_event(int timeout_msec, timer_handler* handler, 
 						  timer_req_type_t req_type, void* user_data,
@@ -875,6 +871,7 @@ void event_handler_manager::process_rdma_cm_event(event_handler_map_t::iterator 
 	evh_logdbg("[%d] Completed rdma_cm event %s (%d)", cma_channel->fd, priv_rdma_cm_event_type_str(cma_event.event), cma_event.event);
 }
 
+
 /*
 The main loop actions:
 	1) update timeout + handle registers that theire timeout expiered
@@ -897,8 +894,6 @@ void* event_handler_manager::thread_loop()
 	}
 	BULLSEYE_EXCLUDE_BLOCK_END
 	
-	signal(SIGINT, update_global_exit);
-
 	poll_fd.events  = POLLIN | POLLPRI;
 	poll_fd.revents = 0;
 	while (m_b_continue_running) {

--- a/src/vma/event/event_handler_manager.cpp
+++ b/src/vma/event/event_handler_manager.cpp
@@ -897,9 +897,7 @@ void* event_handler_manager::thread_loop()
 	}
 	BULLSEYE_EXCLUDE_BLOCK_END
 	
-	if (signal(SIGINT, update_global_exit) == SIG_ERR){
-		evh_logdbg("Failed to register signal function");
-	}
+	signal(SIGINT, update_global_exit);
 
 	poll_fd.events  = POLLIN | POLLPRI;
 	poll_fd.revents = 0;

--- a/src/vma/sock/sock-redirect.cpp
+++ b/src/vma/sock/sock-redirect.cpp
@@ -84,6 +84,7 @@ using namespace std;
 
 struct os_api orig_os_api;
 struct sigaction g_act_prev;
+sighandler_t g_sighandler = NULL;
 class ring_simple;
 class ring_eth_cb;
 class ring_eth_direct;
@@ -176,6 +177,7 @@ void get_orig_funcs()
 	GET_ORIG_FUNC(vfork);
 	GET_ORIG_FUNC(daemon);
 	GET_ORIG_FUNC(sigaction);
+	GET_ORIG_FUNC(signal);
 }
 
 const char* socket_get_domain_str(int domain)
@@ -2535,4 +2537,32 @@ int sigaction(int signum, const struct sigaction *act, struct sigaction *oldact)
 			srdr_logdbg_exit("failed (errno=%d %m)", errno);
 	}
 	return ret;
+}
+
+static void handle_signal(int signum)
+{
+	srdr_logdbg_entry("Caught signal! signum=%d", signum);
+	g_b_exit = true;
+
+	if (g_sighandler) {
+		g_sighandler(signum);
+	}
+}
+
+extern "C"
+sighandler_t signal(int signum, sighandler_t handler)
+{
+	srdr_logdbg_entry("signum=%d, handler=%p", signum, handler);
+
+	if (!orig_os_api.signal) get_orig_funcs();
+
+	if (handler && handler != SIG_ERR && handler != SIG_DFL && handler != SIG_IGN) {
+		// Only SIGINT is supported for now
+		if (signum == SIGINT) {
+			g_sighandler = handler;
+			return orig_os_api.signal(SIGINT, &handle_signal);
+		}
+	}
+
+	return orig_os_api.signal(signum, handler);
 }

--- a/src/vma/sock/sock-redirect.cpp
+++ b/src/vma/sock/sock-redirect.cpp
@@ -2542,7 +2542,10 @@ int sigaction(int signum, const struct sigaction *act, struct sigaction *oldact)
 static void handle_signal(int signum)
 {
 	srdr_logdbg_entry("Caught signal! signum=%d", signum);
-	g_b_exit = true;
+
+	if (signum == SIGINT) {
+		g_b_exit = true;
+	}
 
 	if (g_sighandler) {
 		g_sighandler(signum);

--- a/src/vma/sock/sock-redirect.h
+++ b/src/vma/sock/sock-redirect.h
@@ -159,6 +159,7 @@ struct os_api {
 	int (*daemon) (int __nochdir, int __noclose);
 
 	int (*sigaction) (int signum, const struct sigaction *act, struct sigaction *oldact);
+	sighandler_t (*signal) (int signum, sighandler_t handler);
 };
 
 /**


### PR DESCRIPTION
This commit fixes a problem that caused VMA to ignore SIGINT during
epoll_wait() while VMA_SELECT_POLL=-1 is used.

Signed-off-by: Liran Oz <lirano@mellanox.com>