### PR TITLE
issue: 1523707 Fix deadlock collision for ring_tap

### DIFF
--- a/src/vma/dev/cq_mgr.cpp
+++ b/src/vma/dev/cq_mgr.cpp
@@ -227,7 +227,7 @@ cq_mgr::~cq_mgr()
 
 	cq_logfunc("destroying ibv_cq");
 	IF_VERBS_FAILURE_EX(ibv_destroy_cq(m_p_ibv_cq), EIO) {
-		cq_logerr("destroy cq failed (errno=%d %m)", errno);
+		cq_logdbg("destroy cq failed (errno=%d %m)", errno);
 	} ENDIF_VERBS_FAILURE;
 	VALGRIND_MAKE_MEM_UNDEFINED(m_p_ibv_cq, sizeof(ibv_cq));
 	

--- a/src/vma/dev/qp_mgr.cpp
+++ b/src/vma/dev/qp_mgr.cpp
@@ -345,7 +345,7 @@ void qp_mgr::release_rx_buffers()
 	uintptr_t last_polled_rx_wr_id = 0;
 	while (m_p_cq_mgr_rx &&
 			last_polled_rx_wr_id != m_last_posted_rx_wr_id &&
-			errno != EIO) {
+			(errno != EIO && !m_p_ib_ctx_handler->is_removed())) {
 
 		// Process the FLUSH'ed WQE's
 		int ret = m_p_cq_mgr_rx->drain_and_proccess(&last_polled_rx_wr_id);
@@ -368,7 +368,7 @@ void qp_mgr::release_tx_buffers()
 	qp_logdbg("draining tx cq_mgr %p", m_p_cq_mgr_tx);
 	while (m_p_cq_mgr_tx && m_qp &&
 			((ret = m_p_cq_mgr_tx->poll_and_process_element_tx(&poll_sn)) > 0) &&
-			errno != EIO) {
+			(errno != EIO && !m_p_ib_ctx_handler->is_removed())) {
 		qp_logdbg("draining completed on tx cq_mgr (%d wce)", ret);
 	}
 }

--- a/src/vma/dev/ring_tap.cpp
+++ b/src/vma/dev/ring_tap.cpp
@@ -1262,6 +1262,7 @@ mem_buf_desc_t* ring_tap::mem_buf_tx_get(ring_user_id_t id, bool b_block, int n_
 		request_more_tx_buffers();
 
 		if (unlikely((int)m_tx_pool.size() < n_num_mem_bufs)) {
+			m_lock_ring_tx.unlock();
 			return head;
 		}
 	}


### PR DESCRIPTION
During intensive outgoing traffic it is possible that
number of free buffers are empty and as a result tx pool
can not give new buffer. Error processing in this case
missed unlock.

Signed-off-by: Igor Ivanov <igor.ivanov.va@gmail.com>