### PR TITLE
issue: 1575618 Modify add_conf_rule() input param type

### DIFF
--- a/src/vma/config_parser.c
+++ b/src/vma/config_parser.c
@@ -2204,12 +2204,13 @@ int __vma_parse_config_file (const char *fileName) {
 	return(parse_err);
 }
 
-int __vma_parse_config_line (char *line) {
+int __vma_parse_config_line (const char *line) {
 	extern FILE * libvma_yyin;
 	
 	__vma_rule_push_head = 1;
 	
-	libvma_yyin = fmemopen(line, strlen(line), "r");
+	/* The below casting is valid because we open the stream as read-only. */
+	libvma_yyin = fmemopen((void*)line, strlen(line), "r");
 	
 	if (!libvma_yyin) {
 		printf("libvma Error: Fail to parse line:%s\n", line);

--- a/src/vma/sock/sock-redirect.cpp
+++ b/src/vma/sock/sock-redirect.cpp
@@ -552,7 +552,7 @@ int vma_get_socket_tx_ring_fd(int sock_fd, struct sockaddr *to, socklen_t tolen)
 }
 
 extern "C"
-int vma_add_conf_rule(char *config_line)
+int vma_add_conf_rule(const char *config_line)
 {
 	srdr_logdbg("adding conf rule: %s", config_line);
 

--- a/src/vma/util/libvma.h
+++ b/src/vma/util/libvma.h
@@ -278,7 +278,7 @@ int __vma_config_empty(void);
 
 int __vma_parse_config_file(const char *config_file);
 
-int __vma_parse_config_line(char *config_line);
+int __vma_parse_config_line(const char *config_line);
 
 void __vma_print_conf_file(struct dbl_lst conf_lst);
 

--- a/src/vma/vma_extra.h
+++ b/src/vma/vma_extra.h
@@ -517,7 +517,7 @@ struct __attribute__ ((packed)) vma_api_t {
 	 * @param config_line A char buffer with the exact format as defined in libvma.conf, and should end with '\0'.
 	 * @return 0 on success, or error code on failure.
 	 */
-	int (*add_conf_rule)(char *config_line);
+	int (*add_conf_rule)(const char *config_line);
 
 
 	/*


### PR DESCRIPTION
Modify config_line input parameter of add_conf_rule() to
const char * instead of char *.

Signed-off-by: Liran Oz <lirano@mellanox.com>