### PR TITLE
issue: 1073005 Fix g_tcp_timers_collection destructor cleanup

### DIFF
--- a/src/vma/sock/sockinfo_tcp.cpp
+++ b/src/vma/sock/sockinfo_tcp.cpp
@@ -4511,13 +4511,14 @@ tcp_timers_collection::~tcp_timers_collection()
 void tcp_timers_collection::free_tta_resources(void)
 {
 	if (m_n_count) {
-		__log_dbg("not all TCP timers have been removed, count=%d", m_n_count);
-
 		for (int i = 0; i < m_n_intervals_size; i++) {
-			while (m_p_intervals[i]) {
-				m_p_intervals[i]->group = NULL;
-				m_p_intervals[i] = m_p_intervals[i]->next;
+			if (m_p_intervals[i]) {
+				remove_timer(m_p_intervals[i]);
 			}
+		}
+
+		if (m_n_count) {
+			__log_dbg("not all TCP timers have been removed, count=%d", m_n_count);
 		}
 	}
 


### PR DESCRIPTION
Current implementation prints debug message while tcp-timers are not
cleaned instead of cleaning them.

Signed-off-by: Liran Oz <lirano@mellanox.com>