### PR TITLE
issue: 1614459 Suppress pclose() error for ring_tap

### DIFF
--- a/src/vma/dev/ring_tap.cpp
+++ b/src/vma/dev/ring_tap.cpp
@@ -179,7 +179,7 @@ void ring_tap::tap_create(net_device_val* p_ndev)
 
 	/* Disable Ipv6 for TAP interface */
 	snprintf(command_str, TAP_STR_LENGTH, TAP_DISABLE_IPV6, tap_name);
-	if (run_and_retreive_system_command(command_str, return_str, TAP_STR_LENGTH)  < 0) {
+	if (run_and_retreive_system_command(command_str, return_str, TAP_STR_LENGTH)  < 0 && errno != ECHILD) {
 		ring_logerr("sysctl ipv6 failed fd = %d, %m", m_tap_fd);
 		rc = -errno;
 		goto error;

--- a/src/vma/dev/ring_tap.cpp
+++ b/src/vma/dev/ring_tap.cpp
@@ -179,7 +179,7 @@ void ring_tap::tap_create(net_device_val* p_ndev)
 
 	/* Disable Ipv6 for TAP interface */
 	snprintf(command_str, TAP_STR_LENGTH, TAP_DISABLE_IPV6, tap_name);
-	if (run_and_retreive_system_command(command_str, return_str, TAP_STR_LENGTH)  < 0 && errno != ECHILD) {
+	if (run_and_retreive_system_command(command_str, return_str, TAP_STR_LENGTH)  < 0) {
 		ring_logerr("sysctl ipv6 failed fd = %d, %m", m_tap_fd);
 		rc = -errno;
 		goto error;

--- a/src/vma/util/utils.cpp
+++ b/src/vma/util/utils.cpp
@@ -739,8 +739,13 @@ int run_and_retreive_system_command(const char* cmd_line, char* return_str, int 
 				return_str[0] = '\0';
 			}
 		}
+
 		// Check exit status code
 		rc = pclose(file);
+		if (rc == -1 && errno == ECHILD) {
+			/* suppress a case when termination status can be unavailable to pclose() */
+			rc = 0;
+		}
 
 		for (int i = 0; environ[i]; i++) {
 			if (strstr(environ[i], "_D_PRELOAD=")) {


### PR DESCRIPTION
No need to abort tap creation while pclose() is falied
with ECHILD errno.

Signed-off-by: Liran Oz <lirano@mellanox.com>