### PR TITLE
issue: 1536838 Enable plugin on upstream after reboot without SRIOV

### DIFF
--- a/src/vma/dev/ib_ctx_handler_collection.cpp
+++ b/src/vma/dev/ib_ctx_handler_collection.cpp
@@ -87,14 +87,17 @@ void ib_ctx_handler_collection::update_tbl(const char *ifa_name)
 	int num_devices = 0;
 	int i;
 
+	ibchc_logdbg("Checking for offload capable IB devices...");
+
 	dev_list = vma_ibv_get_device_list(&num_devices);
 
 	BULLSEYE_EXCLUDE_BLOCK_START
-	if (!dev_list && safe_mce_sys().hypervisor != mce_sys_var::HYPER_MSHV) {
-		/*
-		 * MLX modules are not started after reboot when SRIOV is disabled on upstream-driver
-		 * VMs over Windows Hypervisor.
-		 */
+	if (!dev_list) {
+		if (safe_mce_sys().hypervisor == mce_sys_var::HYPER_MSHV) {
+			 // MLX modules are not started after reboot when SRIOV is disabled on upstream-driver
+			 // VMs over Windows Hypervisor.
+			goto out;
+		}
 		ibchc_logwarn("Failure in vma_ibv_get_device_list() (error=%d %m)", errno);
 		ibchc_logwarn("Please check OFED installation");
 		throw_vma_exception("No IB capable devices found!");
@@ -107,8 +110,6 @@ void ib_ctx_handler_collection::update_tbl(const char *ifa_name)
 	}
 
 	BULLSEYE_EXCLUDE_BLOCK_END
-
-	ibchc_logdbg("Checking for offload capable IB devices...");
 
 	if (!ifa_name) {
 		/* Get common time conversion mode for all devices */
@@ -140,6 +141,7 @@ void ib_ctx_handler_collection::update_tbl(const char *ifa_name)
 		m_ib_ctx_map[p_ib_ctx_handler->get_ibv_device()] = p_ib_ctx_handler;
 	}
 
+out:
 	ibchc_logdbg("Check completed. Found %d offload capable IB devices", m_ib_ctx_map.size());
 
 	if (dev_list) {

--- a/src/vma/dev/ib_ctx_handler_collection.cpp
+++ b/src/vma/dev/ib_ctx_handler_collection.cpp
@@ -90,7 +90,11 @@ void ib_ctx_handler_collection::update_tbl(const char *ifa_name)
 	dev_list = vma_ibv_get_device_list(&num_devices);
 
 	BULLSEYE_EXCLUDE_BLOCK_START
-	if (!dev_list) {
+	if (!dev_list && safe_mce_sys().hypervisor != mce_sys_var::HYPER_MSHV) {
+		/*
+		 * MLX modules are not started after reboot when SRIOV is disabled on upstream-driver
+		 * VMs over Windows Hypervisor.
+		 */
 		ibchc_logwarn("Failure in vma_ibv_get_device_list() (error=%d %m)", errno);
 		ibchc_logwarn("Please check OFED installation");
 		throw_vma_exception("No IB capable devices found!");


### PR DESCRIPTION
Mlx modules are not started on upstream over Windows Hypervisor VMs
after reboot when SRIOV is disabled.
It this case, ibv_get_device_list() will return with an error.
This case is valid for Windows Hypervisor VM's because the modules
will be started automatically during the plugin procedure.

Signed-off-by: Liran Oz <lirano@mellanox.com>