### PR TITLE
issue: 1540213 Print warning while mlx4 RoCE lag is enabled

### DIFF
--- a/src/vma/util/sys_vars.h
+++ b/src/vma/util/sys_vars.h
@@ -708,7 +708,7 @@ extern mce_sys_var & safe_mce_sys();
 #define BONDING_ACTIVE_SLAVE_PARAM_FILE			"/sys/class/net/%s/bonding/active_slave"
 #define BONDING_FAILOVER_MAC_PARAM_FILE			"/sys/class/net/%s/bonding/fail_over_mac"
 #define BONDING_XMIT_HASH_POLICY_PARAM_FILE		"/sys/class/net/%s/bonding/xmit_hash_policy"
-#define BONDING_ROCE_LAG_FILE				"/sys/class/net/%s/slave_%s/device/roce_lag_enable"
+#define BONDING_ROCE_LAG_FILE				"/sys/class/net/%s/device/roce_lag_enable"
 /* BONDING_SLAVE_STATE_PARAM_FILE is for kernel  > 3.14 or RH7.2 and higher */
 #define BONDING_SLAVE_STATE_PARAM_FILE			"/sys/class/net/%s/bonding_slave/state"
 #define L2_ADDR_FILE_FMT                                "/sys/class/net/%.*s/address"

--- a/src/vma/util/utils.cpp
+++ b/src/vma/util/utils.cpp
@@ -779,10 +779,10 @@ bool get_bond_active_slave_name(IN const char* bond_name, OUT char* active_slave
 	return true;
 }
 
-bool check_bond_roce_lag_exist(OUT char* bond_roce_lag_path, int sz, IN const char* bond_name, IN const char* slave_name)
+bool check_bond_roce_lag_exist(OUT char* bond_roce_lag_path, int sz, IN const char* slave_name)
 {
 	char sys_res[1024] = {0};
-	snprintf(bond_roce_lag_path, sz, BONDING_ROCE_LAG_FILE, bond_name, slave_name);
+	snprintf(bond_roce_lag_path, sz, BONDING_ROCE_LAG_FILE, slave_name);
 	if (priv_read_file(bond_roce_lag_path, sys_res, 1024, VLOG_FUNC) > 0) {
 		if (strtol(sys_res, NULL,10) > 0 && errno != ERANGE) {
 			return true;

--- a/src/vma/util/utils.h
+++ b/src/vma/util/utils.h
@@ -301,7 +301,7 @@ size_t get_local_ll_addr(const char* ifname, unsigned char* addr, int addr_len, 
 bool get_bond_active_slave_name(IN const char* bond_name, OUT char* active_slave_name, IN int sz);
 bool get_bond_slave_state(IN const char* slave_name, OUT char* curr_state, IN int sz);
 bool get_bond_slaves_name_list(IN const char* bond_name, OUT char* slaves_list, IN int sz);
-bool check_bond_roce_lag_exist(OUT char* bond_roce_lag_path, int sz, IN const char* bond_name, IN const char* slave_name);
+bool check_bond_roce_lag_exist(OUT char* bond_roce_lag_path, int sz, IN const char* slave_name);
 bool check_device_exist(const char* ifname, const char *path);
 bool check_device_name_ib_name(const char* ifname, const char* ibname);
 bool check_netvsc_device_exist(const char* ifname);


### PR DESCRIPTION
RoCE lag is not supported by VMA. while enabled, VMA should
print a relevant warning and refer the user to the Release Notes.

Signed-off-by: Liran Oz <lirano@mellanox.com>