### PR TITLE
issue: 1557681 Fix timer converter Segmentation fault

### DIFF
--- a/src/vma/dev/ib_ctx_handler.cpp
+++ b/src/vma/dev/ib_ctx_handler.cpp
@@ -198,7 +198,7 @@ ib_ctx_handler::~ib_ctx_handler()
 		m_p_ibv_pd = NULL;
 	}
 
-	delete m_p_ctx_time_converter;
+	m_p_ctx_time_converter->clean_obj();
 	delete m_p_ibv_device_attr;
 
 	ibv_close_device(m_p_ibv_context);

--- a/src/vma/dev/time_converter.cpp
+++ b/src/vma/dev/time_converter.cpp
@@ -141,3 +141,14 @@ ts_conversion_mode_t time_converter::get_devices_converter_status(struct ibv_dev
 	return ctx_time_conversion_mode;
 }
 
+void time_converter::clean_obj()
+{
+	set_cleaned();
+
+	if (m_timer_handle) {
+		g_p_event_handler_manager->unregister_timers_event_and_delete(this);
+		m_timer_handle = NULL;
+	} else {
+		cleanable_obj::clean_obj();
+	}
+}

--- a/src/vma/dev/time_converter.cpp
+++ b/src/vma/dev/time_converter.cpp
@@ -145,7 +145,7 @@ void time_converter::clean_obj()
 {
 	set_cleaned();
 
-	if (m_timer_handle) {
+	if (m_timer_handle && g_p_event_handler_manager->is_running()) {
 		g_p_event_handler_manager->unregister_timers_event_and_delete(this);
 		m_timer_handle = NULL;
 	} else {

--- a/src/vma/dev/time_converter.h
+++ b/src/vma/dev/time_converter.h
@@ -35,6 +35,7 @@
 #define TIME_CONVERTER_H
 
 #include <infiniband/verbs.h>
+#include <vma/sock/cleanable_obj.h>
 #include "vma/event/timer_handler.h"
 #include <vma/util/sys_vars.h>
 
@@ -52,19 +53,21 @@ public:
 	}
 };
 
-class time_converter : public timer_handler
+class time_converter : public timer_handler, public cleanable_obj
 {
 public:
-	time_converter(): m_converter_status(TS_CONVERSION_MODE_DISABLE) {};
+	time_converter(): m_timer_handle(NULL), m_converter_status(TS_CONVERSION_MODE_DISABLE) {};
 	virtual ~time_converter() = 0;
 
 	virtual void              convert_hw_time_to_system_time(uint64_t hwtime, struct timespec* systime) = 0;
 	virtual void              handle_timer_expired(void* user_data) = 0;
+	virtual void              clean_obj();
 	ts_conversion_mode_t      get_converter_status() { return m_converter_status; };
 
 	static ts_conversion_mode_t     get_devices_converter_status(struct ibv_device** ibv_dev_list, int num_devices);
 
 protected:
+	void*                     m_timer_handle;
 	ts_conversion_mode_t      m_converter_status;
 
 	static uint32_t           get_single_converter_status(struct ibv_context* ctx);

--- a/src/vma/dev/time_converter_ib_ctx.cpp
+++ b/src/vma/dev/time_converter_ib_ctx.cpp
@@ -53,7 +53,7 @@
 #define IB_CTX_TC_DEVIATION_THRESHOLD 10
 
 time_converter_ib_ctx::time_converter_ib_ctx(struct ibv_context* ctx, ts_conversion_mode_t ctx_time_converter_mode, uint64_t hca_core_clock) :
-	m_timer_handle(NULL), m_p_ibv_context(ctx), m_ctx_parmeters_id(0)
+	m_p_ibv_context(ctx), m_ctx_parmeters_id(0)
 {
 #ifdef DEFINED_IBV_CQ_TIMESTAMP
 	if (ctx_time_converter_mode != TS_CONVERSION_MODE_DISABLE) {
@@ -81,15 +81,13 @@ time_converter_ib_ctx::time_converter_ib_ctx(struct ibv_context* ctx, ts_convers
 	}
 }
 
-time_converter_ib_ctx::~time_converter_ib_ctx() {
-	if (m_timer_handle) {
-		g_p_event_handler_manager->unregister_timer_event(this, m_timer_handle);
-		m_timer_handle = NULL;
-	}
-}
-
 void time_converter_ib_ctx::handle_timer_expired(void* user_data) {
 	NOT_IN_USE(user_data);
+
+	if (is_cleaned()) {
+		return;
+	}
+
 	fix_hw_clock_deviation();
 }
 

--- a/src/vma/dev/time_converter_ib_ctx.h
+++ b/src/vma/dev/time_converter_ib_ctx.h
@@ -44,14 +44,13 @@ class time_converter_ib_ctx : public time_converter
 public:
 	time_converter_ib_ctx(struct ibv_context* ctx, ts_conversion_mode_t ctx_time_converter_mode, uint64_t hca_core_clock);
 
-	virtual ~time_converter_ib_ctx();
+	virtual ~time_converter_ib_ctx() {};
 
 	void                      convert_hw_time_to_system_time(uint64_t hwtime, struct timespec* systime);
 	void                      handle_timer_expired(void* user_data);
 	uint64_t                  get_hca_core_clock();
 
 private:
-	void*                     m_timer_handle;
 	struct ibv_context*       m_p_ibv_context;
 	ctx_timestamping_params_t m_ctx_convert_parmeters[2];
 	int                       m_ctx_parmeters_id;

--- a/src/vma/dev/time_converter_ptp.cpp
+++ b/src/vma/dev/time_converter_ptp.cpp
@@ -55,7 +55,7 @@
 
 
 time_converter_ptp::time_converter_ptp(struct ibv_context* ctx) :
-	m_timer_handle(NULL), m_p_ibv_context(ctx), m_ibv_exp_values_id(0)
+	m_p_ibv_context(ctx), m_ibv_exp_values_id(0)
 {
 	for (size_t i=0; i < ARRAY_SIZE(m_ibv_exp_values); i++) {
 		memset(&m_ibv_exp_values[i], 0, sizeof(m_ibv_exp_values[i]));
@@ -69,15 +69,13 @@ time_converter_ptp::time_converter_ptp(struct ibv_context* ctx) :
 	m_converter_status = TS_CONVERSION_MODE_PTP;
 }
 
-time_converter_ptp::~time_converter_ptp() {
-	if (m_timer_handle) {
-		g_p_event_handler_manager->unregister_timer_event(this, m_timer_handle);
-		m_timer_handle = NULL;
-	}
-}
-
 void time_converter_ptp::handle_timer_expired(void* user_data) {
+
 	NOT_IN_USE(user_data);
+
+	if (is_cleaned()) {
+		return;
+	}
 
 	int ret = 0;
 	ret = ibv_exp_query_values(m_p_ibv_context, IBV_EXP_VALUES_CLOCK_INFO, &m_ibv_exp_values[1 - m_ibv_exp_values_id]);

--- a/src/vma/dev/time_converter_ptp.h
+++ b/src/vma/dev/time_converter_ptp.h
@@ -45,13 +45,12 @@ class time_converter_ptp : public time_converter
 {
 public:
 	time_converter_ptp(struct ibv_context* ctx);
-	virtual ~time_converter_ptp();
+	virtual ~time_converter_ptp() {};
 
 	inline void               convert_hw_time_to_system_time(uint64_t hwtime, struct timespec* systime);
 	virtual void              handle_timer_expired(void* user_data);
 
 private:
-	void*                     m_timer_handle;
 	struct ibv_context*       m_p_ibv_context;
 
 	struct ibv_exp_values     m_ibv_exp_values[2];

--- a/src/vma/event/event_handler_manager.h
+++ b/src/vma/event/event_handler_manager.h
@@ -173,6 +173,7 @@ public:
 
 	void*   thread_loop();
 	void    stop_thread();
+	bool    is_running() {return m_b_continue_running; };
 
 	void    update_epfd(int fd, int operation, int events);
 


### PR DESCRIPTION
Time converter object was destroyed during plugout without cleaning
it from the internal thread's timer list.

Signed-off-by: Liran Oz <lirano@mellanox.com>