### PR TITLE
issue: 1498311 Fix crash during CQ creation on upstream

### DIFF
--- a/src/vma/dev/cq_mgr.cpp
+++ b/src/vma/dev/cq_mgr.cpp
@@ -74,8 +74,7 @@ atomic_t cq_mgr::m_n_cq_id_counter = ATOMIC_INIT(1);
 
 uint64_t cq_mgr::m_n_global_sn = 0;
 
-cq_mgr::cq_mgr(ring_simple* p_ring, ib_ctx_handler* p_ib_ctx_handler, uint32_t *cq_size,
-		struct ibv_comp_channel* p_comp_event_channel, bool is_rx, bool config /* = true */) :
+cq_mgr::cq_mgr(ring_simple* p_ring, ib_ctx_handler* p_ib_ctx_handler, int cq_size, struct ibv_comp_channel* p_comp_event_channel, bool is_rx, bool config) :
 	m_p_ibv_cq(NULL)
 	,m_b_is_rx(is_rx)
 	,m_cq_id(0)
@@ -124,7 +123,7 @@ cq_mgr::cq_mgr(ring_simple* p_ring, ib_ctx_handler* p_ib_ctx_handler, uint32_t *
 		configure(cq_size);
 }
 
-void cq_mgr::configure(uint32_t *cq_size)
+void cq_mgr::configure(int cq_size)
 {
 	vma_ibv_cq_init_attr attr;
 	memset(&attr, 0, sizeof(attr));
@@ -132,22 +131,7 @@ void cq_mgr::configure(uint32_t *cq_size)
 	prep_ibv_cq(attr);
 
 	m_p_ibv_cq = vma_ibv_create_cq(m_p_ib_ctx_handler->get_ibv_context(),
-			*cq_size - 1, (void *)this, m_comp_event_channel, 0, &attr);
-
-	if (!m_p_ibv_cq && safe_mce_sys().hypervisor == mce_sys_var::HYPER_MSHV && !strncmp(m_p_ib_ctx_handler->get_ibname(), "mlx4", 4)) {
-		// This is a workaround for an issue with cq creation of mlx4 devices on upstream-driver
-		// VMs over Windows Hypervisor.
-		static uint32_t max_upstream_cq_size = 8192;
-		if (*cq_size > max_upstream_cq_size) {
-			cq_logdbg("cq creation failed with cq_size of %d. retrying with size of %d",
-					*cq_size, max_upstream_cq_size);
-
-			*cq_size = max_upstream_cq_size;
-			m_p_ibv_cq = vma_ibv_create_cq(m_p_ib_ctx_handler->get_ibv_context(),
-					*cq_size - 1, (void *)this, m_comp_event_channel, 0, &attr);
-		}
-	}
-
+			cq_size - 1, (void *)this, m_comp_event_channel, 0, &attr);
 	BULLSEYE_EXCLUDE_BLOCK_START
 	if (!m_p_ibv_cq) {
 		cq_logpanic("ibv_create_cq failed (errno=%d %m)", errno);
@@ -184,7 +168,7 @@ void cq_mgr::configure(uint32_t *cq_size)
 		cq_logdbg("RX CSUM support = %d", m_b_is_rx_hw_csum_on);
 	}
 
-	cq_logdbg("Created CQ as %s with fd[%d] and of size %d elements (ibv_cq_hndl=%p)", (m_b_is_rx?"Rx":"Tx"), get_channel_fd(), *cq_size, m_p_ibv_cq);
+	cq_logdbg("Created CQ as %s with fd[%d] and of size %d elements (ibv_cq_hndl=%p)", (m_b_is_rx?"Rx":"Tx"), get_channel_fd(), cq_size, m_p_ibv_cq);
 }
 
 void cq_mgr::prep_ibv_cq(vma_ibv_cq_init_attr& attr) const

--- a/src/vma/dev/cq_mgr.cpp
+++ b/src/vma/dev/cq_mgr.cpp
@@ -134,7 +134,7 @@ void cq_mgr::configure(int cq_size)
 			cq_size - 1, (void *)this, m_comp_event_channel, 0, &attr);
 	BULLSEYE_EXCLUDE_BLOCK_START
 	if (!m_p_ibv_cq) {
-		cq_logpanic("ibv_create_cq failed (errno=%d %m)", errno);
+		throw_vma_exception("ibv_create_cq failed");
 	}
 	BULLSEYE_EXCLUDE_BLOCK_END
 	VALGRIND_MAKE_MEM_DEFINED(m_p_ibv_cq, sizeof(ibv_cq));

--- a/src/vma/dev/cq_mgr.h
+++ b/src/vma/dev/cq_mgr.h
@@ -113,11 +113,11 @@ class cq_mgr
 
 public:
 	cq_mgr(ring_simple *p_ring, ib_ctx_handler *p_ib_ctx_handler,
-	       uint32_t* cq_size, struct ibv_comp_channel *p_comp_event_channel,
-	       bool is_rx, bool config = true);
+	       int cq_size, struct ibv_comp_channel *p_comp_event_channel,
+	       bool is_rx, bool config=true);
 	virtual ~cq_mgr();
 
-	void configure(uint32_t *cq_size);
+	void configure(int cq_size);
 
 	ibv_cq *get_ibv_cq_hndl();
 	int	get_channel_fd();

--- a/src/vma/dev/cq_mgr.h
+++ b/src/vma/dev/cq_mgr.h
@@ -113,11 +113,11 @@ class cq_mgr
 
 public:
 	cq_mgr(ring_simple *p_ring, ib_ctx_handler *p_ib_ctx_handler,
-	       int cq_size, struct ibv_comp_channel *p_comp_event_channel,
-	       bool is_rx, bool config=true);
+	       uint32_t* cq_size, struct ibv_comp_channel *p_comp_event_channel,
+	       bool is_rx, bool config = true);
 	virtual ~cq_mgr();
 
-	void configure(int cq_size);
+	void configure(uint32_t *cq_size);
 
 	ibv_cq *get_ibv_cq_hndl();
 	int	get_channel_fd();

--- a/src/vma/dev/qp_mgr.cpp
+++ b/src/vma/dev/qp_mgr.cpp
@@ -155,13 +155,13 @@ qp_mgr::~qp_mgr()
 cq_mgr* qp_mgr::init_rx_cq_mgr(struct ibv_comp_channel* p_rx_comp_event_channel)
 {
 	qp_logfunc("");
-	return new cq_mgr(m_p_ring, m_p_ib_ctx_handler, &m_rx_num_wr, p_rx_comp_event_channel, true);
+	return new cq_mgr(m_p_ring, m_p_ib_ctx_handler, m_rx_num_wr, p_rx_comp_event_channel, true);
 }
 
 cq_mgr* qp_mgr::init_tx_cq_mgr()
 {
 	qp_logfunc("");
-	return new cq_mgr(m_p_ring, m_p_ib_ctx_handler, &m_tx_num_wr, m_p_ring->get_tx_comp_event_channel(), false);
+	return new cq_mgr(m_p_ring, m_p_ib_ctx_handler, m_tx_num_wr, m_p_ring->get_tx_comp_event_channel(), false);
 }
 
 int qp_mgr::configure(struct ibv_comp_channel* p_rx_comp_event_channel)

--- a/src/vma/dev/qp_mgr.cpp
+++ b/src/vma/dev/qp_mgr.cpp
@@ -155,13 +155,13 @@ qp_mgr::~qp_mgr()
 cq_mgr* qp_mgr::init_rx_cq_mgr(struct ibv_comp_channel* p_rx_comp_event_channel)
 {
 	qp_logfunc("");
-	return new cq_mgr(m_p_ring, m_p_ib_ctx_handler, m_rx_num_wr, p_rx_comp_event_channel, true);
+	return new cq_mgr(m_p_ring, m_p_ib_ctx_handler, &m_rx_num_wr, p_rx_comp_event_channel, true);
 }
 
 cq_mgr* qp_mgr::init_tx_cq_mgr()
 {
 	qp_logfunc("");
-	return new cq_mgr(m_p_ring, m_p_ib_ctx_handler, m_tx_num_wr, m_p_ring->get_tx_comp_event_channel(), false);
+	return new cq_mgr(m_p_ring, m_p_ib_ctx_handler, &m_tx_num_wr, m_p_ring->get_tx_comp_event_channel(), false);
 }
 
 int qp_mgr::configure(struct ibv_comp_channel* p_rx_comp_event_channel)

--- a/src/vma/dev/qp_mgr.cpp
+++ b/src/vma/dev/qp_mgr.cpp
@@ -163,7 +163,7 @@ cq_mgr* qp_mgr::handle_cq_initialization(uint32_t *num_wr, struct ibv_comp_chann
 	} catch (vma_exception& e) {
 		// This is a workaround for an issue with cq creation of mlx4 devices on
 		// upstream-driver VMs over Windows Hypervisor.
-		if (safe_mce_sys().hypervisor == mce_sys_var::HYPER_MSHV && !is_lib_mlx5(m_p_ib_ctx_handler->get_ibname()) &&
+		if (safe_mce_sys().hypervisor == mce_sys_var::HYPER_MSHV && !strncmp(m_p_ib_ctx_handler->get_ibname(), "mlx4", 4) &&
 				*num_wr > MAX_UPSTREAM_CQ_MSHV_SIZE) {
 			qp_logdbg("cq creation failed with cq_size of %d. retrying with size of %d", *num_wr, MAX_UPSTREAM_CQ_MSHV_SIZE);
 			*num_wr = MAX_UPSTREAM_CQ_MSHV_SIZE;

--- a/src/vma/dev/qp_mgr.cpp
+++ b/src/vma/dev/qp_mgr.cpp
@@ -60,6 +60,7 @@
 #define FICTIVE_AH_SL		5
 #define FICTIVE_AH_DLID		0x3
 
+#define MAX_UPSTREAM_CQ_MSHV_SIZE 8192
 
 qp_mgr::qp_mgr(const ring_simple* p_ring, const ib_ctx_handler* p_context,
 		const uint8_t port_num, const uint32_t tx_num_wr):
@@ -152,16 +153,42 @@ qp_mgr::~qp_mgr()
 	qp_logdbg("delete done");
 }
 
-cq_mgr* qp_mgr::init_rx_cq_mgr(struct ibv_comp_channel* p_rx_comp_event_channel)
+cq_mgr* qp_mgr::handle_cq_initialization(uint32_t *num_wr, struct ibv_comp_channel* comp_event_channel, bool is_rx)
 {
 	qp_logfunc("");
-	return new cq_mgr(m_p_ring, m_p_ib_ctx_handler, m_rx_num_wr, p_rx_comp_event_channel, true);
+	cq_mgr* cq = NULL;
+
+	try {
+		cq = new cq_mgr(m_p_ring, m_p_ib_ctx_handler, *num_wr, comp_event_channel, is_rx);
+	} catch (vma_exception& e) {
+		// This is a workaround for an issue with cq creation of mlx4 devices on
+		// upstream-driver VMs over Windows Hypervisor.
+		if (safe_mce_sys().hypervisor == mce_sys_var::HYPER_MSHV && !is_lib_mlx5(m_p_ib_ctx_handler->get_ibname()) &&
+				*num_wr > MAX_UPSTREAM_CQ_MSHV_SIZE) {
+			qp_logdbg("cq creation failed with cq_size of %d. retrying with size of %d", *num_wr, MAX_UPSTREAM_CQ_MSHV_SIZE);
+			*num_wr = MAX_UPSTREAM_CQ_MSHV_SIZE;
+			try {
+				cq = new cq_mgr(m_p_ring, m_p_ib_ctx_handler, *num_wr, comp_event_channel, is_rx);
+			} catch (vma_exception&) {
+			}
+		}
+
+		if (!cq) {
+			qp_logerr("%s", e.message);
+		}
+	}
+
+	return cq;
+}
+
+cq_mgr* qp_mgr::init_rx_cq_mgr(struct ibv_comp_channel* p_rx_comp_event_channel)
+{
+	return handle_cq_initialization(&m_rx_num_wr, p_rx_comp_event_channel, true);
 }
 
 cq_mgr* qp_mgr::init_tx_cq_mgr()
 {
-	qp_logfunc("");
-	return new cq_mgr(m_p_ring, m_p_ib_ctx_handler, m_tx_num_wr, m_p_ring->get_tx_comp_event_channel(), false);
+	return handle_cq_initialization(&m_tx_num_wr, m_p_ring->get_tx_comp_event_channel(), false);
 }
 
 int qp_mgr::configure(struct ibv_comp_channel* p_rx_comp_event_channel)

--- a/src/vma/dev/qp_mgr.h
+++ b/src/vma/dev/qp_mgr.h
@@ -197,6 +197,8 @@ protected:
 	virtual cq_mgr* init_rx_cq_mgr(struct ibv_comp_channel* p_rx_comp_event_channel);
 	virtual cq_mgr* init_tx_cq_mgr(void);
 
+	cq_mgr* handle_cq_initialization(uint32_t *num_wr, struct ibv_comp_channel* comp_event_channel, bool is_rx);
+
 	virtual int     post_qp_create(void) { return 0;};
 	virtual int     send_to_wire(vma_ibv_send_wr* p_send_wqe, vma_wr_tx_packet_attr attr, bool request_comp);
 	virtual bool    is_completion_need() { return !m_n_unsignaled_count; };


### PR DESCRIPTION
Following a bug on upstream-driver VMs over Windows Hypervisor
for mlx4 devices, creation of CQ with size > 8192 is not supported.
This commits avoid this crash by reducing the size of CQ to 8192.

Signed-off-by: Liran Oz <lirano@mellanox.com>