### PR TITLE
issue: 1540483 Add flow tag support for upstream

### DIFF
--- a/config/m4/verbs.m4
+++ b/config/m4/verbs.m4
@@ -125,6 +125,7 @@ CHECK_VERBS_ATTRIBUTE([IBV_QP_CREATE_SOURCE_QPN], [infiniband/verbs.h], [IBV_QP_
 CHECK_VERBS_ATTRIBUTE([IBV_FLOW_SPEC_IB], [infiniband/verbs.h], [IBV_FLOW_SPEC_IB])
 CHECK_VERBS_ATTRIBUTE([IBV_DEVICE_RAW_IP_CSUM], [infiniband/verbs.h])
 CHECK_VERBS_ATTRIBUTE([IBV_SEND_IP_CSUM], [infiniband/verbs.h])
+CHECK_VERBS_ATTRIBUTE([IBV_FLOW_SPEC_ACTION_TAG], [infiniband/verbs.h], [IBV_FLOW_TAG])
 
 # Check <verbs_exp.h>
 #
@@ -156,7 +157,7 @@ if test "x$vma_cv_verbs" == x2; then
         CHECK_VERBS_ATTRIBUTE([IBV_EXP_VALUES_CLOCK_INFO], [infiniband/verbs_exp.h])
         CHECK_VERBS_ATTRIBUTE([IBV_EXP_DEVICE_RX_CSUM_L4_PKT], [infiniband/verbs_exp.h])
         CHECK_VERBS_ATTRIBUTE([IBV_EXP_DEVICE_RX_CSUM_TCP_UDP_PKT], [infiniband/verbs_exp.h])
-        CHECK_VERBS_ATTRIBUTE([IBV_EXP_FLOW_SPEC_ACTION_TAG], [infiniband/verbs_exp.h], [IBV_EXP_FLOW_TAG])
+        CHECK_VERBS_ATTRIBUTE([IBV_EXP_FLOW_SPEC_ACTION_TAG], [infiniband/verbs_exp.h], [IBV_FLOW_TAG])
     )
 
     have_mp_rq=yes

--- a/src/vma/ib/base/verbs_extra.cpp
+++ b/src/vma/ib/base/verbs_extra.cpp
@@ -276,7 +276,7 @@ int priv_ibv_query_flow_tag_supported(struct ibv_qp *qp, uint8_t port_num)
 	NOT_IN_USE(port_num);
 	int res = -1;
 
-#ifdef DEFINED_IBV_EXP_FLOW_TAG
+#ifdef DEFINED_IBV_FLOW_TAG
 
 	// Create
 	struct __attribute__ ((packed)) {
@@ -313,7 +313,7 @@ int priv_ibv_query_flow_tag_supported(struct ibv_qp *qp, uint8_t port_num)
 		res = 0;
 		vma_ibv_destroy_flow(ibv_flow);
 	}
-#endif // DEFINED_IBV_EXP_FLOW_TAG
+#endif // DEFINED_IBV_FLOW_TAG
 
 	return res;
 }

--- a/src/vma/ib/base/verbs_extra.h
+++ b/src/vma/ib/base/verbs_extra.h
@@ -203,8 +203,16 @@ typedef struct ibv_flow_spec_ib			vma_ibv_flow_spec_ib;
 typedef struct ibv_flow_spec_eth		vma_ibv_flow_spec_eth;
 typedef struct ibv_flow_spec_ipv4		vma_ibv_flow_spec_ipv4;
 typedef struct ibv_flow_spec_tcp_udp		vma_ibv_flow_spec_tcp_udp;
-#define vma_get_flow_tag(cqe)			0
-typedef struct ibv_exp_flow_spec_action_tag_dummy {}	vma_ibv_flow_spec_action_tag;
+
+// Flow tag
+#ifdef DEFINED_IBV_FLOW_TAG
+#define VMA_IBV_FLOW_SPEC_ACTION_TAG               IBV_FLOW_SPEC_ACTION_TAG
+typedef struct ibv_flow_spec_action_tag            vma_ibv_flow_spec_action_tag;
+#define vma_get_flow_tag(cqe)                      ntohl((uint32_t)(cqe->sop_drop_qpn))
+#else
+typedef struct ibv_flow_spec_action_tag_dummy {}   vma_ibv_flow_spec_action_tag;
+#define vma_get_flow_tag(cqe)                      0
+#endif // DEFINED_IBV_FLOW_TAG
 
 #ifdef DEFINED_IBV_CQ_ATTR_MODERATE
 typedef struct ibv_modify_cq_attr               vma_ibv_cq_attr;
@@ -346,14 +354,16 @@ typedef struct ibv_exp_flow_spec_ib		vma_ibv_flow_spec_ib;
 typedef struct ibv_exp_flow_spec_eth		vma_ibv_flow_spec_eth;
 typedef struct ibv_exp_flow_spec_ipv4		vma_ibv_flow_spec_ipv4;
 typedef struct ibv_exp_flow_spec_tcp_udp	vma_ibv_flow_spec_tcp_udp;
+
 //Flow tag
-#ifdef DEFINED_IBV_EXP_FLOW_TAG
-#define vma_get_flow_tag(wc)			ntohl((uint32_t)(wc->sop_drop_qpn))
-typedef struct ibv_exp_flow_spec_action_tag	vma_ibv_flow_spec_action_tag;
+#ifdef DEFINED_IBV_FLOW_TAG
+#define VMA_IBV_FLOW_SPEC_ACTION_TAG                    IBV_EXP_FLOW_SPEC_ACTION_TAG
+#define vma_get_flow_tag(cqe)                           ntohl((uint32_t)(cqe->sop_drop_qpn))
+typedef struct ibv_exp_flow_spec_action_tag             vma_ibv_flow_spec_action_tag;
 #else
-#define vma_get_flow_tag(cqe)			0
-typedef struct ibv_exp_flow_spec_action_tag_dummy {}	vma_ibv_flow_spec_action_tag;
-#endif //DEFINED_IBV_EXP_FLOW_TAG
+#define vma_get_flow_tag(cqe)                           0
+typedef struct ibv_exp_flow_spec_action_tag_dummy {}    vma_ibv_flow_spec_action_tag;
+#endif //DEFINED_IBV_FLOW_TAG
 
 #endif /* DEFINED_VERBS_VERSION */
 
@@ -473,11 +483,11 @@ static inline void ibv_flow_spec_flow_tag_set(vma_ibv_flow_spec_action_tag* flow
 	NOT_IN_USE(tag_id);
 	if (flow_tag == NULL)
 		return;
-#ifdef DEFINED_IBV_EXP_FLOW_TAG
-	flow_tag->type = IBV_EXP_FLOW_SPEC_ACTION_TAG;
+#ifdef DEFINED_IBV_FLOW_TAG
+	flow_tag->type = VMA_IBV_FLOW_SPEC_ACTION_TAG;
 	flow_tag->size = sizeof(vma_ibv_flow_spec_action_tag);
 	flow_tag->tag_id = tag_id;
-#endif //DEFINED_IBV_EXP_FLOW_TAG
+#endif //DEFINED_IBV_FLOW_TAG
 }
 
 


### PR DESCRIPTION
This feature enables a substantial reduction of deep
packet inspection during RFS dispatch.
Supported for mlx5 (and above) devices.

Signed-off-by: Liran Oz <lirano@mellanox.com>