### PR TITLE
issue: 1647737 Modify Packet Pacing capability calculation

### DIFF
--- a/src/vma/dev/ib_ctx_handler.cpp
+++ b/src/vma/dev/ib_ctx_handler.cpp
@@ -200,7 +200,7 @@ void ib_ctx_handler::set_str()
 	strcat(m_str, str_x);
 
 	str_x[0] = '\0';
-	sprintf(str_x, " packet_pacing_caps: min rate %u, max rate %u, burst %u", m_pacing_caps.rate_limit_min, m_pacing_caps.rate_limit_max, m_pacing_caps.burst);
+	sprintf(str_x, " packet_pacing_caps: min rate %u, max rate %u", m_pacing_caps.rate_limit_min, m_pacing_caps.rate_limit_max);
 	strcat(m_str, str_x);
 }
 
@@ -330,7 +330,7 @@ void ib_ctx_handler::set_burst_capability(bool burst)
 	m_pacing_caps.burst = burst;
 }
 
-bool ib_ctx_handler::is_packet_pacing_supported(uint32_t rate)
+bool ib_ctx_handler::is_packet_pacing_supported(uint32_t rate /* =1 */)
 {
 	if (rate) {
 		return m_pacing_caps.rate_limit_min <= rate && rate <= m_pacing_caps.rate_limit_max;

--- a/src/vma/dev/ib_ctx_handler.cpp
+++ b/src/vma/dev/ib_ctx_handler.cpp
@@ -330,6 +330,15 @@ void ib_ctx_handler::set_burst_capability(bool burst)
 	m_pacing_caps.burst = burst;
 }
 
+bool ib_ctx_handler::is_packet_pacing_supported(uint32_t rate)
+{
+	if (rate) {
+		return m_pacing_caps.rate_limit_min <= rate && rate <= m_pacing_caps.rate_limit_max;
+	} else {
+		return true;
+	}
+}
+
 bool ib_ctx_handler::is_active(int port_num)
 {
 	ibv_port_attr port_attr;

--- a/src/vma/dev/ib_ctx_handler.h
+++ b/src/vma/dev/ib_ctx_handler.h
@@ -84,7 +84,7 @@ public:
 	bool                    get_flow_tag_capability() { return m_flow_tag_enabled; } // m_flow_tag_capability
 	void                    set_burst_capability(bool burst);
 	bool                    get_burst_capability() { return m_pacing_caps.burst; }
-	bool                    is_packet_pacing_supported(uint32_t rate) { return m_pacing_caps.rate_limit_min >= rate && rate <= m_pacing_caps.rate_limit_max; }
+	bool                    is_packet_pacing_supported(uint32_t rate);
 	size_t                  get_on_device_memory_size() { return m_on_device_memory; }
 	bool                    is_active(int port_num);
 	virtual void            handle_event_ibverbs_cb(void *ev_data, void *ctx);

--- a/src/vma/dev/ib_ctx_handler.h
+++ b/src/vma/dev/ib_ctx_handler.h
@@ -84,7 +84,7 @@ public:
 	bool                    get_flow_tag_capability() { return m_flow_tag_enabled; } // m_flow_tag_capability
 	void                    set_burst_capability(bool burst);
 	bool                    get_burst_capability() { return m_pacing_caps.burst; }
-	bool                    is_packet_pacing_supported(uint32_t rate);
+	bool                    is_packet_pacing_supported(uint32_t rate = 1);
 	size_t                  get_on_device_memory_size() { return m_on_device_memory; }
 	bool                    is_active(int port_num);
 	virtual void            handle_event_ibverbs_cb(void *ev_data, void *ctx);

--- a/src/vma/dev/ib_ctx_handler.h
+++ b/src/vma/dev/ib_ctx_handler.h
@@ -44,6 +44,14 @@
 
 typedef std::tr1::unordered_map<uint32_t, struct ibv_mr*> mr_map_lkey_t;
 
+struct pacing_caps_t {
+	uint32_t rate_limit_min;
+	uint32_t rate_limit_max;
+	bool burst;
+
+	pacing_caps_t() : rate_limit_min(0), rate_limit_max(0), burst(false) {};
+};
+
 // client to event manager 'command' invoker (??)
 //
 class ib_ctx_handler : public event_handler_ibverbs
@@ -74,6 +82,9 @@ public:
 	ts_conversion_mode_t    get_ctx_time_converter_status();
 	void                    set_flow_tag_capability(bool flow_tag_capability); 
 	bool                    get_flow_tag_capability() { return m_flow_tag_enabled; } // m_flow_tag_capability
+	void                    set_burst_capability(bool burst);
+	bool                    get_burst_capability() { return m_pacing_caps.burst; }
+	bool                    is_packet_pacing_supported(uint32_t rate) { return m_pacing_caps.rate_limit_min >= rate && rate <= m_pacing_caps.rate_limit_max; }
 	size_t                  get_on_device_memory_size() { return m_on_device_memory; }
 	bool                    is_active(int port_num);
 	virtual void            handle_event_ibverbs_cb(void *ev_data, void *ctx);
@@ -93,6 +104,7 @@ private:
 	vma_ibv_device_attr_ex* m_p_ibv_device_attr;
 	ibv_pd*                 m_p_ibv_pd;
 	bool                    m_flow_tag_enabled;
+	pacing_caps_t           m_pacing_caps;
 	size_t                  m_on_device_memory;
 	bool                    m_removed;
 	lock_spin               m_lock_umr;

--- a/src/vma/dev/net_device_val.cpp
+++ b/src/vma/dev/net_device_val.cpp
@@ -1608,7 +1608,6 @@ bool net_device_val::verify_qp_creation(const char* ifname, enum ibv_qp_type qp_
 {
 	bool success = false;
 	char bond_roce_lag_path[256] = {0};
-	struct vma_rate_limit_t rate = {1000, 100, 100};
 	struct ibv_cq* cq = NULL;
 	struct ibv_comp_channel *channel = NULL;
 	struct ibv_qp* qp = NULL;
@@ -1695,7 +1694,7 @@ bool net_device_val::verify_qp_creation(const char* ifname, enum ibv_qp_type qp_
 			}
 			nd_logdbg("verified interface %s for flow tag capabilities : %s", ifname, p_ib_ctx->get_flow_tag_capability() ? "enabled" : "disabled");
 
-			if (qp_type == IBV_QPT_RAW_PACKET && !priv_ibv_modify_qp_ratelimit(qp, rate, RL_RATE | RL_BURST_SIZE | RL_PKT_SIZE)) {
+			if (qp_type == IBV_QPT_RAW_PACKET && !priv_ibv_query_burst_supported(qp, port_num)) {
 				p_ib_ctx->set_burst_capability(true);
 			}
 			nd_logdbg("verified interface %s for burst capabilities : %s", ifname, p_ib_ctx->get_burst_capability() ? "enabled" : "disabled");

--- a/src/vma/dev/net_device_val.cpp
+++ b/src/vma/dev/net_device_val.cpp
@@ -1694,7 +1694,7 @@ bool net_device_val::verify_qp_creation(const char* ifname, enum ibv_qp_type qp_
 			}
 			nd_logdbg("verified interface %s for flow tag capabilities : %s", ifname, p_ib_ctx->get_flow_tag_capability() ? "enabled" : "disabled");
 
-			if (qp_type == IBV_QPT_RAW_PACKET && !priv_ibv_query_burst_supported(qp, port_num)) {
+			if (qp_type == IBV_QPT_RAW_PACKET && p_ib_ctx->is_packet_pacing_supported() && !priv_ibv_query_burst_supported(qp, port_num)) {
 				p_ib_ctx->set_burst_capability(true);
 			}
 			nd_logdbg("verified interface %s for burst capabilities : %s", ifname, p_ib_ctx->get_burst_capability() ? "enabled" : "disabled");

--- a/src/vma/dev/net_device_val.cpp
+++ b/src/vma/dev/net_device_val.cpp
@@ -1608,6 +1608,7 @@ bool net_device_val::verify_qp_creation(const char* ifname, enum ibv_qp_type qp_
 {
 	bool success = false;
 	char bond_roce_lag_path[256] = {0};
+	struct vma_rate_limit_t rate = {1000, 100, 100};
 	struct ibv_cq* cq = NULL;
 	struct ibv_comp_channel *channel = NULL;
 	struct ibv_qp* qp = NULL;
@@ -1688,11 +1689,16 @@ bool net_device_val::verify_qp_creation(const char* ifname, enum ibv_qp_type qp_
 			goto qp_failure;
 		} else {
 			success = true;
+
 			if (qp_type == IBV_QPT_RAW_PACKET && !priv_ibv_query_flow_tag_supported(qp, port_num)) {
 				p_ib_ctx->set_flow_tag_capability(true);
-
 			}
 			nd_logdbg("verified interface %s for flow tag capabilities : %s", ifname, p_ib_ctx->get_flow_tag_capability() ? "enabled" : "disabled");
+
+			if (qp_type == IBV_QPT_RAW_PACKET && !priv_ibv_modify_qp_ratelimit(qp, rate, RL_RATE | RL_BURST_SIZE | RL_PKT_SIZE)) {
+				p_ib_ctx->set_burst_capability(true);
+			}
+			nd_logdbg("verified interface %s for burst capabilities : %s", ifname, p_ib_ctx->get_burst_capability() ? "enabled" : "disabled");
 		}
 	} else {
 		nd_logdbg("QP creation failed on interface %s (errno=%d %m), Traffic will not be offloaded", ifname, errno);

--- a/src/vma/dev/qp_mgr.h
+++ b/src/vma/dev/qp_mgr.h
@@ -133,7 +133,6 @@ public:
 	void                release_tx_buffers();
 	virtual void        trigger_completion_for_all_sent_packets();
 	uint32_t            is_ratelimit_change(struct vma_rate_limit_t &rate_limit);
-	bool                is_ratelimit_supported(vma_ibv_device_attr *attr, struct vma_rate_limit_t &rate_limit);
 	int                 modify_qp_ratelimit(struct vma_rate_limit_t &rate_limit, uint32_t rl_changes);
 	static inline bool  is_lib_mlx5(const char* device_name) {return strstr(device_name, "mlx5");}
 	virtual void        dm_release_data(mem_buf_desc_t* buff) { NOT_IN_USE(buff); }

--- a/src/vma/dev/ring.h
+++ b/src/vma/dev/ring.h
@@ -113,7 +113,6 @@ public:
 	ring_user_id_t		generate_id() { return 0; };
 	virtual ring_user_id_t	generate_id(const address_t src_mac, const address_t dst_mac, uint16_t eth_proto, uint16_t encap_proto, uint32_t src_ip, uint32_t dst_ip, uint16_t src_port, uint16_t dst_port) = 0;
 	virtual int		modify_ratelimit(struct vma_rate_limit_t &rate_limit) = 0;
-	virtual bool		is_ratelimit_supported(struct vma_rate_limit_t &rate_limit) = 0;
 	virtual int		reg_mr(void *addr, size_t length, uint32_t &lkey) { NOT_IN_USE(addr); NOT_IN_USE(length); NOT_IN_USE(lkey); return -1;};
 	virtual int		dereg_mr(void *addr, size_t length) { NOT_IN_USE(addr);NOT_IN_USE(length); return -1;};
 

--- a/src/vma/dev/ring_bond.cpp
+++ b/src/vma/dev/ring_bond.cpp
@@ -761,17 +761,6 @@ int ring_bond::modify_ratelimit(struct vma_rate_limit_t &rate_limit) {
 	return 0;
 }
 
-bool ring_bond::is_ratelimit_supported(struct vma_rate_limit_t &rate_limit)
-{
-	for (uint32_t i = 0; i < m_bond_rings.size(); i++) {
-		if (m_bond_rings[i] &&
-		    !m_bond_rings[i]->is_ratelimit_supported(rate_limit)) {
-				return false;
-		}
-	}
-	return true;
-}
-
 int ring_bond::socketxtreme_poll(struct vma_completion_t *, unsigned int, int)
 {
 	return 0;

--- a/src/vma/dev/ring_bond.h
+++ b/src/vma/dev/ring_bond.h
@@ -76,7 +76,6 @@ public:
 	virtual ring_user_id_t	generate_id(const address_t src_mac, const address_t dst_mac, uint16_t eth_proto, uint16_t encap_proto, uint32_t src_ip, uint32_t dst_ip, uint16_t src_port, uint16_t dst_port);
 	virtual bool 		get_hw_dummy_send_support(ring_user_id_t id, vma_ibv_send_wr* p_send_wqe);
 	virtual int		modify_ratelimit(struct vma_rate_limit_t &rate_limit);
-	virtual bool		is_ratelimit_supported(struct vma_rate_limit_t &rate_limit);
 	int 			socketxtreme_poll(struct vma_completion_t *vma_completions, unsigned int ncompletions, int flags);
 	virtual void    slave_create(int if_index) = 0;
 	virtual void    slave_destroy(int if_index);

--- a/src/vma/dev/ring_simple.cpp
+++ b/src/vma/dev/ring_simple.cpp
@@ -92,25 +92,9 @@ qp_mgr* ring_eth::create_qp_mgr(const ib_ctx_handler* ib_ctx, uint8_t port_num, 
 	return new qp_mgr_eth(this, ib_ctx, port_num, p_rx_comp_event_channel, get_tx_num_wr(), m_partition);
 }
 
-bool ring_eth::is_ratelimit_supported(struct vma_rate_limit_t &rate_limit)
-{
-#ifdef DEFINED_IBV_EXP_QP_RATE_LIMIT
-	return m_p_qp_mgr->is_ratelimit_supported(m_p_ib_ctx->get_ibv_device_attr(), rate_limit);
-#else
-	NOT_IN_USE(rate_limit);
-	return false;
-#endif
-}
-
 qp_mgr* ring_ib::create_qp_mgr(const ib_ctx_handler* ib_ctx, uint8_t port_num, struct ibv_comp_channel* p_rx_comp_event_channel)
 {
 	return new qp_mgr_ib(this, ib_ctx, port_num, p_rx_comp_event_channel, get_tx_num_wr(), m_partition);
-}
-
-bool ring_ib::is_ratelimit_supported(struct vma_rate_limit_t &rate_limit)
-{
-	NOT_IN_USE(rate_limit);
-	return false;
 }
 
 ring_simple::ring_simple(int if_index, ring* parent, ring_type_t type):
@@ -987,6 +971,16 @@ bool ring_simple::is_up() {
 
 int ring_simple::modify_ratelimit(struct vma_rate_limit_t &rate_limit)
 {
+	if (!m_p_ib_ctx->is_packet_pacing_supported(rate_limit.rate)) {
+		ring_logwarn("Packet pacing is not supported for this device");
+		return -1;
+	}
+
+	if ((rate_limit.max_burst_sz || rate_limit.typical_pkt_sz) && !m_p_ib_ctx->get_burst_capability()) {
+		ring_logwarn("Burst is not supported for this device");
+		return -1;
+	}
+
 	uint32_t rl_changes = m_p_qp_mgr->is_ratelimit_change(rate_limit);
 
 	if (m_up && rl_changes)

--- a/src/vma/dev/ring_simple.cpp
+++ b/src/vma/dev/ring_simple.cpp
@@ -993,7 +993,7 @@ int ring_simple::get_ring_descriptors(vma_mlx_hw_device_data &d)
 {
 	d.dev_data.vendor_id = m_p_ib_ctx->get_ibv_device_attr()->vendor_id;
 	d.dev_data.vendor_part_id = m_p_ib_ctx->get_ibv_device_attr()->vendor_part_id;
-	if (vma_is_packet_pacing_supported(m_p_ib_ctx->get_ibv_device_attr())) {
+	if (m_p_ib_ctx->is_packet_pacing_supported()) {
 		d.dev_data.device_cap |= VMA_HW_PP_EN;
 	}
 	if (vma_is_umr_supported(m_p_ib_ctx->get_ibv_device_attr())) {

--- a/src/vma/dev/ring_simple.h
+++ b/src/vma/dev/ring_simple.h
@@ -220,7 +220,6 @@ public:
 			}
 		}
 	}
-	virtual bool is_ratelimit_supported(struct vma_rate_limit_t &rate_limit);
 protected:
 	virtual qp_mgr* create_qp_mgr(const ib_ctx_handler* ib_ctx, uint8_t port_num, struct ibv_comp_channel* p_rx_comp_event_channel);
 };
@@ -238,7 +237,6 @@ public:
 			create_resources();
 		}
 	}
-	virtual bool is_ratelimit_supported(struct vma_rate_limit_t &rate_limit);
 protected:
 	virtual qp_mgr* create_qp_mgr(const ib_ctx_handler* ib_ctx, uint8_t port_num, struct ibv_comp_channel* p_rx_comp_event_channel);
 };

--- a/src/vma/dev/ring_tap.h
+++ b/src/vma/dev/ring_tap.h
@@ -68,7 +68,6 @@ public:
 	}
 
 	virtual int modify_ratelimit(struct vma_rate_limit_t &rate_limit) { NOT_IN_USE(rate_limit); return 0; }
-	virtual bool is_ratelimit_supported(struct vma_rate_limit_t &rate_limit) { NOT_IN_USE(rate_limit); return false; }
 	void inc_cq_moderation_stats(size_t sz_data) { NOT_IN_USE(sz_data); }
 	virtual int get_max_tx_inline() { return 0; }
 	virtual uint32_t get_underly_qpn() { return -1; }

--- a/src/vma/ib/base/verbs_extra.cpp
+++ b/src/vma/ib/base/verbs_extra.cpp
@@ -270,6 +270,26 @@ int priv_ibv_query_qp_state(struct ibv_qp *qp)
 	return (ibv_qp_state)qp_attr.qp_state;
 }
 
+int priv_ibv_query_burst_supported(struct ibv_qp *qp, uint8_t port_num)
+{
+#ifdef	DEFINED_IBV_EXP_QP_SUPPORT_BURST
+	if (priv_ibv_modify_qp_from_err_to_init_raw(qp, port_num) == 0) {
+		if (priv_ibv_modify_qp_from_init_to_rts(qp, 0) == 0) {
+			struct vma_rate_limit_t rate = {1000, 100, 100};
+			if (priv_ibv_modify_qp_ratelimit(qp, rate, RL_RATE | RL_BURST_SIZE | RL_PKT_SIZE) == 0){
+				return 0;
+			}
+		}
+	}
+
+#else
+	NOT_IN_USE(qp);
+	NOT_IN_USE(port_num);
+#endif
+
+	return -1;
+}
+
 int priv_ibv_query_flow_tag_supported(struct ibv_qp *qp, uint8_t port_num)
 {
 	NOT_IN_USE(qp);

--- a/src/vma/ib/base/verbs_extra.cpp
+++ b/src/vma/ib/base/verbs_extra.cpp
@@ -386,7 +386,7 @@ int priv_ibv_modify_qp_ratelimit(struct ibv_qp *qp, struct vma_rate_limit_t &rat
 #endif
 	BULLSEYE_EXCLUDE_BLOCK_START
 	IF_VERBS_FAILURE(vma_ibv_modify_qp(qp, &qp_attr, exp_attr_mask)) {
-		vlog_printf(VLOG_WARNING, "failed setting rate limit\n");
+		vlog_printf(VLOG_DEBUG, "failed setting rate limit\n");
 		return -2;
 	} ENDIF_VERBS_FAILURE;
 	BULLSEYE_EXCLUDE_BLOCK_END

--- a/src/vma/ib/base/verbs_extra.h
+++ b/src/vma/ib/base/verbs_extra.h
@@ -112,6 +112,7 @@ void priv_ibv_modify_cq_moderation(struct ibv_cq* cq, uint32_t period, uint32_t 
 #define FLOW_TAG_MASK     ((1 << 20) -1)
 int priv_ibv_query_flow_tag_supported(struct ibv_qp *qp, uint8_t port_num);
 int priv_ibv_create_flow_supported(struct ibv_qp *qp, uint8_t port_num);
+int priv_ibv_query_burst_supported(struct ibv_qp *qp, uint8_t port_num);
 
 /* DEFINED_VERBS_VERSION:
  * 1 - Legacy Verbs API

--- a/src/vma/ib/base/verbs_extra.h
+++ b/src/vma/ib/base/verbs_extra.h
@@ -470,12 +470,6 @@ typedef struct ibv_exp_reg_mr_in         vma_ibv_reg_mr_in;
 #define vma_is_mp_rq_supported(attr)		(0)
 #endif
 
-#ifdef DEFINED_IBV_EXP_QP_RATE_LIMIT
-#define vma_is_packet_pacing_supported(attr)	((attr)->packet_pacing_caps.qp_rate_limit_min)
-#else
-#define vma_is_packet_pacing_supported(attr)	(0)
-#endif
-
 #if defined(HAVE_IBV_EXP_GET_DEVICE_LIST)
 #define vma_ibv_get_device_list(num)		ibv_exp_get_device_list(num)
 #else

--- a/src/vma/sock/sockinfo.cpp
+++ b/src/vma/sock/sockinfo.cpp
@@ -1425,11 +1425,6 @@ int sockinfo::modify_ratelimit(dst_entry* p_dst_entry, struct vma_rate_limit_t &
 {
 	if (m_ring_alloc_log_tx.get_ring_alloc_logic() == RING_LOGIC_PER_SOCKET ||
 	    m_ring_alloc_log_tx.get_ring_alloc_logic() == RING_LOGIC_PER_USER_ID) {
-		// check in qp attr that device supports
-		if (m_p_rx_ring && !m_p_rx_ring->is_ratelimit_supported(rate_limit)) {
-			si_logwarn("device doesn't support packet pacing or bad value, run ibv_devinfo -v");
-			return -1;
-		}
 
 		if (p_dst_entry) {
 			int ret = p_dst_entry->modify_ratelimit(rate_limit);


### PR DESCRIPTION
Packet Pacing should be calculated once for each device and not during
QP creation.

Signed-off-by: Liran Oz <lirano@mellanox.com>