### PR TITLE
issue: 1668925 Fix RoCE lag warning is not presented

### DIFF
--- a/src/vma/dev/net_device_val.cpp
+++ b/src/vma/dev/net_device_val.cpp
@@ -258,7 +258,7 @@ net_device_val::net_device_val(struct net_device_val_desc *desc) : m_lock("net_d
 	case LAG_8023ad:
 	case ACTIVE_BACKUP:
 		// this is a bond interface (or a vlan/alias over bond), find the slaves
-		valid = (bool)(ib_ctx && verify_bond_ipoib_or_eth_qp_creation());
+		valid = verify_bond_ipoib_or_eth_qp_creation();
 		break;
 	default:
 		valid = (bool)(ib_ctx && verify_ipoib_or_eth_qp_creation(get_ifname_link()));


### PR DESCRIPTION
While RoCE lag is enabled, only single port has IB device.
Legacy VMA did not print RoCE lag warning while active slave did
not have IB device.

Signed-off-by: Liran Oz <lirano@mellanox.com>