### PR TITLE
issue: 1566916 Fix CQ cleanup ordering issue

### DIFF
--- a/src/vma/dev/cq_mgr.cpp
+++ b/src/vma/dev/cq_mgr.cpp
@@ -309,6 +309,8 @@ void cq_mgr::del_qp_rx(qp_mgr *qp)
 	BULLSEYE_EXCLUDE_BLOCK_END
 	cq_logdbg("qp_mgr=%p", m_qp_rec.qp);
 	return_extra_buffers();
+
+	clean_cq();
 	memset(&m_qp_rec, 0, sizeof(m_qp_rec));
 }
 

--- a/src/vma/dev/qp_mgr.cpp
+++ b/src/vma/dev/qp_mgr.cpp
@@ -109,9 +109,6 @@ qp_mgr::~qp_mgr()
 {
 	qp_logfunc("");
 
-	if (m_p_cq_mgr_rx) {
-		m_p_cq_mgr_rx->clean_cq();
-	}
 	qp_logdbg("calling ibv_destroy_qp(qp=%p)", m_qp);
 	if (m_qp) {
 		IF_VERBS_FAILURE_EX(ibv_destroy_qp(m_qp), EIO) {


### PR DESCRIPTION
Bug:
qp_mgr->down() and del_qp_rx() for RX CQ that reinitializes m_qp_rec
that is used during ~qp_mgr() inside clean_cq() for RX CQ.

Signed-off-by: Igor Ivanov <igor.ivanov.va@gmail.com>