### PR TITLE
issue: 1554637 Modify NetVSC device detection

### DIFF
--- a/src/vma/dev/ib_ctx_handler_collection.cpp
+++ b/src/vma/dev/ib_ctx_handler_collection.cpp
@@ -94,11 +94,6 @@ void ib_ctx_handler_collection::update_tbl(const char *ifa_name)
 
 	BULLSEYE_EXCLUDE_BLOCK_START
 	if (!dev_list) {
-		if (safe_mce_sys().hypervisor == mce_sys_var::HYPER_MSHV) {
-			 // MLX modules are not started after reboot when SRIOV is disabled on upstream-driver
-			 // VMs over Windows Hypervisor.
-			goto out;
-		}
 		ibchc_logwarn("Failure in vma_ibv_get_device_list() (error=%d %m)", errno);
 		ibchc_logwarn("Please check OFED installation");
 		throw_vma_exception("No IB capable devices found!");
@@ -142,7 +137,6 @@ void ib_ctx_handler_collection::update_tbl(const char *ifa_name)
 		m_ib_ctx_map[p_ib_ctx_handler->get_ibv_device()] = p_ib_ctx_handler;
 	}
 
-out:
 	ibchc_logdbg("Check completed. Found %d offload capable IB devices", m_ib_ctx_map.size());
 
 	if (dev_list) {

--- a/src/vma/dev/ib_ctx_handler_collection.cpp
+++ b/src/vma/dev/ib_ctx_handler_collection.cpp
@@ -94,15 +94,14 @@ void ib_ctx_handler_collection::update_tbl(const char *ifa_name)
 
 	BULLSEYE_EXCLUDE_BLOCK_START
 	if (!dev_list) {
-		ibchc_logwarn("Failure in vma_ibv_get_device_list() (error=%d %m)", errno);
-		ibchc_logwarn("Please check OFED installation");
+		ibchc_logerr("Failure in vma_ibv_get_device_list() (error=%d %m)", errno);
+		ibchc_logerr("Please check rdma configuration");
 		throw_vma_exception("No IB capable devices found!");
 	}
 	if (!num_devices) {
-		ibchc_logdbg("*************************************************************");
-		ibchc_logdbg("* VMA does not detect IB capable devices                    *");
-		ibchc_logdbg("* No performance gain is expected in current configuration  *");
-		ibchc_logdbg("*************************************************************");
+		vlog_levels_t _level = ifa_name ? VLOG_DEBUG : VLOG_ERROR; // Print an error only during initialization.
+		vlog_printf(_level, "VMA does not detect IB capable devices\n");
+		vlog_printf(_level, "No performance gain is expected in current configuration\n");
 	}
 
 	BULLSEYE_EXCLUDE_BLOCK_END

--- a/src/vma/dev/net_device_val.cpp
+++ b/src/vma/dev/net_device_val.cpp
@@ -245,7 +245,7 @@ net_device_val::net_device_val(struct net_device_val_desc *desc) : m_lock("net_d
 		if (get_type() == ARPHRD_ETHER) {
 			char slave_ifname[IFNAMSIZ] = {0};
 			unsigned int slave_flags = 0;
-			valid = true; /* it is valid flow to operate w/o SRIOV */
+			/* valid = true; uncomment it is valid flow to operate w/o SRIOV */
 			if (get_netvsc_slave(get_ifname_link(), slave_ifname, slave_flags)) {
 				valid = verify_qp_creation(slave_ifname, IBV_QPT_RAW_PACKET);
 			}


### PR DESCRIPTION
VMA will offload a NetVSC device (Windows Hyper-V network driver)
only if SRIOV is enabled at the initialization time.

Signed-off-by: Liran Oz <lirano@mellanox.com>