### PR TITLE
issue: 1552382 Redirect ioctl SIOCGIFVLAN

### DIFF
--- a/src/vma/sock/sockinfo.cpp
+++ b/src/vma/sock/sockinfo.cpp
@@ -35,6 +35,7 @@
 
 #include <sys/epoll.h>
 #include <netdb.h>
+#include <linux/sockios.h>
 
 #include "utils/bullseye.h"
 #include "vlogger/vlogger.h"
@@ -215,7 +216,8 @@ int sockinfo::ioctl(unsigned long int __request, unsigned long int __arg)
 			return ret;
 		}
 		break;
-
+	case SIOCGIFVLAN: /* prevent error print */
+		break;
 	default:
 		char buf[128];
 		snprintf(buf, sizeof(buf), "unimplemented ioctl request=%#x, flags=%#x", (unsigned)__request, (unsigned)__arg);


### PR DESCRIPTION
This change will prevent error print when using this ioctl
when VMA_EXCEPTION_HANDLING=2.

Signed-off-by: Rafi Wiener <rafiw@mellanox.com>