### PR TITLE
issue: 1072998 memory leak in tcp event timer

### DIFF
--- a/contrib/valgrind/valgrind_vma.supp
+++ b/contrib/valgrind/valgrind_vma.supp
@@ -45,15 +45,6 @@
    fun:do_global_ctors_helper
    fun:_Z15do_global_ctorsv
 }
-{
-   RM #1072998
-   Memcheck:Leak
-   match-leak-kinds: definite
-   fun:malloc
-   fun:_ZN21event_handler_manager20register_timer_eventEiP13timer_handler16timer_req_type_tPvP12timers_group
-   fun:_ZN12sockinfo_tcp14register_timerEv
-   fun:_ZN12sockinfo_tcp7connectEPK8sockaddrj
-}
 ###########################################################
 # false positive librdmacm.so
 {


### PR DESCRIPTION
Remove valgrind ignore for issue 1072998 memory leak in tcp event
timer from suppressions file

Signed-off-by: Mohammad Qurt <mohammadq@mellanox.com>