### PR TITLE
issue: 1513181 Increased FID_MAX for daemon

### DIFF
--- a/tools/daemon/daemon.h
+++ b/tools/daemon/daemon.h
@@ -72,7 +72,7 @@
 
 #define PID_MAX         499    /**< Default maximum number of processes
                                     per node (should be prime number) */
-#define FID_MAX         2203   /**< Default maximum number of sockets
+#define FID_MAX         65599  /**< Default maximum number of sockets
                                     per process (should be prime number) */
 
 #ifndef HAVE_LINUX_LIMITS_H


### PR DESCRIPTION
FID_MAX default value is increased to provide better out of box
solution. End user has a way to configure daemon for his application
using --fid command line option.
64K default value seems fine as far as there is C10k problem.

Signed-off-by: Igor Ivanov <igor.ivanov.va@gmail.com>