### PR TITLE
issue: 1651457 Add burst capabilty check to get_ring_descriptors

### DIFF
--- a/src/vma/dev/ring_simple.cpp
+++ b/src/vma/dev/ring_simple.cpp
@@ -996,6 +996,9 @@ int ring_simple::get_ring_descriptors(vma_mlx_hw_device_data &d)
 	if (m_p_ib_ctx->is_packet_pacing_supported()) {
 		d.dev_data.device_cap |= VMA_HW_PP_EN;
 	}
+	if (m_p_ib_ctx->get_burst_capability()) {
+		d.dev_data.device_cap |= VMA_HW_PP_BURST_EN;
+	}
 	if (vma_is_umr_supported(m_p_ib_ctx->get_ibv_device_attr())) {
 		d.dev_data.device_cap |= VMA_HW_UMR_EN;
 	}

--- a/src/vma/vma_extra.h
+++ b/src/vma/vma_extra.h
@@ -360,6 +360,7 @@ typedef enum {
 	VMA_HW_PP_EN = (1 << 0),
 	VMA_HW_UMR_EN = (1 << 1),
 	VMA_HW_MP_RQ_EN = (1 << 2),
+	VMA_HW_PP_BURST_EN = (1 << 3),
 } mlx_hw_device_cap;
 
 struct dev_data {


### PR DESCRIPTION
legacy VMA reports about packet pacing capability and not on burst
capability.

Signed-off-by: Liran Oz <lirano@mellanox.com>