### PR TITLE
issue: 1592040 Add mlx5 Dummy-send support for upstream

### DIFF
--- a/config/m4/verbs.m4
+++ b/config/m4/verbs.m4
@@ -138,7 +138,7 @@ CHECK_VERBS_MEMBER([struct ibv_device_attr_ex.orig_attr], [infiniband/verbs.h], 
 #
 if test "x$vma_cv_verbs" == x2; then
     CHECK_VERBS_ATTRIBUTE([IBV_EXP_CQ_MODERATION], [infiniband/verbs_exp.h], [IBV_CQ_ATTR_MODERATE])
-    CHECK_VERBS_ATTRIBUTE([IBV_EXP_WR_NOP], [infiniband/verbs_exp.h])
+    CHECK_VERBS_ATTRIBUTE([IBV_EXP_WR_NOP], [infiniband/verbs_exp.h], [IBV_WR_NOP])
     CHECK_VERBS_ATTRIBUTE([IBV_EXP_ACCESS_ALLOCATE_MR], [infiniband/verbs_exp.h])
     CHECK_VERBS_ATTRIBUTE([IBV_EXP_QP_INIT_ATTR_ASSOCIATED_QPN], [infiniband/verbs_exp.h], [IBV_QP_INIT_SOURCE_QPN])
     CHECK_VERBS_ATTRIBUTE([IBV_EXP_FLOW_SPEC_IB], [infiniband/verbs_exp.h], [IBV_FLOW_SPEC_IB])
@@ -196,6 +196,12 @@ if test "x$vma_cv_verbs" == x2; then
 
     AC_CHECK_FUNCS([rdma_lib_reset])
     AC_CHECK_FUNCS([ibv_exp_get_device_list])
+fi
+
+# Check <mlx5dv.h>
+#
+if test "x$vma_cv_verbs" == x3; then
+    CHECK_VERBS_ATTRIBUTE([MLX5_OPCODE_NOP], [infiniband/mlx5dv.h], [IBV_WR_NOP])
 fi
 
 # Restore LIBS

--- a/config/m4/verbs.m4
+++ b/config/m4/verbs.m4
@@ -198,10 +198,12 @@ if test "x$vma_cv_verbs" == x2; then
     AC_CHECK_FUNCS([ibv_exp_get_device_list])
 fi
 
-# Check <mlx5dv.h>
+# Check Upstream
 #
 if test "x$vma_cv_verbs" == x3; then
-    CHECK_VERBS_ATTRIBUTE([MLX5_OPCODE_NOP], [infiniband/mlx5dv.h], [IBV_WR_NOP])
+    if test "x$vma_cv_directverbs" == x3; then
+        CHECK_VERBS_ATTRIBUTE([MLX5_OPCODE_NOP], [infiniband/mlx5dv.h], [IBV_WR_NOP])
+    fi
 fi
 
 # Restore LIBS

--- a/src/vma/dev/qp_mgr.cpp
+++ b/src/vma/dev/qp_mgr.cpp
@@ -187,10 +187,8 @@ int qp_mgr::configure(struct ibv_comp_channel* p_rx_comp_event_channel)
 			priv_vma_transport_type_str(m_p_ring->get_transport_type()),
 			m_p_ib_ctx_handler->get_ibname(), m_p_ib_ctx_handler->get_ibv_device(), m_port_num);
 
-	vma_ibv_device_attr *r_ibv_dev_attr = m_p_ib_ctx_handler->get_ibv_device_attr();
-
 	// Check device capabilities for max QP work requests
-	m_max_qp_wr = ALIGN_WR_DOWN(r_ibv_dev_attr->max_qp_wr - 1);
+	m_max_qp_wr = ALIGN_WR_DOWN(m_p_ib_ctx_handler->get_ibv_device_attr()->max_qp_wr - 1);
 	if (m_rx_num_wr > m_max_qp_wr) {
 		qp_logwarn("Allocating only %d Rx QP work requests while user "
 			   "requested %s=%d for QP on <%p, %d>",
@@ -199,10 +197,6 @@ int qp_mgr::configure(struct ibv_comp_channel* p_rx_comp_event_channel)
 		m_rx_num_wr = m_max_qp_wr;
 	}
 
-	// Check device capabilities for dummy send support
-#ifdef DEFINED_IBV_EXP_WR_NOP
-	m_hw_dummy_send_support = r_ibv_dev_attr->exp_device_cap_flags & IBV_EXP_DEVICE_NOP;
-#endif
 	qp_logdbg("HW Dummy send support for QP = %d", m_hw_dummy_send_support);
 
 	// Create associated Tx & Rx cq_mgrs

--- a/src/vma/dev/qp_mgr_eth_mlx5.cpp
+++ b/src/vma/dev/qp_mgr_eth_mlx5.cpp
@@ -125,6 +125,9 @@ qp_mgr_eth_mlx5::qp_mgr_eth_mlx5(const ring_simple* p_ring,
         ,m_sq_wqe_counter(0)
         ,m_dm_enabled(0)
 {
+	// Check device capabilities for dummy send support
+	m_hw_dummy_send_support = vma_is_nop_supported(m_p_ib_ctx_handler->get_ibv_device_attr());
+
 	if (call_configure && configure(p_rx_comp_event_channel)) {
 		throw_vma_exception("failed creating qp_mgr_eth");
 	}

--- a/src/vma/ib/base/verbs_extra.h
+++ b/src/vma/ib/base/verbs_extra.h
@@ -195,8 +195,16 @@ typedef struct ibv_values_ex                  vma_ts_values;
 #define VMA_IBV_WR_SEND				IBV_WR_SEND
 #define vma_ibv_wr_opcode			ibv_wr_opcode
 #define vma_send_wr_opcode(wr)			(wr).opcode
-// Use 0 as "default" opcode since IBV_WR_NOP is not defined.
-#define VMA_IBV_WR_NOP				(vma_ibv_wr_opcode)(0)
+
+// Dummy send
+#ifdef DEFINED_IBV_WR_NOP
+#define vma_is_nop_supported(device_attr)    1
+#define VMA_IBV_WR_NOP                      (vma_ibv_wr_opcode)MLX5_OPCODE_NOP
+#else
+#define vma_is_nop_supported(device_attr)    0
+#define VMA_IBV_WR_NOP                      (vma_ibv_wr_opcode)(0) // Use 0 as "default" opcode when NOP is not defined.
+#endif
+
 #define vma_ibv_post_send(qp, wr, bad_wr)	ibv_post_send(qp, wr, bad_wr)
 typedef struct ibv_send_wr			vma_ibv_send_wr;
 //ibv_reg_mr
@@ -349,11 +357,13 @@ typedef struct ibv_exp_cq_attr                  vma_ibv_cq_attr;
 #define vma_ibv_wr_opcode			ibv_exp_wr_opcode
 #define vma_send_wr_opcode(wr)			(wr).exp_opcode
 
-#ifdef DEFINED_IBV_EXP_WR_NOP
-#define VMA_IBV_WR_NOP				IBV_EXP_WR_NOP
+// Dummy send
+#ifdef DEFINED_IBV_WR_NOP
+#define vma_is_nop_supported(device_attr)    ((device_attr)->exp_device_cap_flags & IBV_EXP_DEVICE_NOP)
+#define VMA_IBV_WR_NOP                       IBV_EXP_WR_NOP
 #else
-// Use 0 as "default" opcode when NOP is not defined.
-#define VMA_IBV_WR_NOP				(vma_ibv_wr_opcode)(0)
+#define vma_is_nop_supported(device_attr)    0
+#define VMA_IBV_WR_NOP                      (vma_ibv_wr_opcode)(0) // Use 0 as "default" opcode when NOP is not defined.
 #endif
 
 #define vma_ibv_post_send(qp, wr, bad_wr)	ibv_exp_post_send(qp, wr, bad_wr)


### PR DESCRIPTION
This feature adds a new VMA extra API allowing applications to call
a dummy send flow which will warm up the CPU caches on the send fast path.
See User Manual for more info.

Signed-off-by: Liran Oz <lirano@mellanox.com>