### PR TITLE
issue: 1574870 Print warning while RoCE LAG is enabled

### DIFF
--- a/src/vma/dev/net_device_val.h
+++ b/src/vma/dev/net_device_val.h
@@ -131,7 +131,7 @@ private:
 typedef ring_alloc_logic_attr resource_allocation_key;
 // each ring has a ref count
 typedef std::tr1::unordered_map<resource_allocation_key *, std::pair<ring*, int>, ring_alloc_logic_attr, ring_alloc_logic_attr> rings_hash_map_t;
-
+typedef std::tr1::unordered_map<uint64_t, std::vector<std::string> > sys_image_guid_map_t;
 typedef std::tr1::unordered_map<resource_allocation_key *, std::pair<resource_allocation_key *, int> ,ring_alloc_logic_attr, ring_alloc_logic_attr> rings_key_redirection_hash_map_t;
 
 #define THE_RING                        ring_iter->second.first
@@ -283,6 +283,7 @@ protected:
 	transport_type_t	m_transport_type;
 	lock_mutex_recursive	m_lock;
 	rings_hash_map_t	m_h_ring_map;
+	sys_image_guid_map_t	m_sys_image_guid_map;
 	rings_key_redirection_hash_map_t        m_h_ring_key_redirection_map;
 
 	state			m_state;          /* device current state */

--- a/src/vma/util/utils.cpp
+++ b/src/vma/util/utils.cpp
@@ -163,12 +163,20 @@ int get_base_interface_name(const char *if_name, char *base_ifname, size_t sz_ba
 	return 0;
 }
 
-void print_roce_lag_warnings(char* interface, char* disable_path /* = NULL */)
+void print_roce_lag_warnings(char* interface, char* disable_path /* = NULL */, const char* port1 /* = NULL */, const char* port2 /* = NULL */)
 {
 	vlog_printf(VLOG_WARNING,"******************************************************************************************************\n");
-	vlog_printf(VLOG_WARNING,"* Interface %s will not be offloaded.\n", interface);
-	vlog_printf(VLOG_WARNING,"* VMA cannot offload the device while RoCE LAG is enabled.\n");
+
+	if (port1 && port2) {
+		vlog_printf(VLOG_WARNING,"* Bond %s has two slaves of the same device while RoCE LAG is enabled (%s, %s).\n", interface, port1, port2);
+		vlog_printf(VLOG_WARNING,"* Unexpected behaviour may occur during runtime.\n");
+	} else {
+		vlog_printf(VLOG_WARNING,"* Interface %s will not be offloaded.\n", interface);
+		vlog_printf(VLOG_WARNING,"* VMA cannot offload the device while RoCE LAG is enabled.\n");
+	}
+
 	vlog_printf(VLOG_WARNING,"* Please refer to VMA Release Notes for more info\n");
+
 	if (disable_path) {
 		vlog_printf(VLOG_WARNING,"* In order to disable RoCE LAG please use:\n");
 		vlog_printf(VLOG_WARNING,"* echo 0 > %s\n", disable_path);

--- a/src/vma/util/utils.h
+++ b/src/vma/util/utils.h
@@ -299,7 +299,7 @@ size_t get_vlan_base_name_from_ifname(const char* ifname, char* base_ifname, siz
 size_t get_local_ll_addr(const char* ifname, unsigned char* addr, int addr_len,  bool is_broadcast);
 
 /* Print warning while RoCE Lag is enabled */
-void print_roce_lag_warnings(char* interface, char* disable_path = NULL);
+void print_roce_lag_warnings(char* interface, char* disable_path = NULL, const char* port1 = NULL, const char* port2 = NULL);
 
 bool get_bond_active_slave_name(IN const char* bond_name, OUT char* active_slave_name, IN int sz);
 bool get_bond_slave_state(IN const char* slave_name, OUT char* curr_state, IN int sz);


### PR DESCRIPTION
Print warning message while bond device contains two slaves
of the same HCA while RoCE LAG is enabled for both slaves.
Unexpected behaviour may occur during runtime.

Signed-off-by: Liran Oz <lirano@mellanox.com>