### PR TITLE
issue: 1564259 Fix IP_TTL socket option inheritance

### DIFF
--- a/src/vma/sock/sockinfo_tcp.cpp
+++ b/src/vma/sock/sockinfo_tcp.cpp
@@ -105,6 +105,11 @@ static bool is_inherited_option(int __level, int __optname)
 		case TCP_NODELAY:
 			ret = true;
 		}
+	} else if (__level == IPPROTO_IP) {
+		switch (__optname) {
+		case IP_TTL:
+			ret = true;
+		}
 	}
 
 	return ret;


### PR DESCRIPTION
IP_TTL value should be inherited from the listen socket.

Signed-off-by: Liran Oz <lirano@mellanox.com>