### PR TITLE
issue: 1670999 Print mlx4 steering warning in ib_ctx_handler_collection

### DIFF
--- a/src/vma/dev/ib_ctx_handler.cpp
+++ b/src/vma/dev/ib_ctx_handler.cpp
@@ -219,7 +219,7 @@ void ib_ctx_handler::set_ctx_time_converter_status(ts_conversion_mode_t conversi
 	break;
 	case TS_CONVERSION_MODE_PTP: {
 #ifdef DEFINED_IBV_CLOCK_INFO
-		if (strncmp(get_ibname(), "mlx4", 4) == 0) {
+		if (is_mlx4()) {
 			m_p_ctx_time_converter = new time_converter_ib_ctx(m_p_ibv_context, TS_CONVERSION_MODE_SYNC, m_p_ibv_device_attr->hca_core_clock);
 			ibch_logwarn("ptp is not supported for mlx4 devices, reverting to mode TS_CONVERSION_MODE_SYNC (ibv context %p)",
 					m_p_ibv_context);

--- a/src/vma/dev/ib_ctx_handler.h
+++ b/src/vma/dev/ib_ctx_handler.h
@@ -87,6 +87,8 @@ public:
 	bool                    is_packet_pacing_supported(uint32_t rate = 1);
 	size_t                  get_on_device_memory_size() { return m_on_device_memory; }
 	bool                    is_active(int port_num);
+	bool                    is_mlx4(){ return is_mlx4(get_ibname()); }
+	static bool             is_mlx4(const char *dev) { return strncmp(dev, "mlx4", 4) == 0; }
 	virtual void            handle_event_ibverbs_cb(void *ev_data, void *ctx);
 
 	void set_str();

--- a/src/vma/dev/ib_ctx_handler_collection.cpp
+++ b/src/vma/dev/ib_ctx_handler_collection.cpp
@@ -138,7 +138,7 @@ void ib_ctx_handler_collection::update_tbl(const char *ifa_name)
 		}
 
 		if (ib_ctx_handler::is_mlx4(dev_list[i]->name)) {
-			// only support mlx5 device in this mode
+			// Note: mlx4 does not support this capability.
 			if(safe_mce_sys().enable_socketxtreme) {
 				ibchc_logdbg("Blocking offload: mlx4 interfaces in socketxtreme mode");
 				continue;

--- a/src/vma/dev/ib_ctx_handler_collection.cpp
+++ b/src/vma/dev/ib_ctx_handler_collection.cpp
@@ -144,8 +144,11 @@ void ib_ctx_handler_collection::update_tbl(const char *ifa_name)
 				continue;
 			}
 
-			// Check if mlx4 steering is supported
-			check_flow_steering_log_num_mgm_entry_size();
+			// Check if mlx4 steering creation is supported.
+			// Those setting are passed to the VM by the Hypervisor - NO NEED to specify the param on the VM.
+			if (safe_mce_sys().hypervisor == mce_sys_var::HYPER_NONE) {
+				check_flow_steering_log_num_mgm_entry_size();
+			}
 		}
 
 		/* 3. Add new ib devices */

--- a/src/vma/dev/ib_ctx_handler_collection.cpp
+++ b/src/vma/dev/ib_ctx_handler_collection.cpp
@@ -53,6 +53,30 @@
 
 ib_ctx_handler_collection* g_p_ib_ctx_handler_collection = NULL;
 
+void check_flow_steering_log_num_mgm_entry_size()
+{
+	static bool checked_mlx4_steering = false;
+	if (checked_mlx4_steering) {
+		return;
+	}
+
+	checked_mlx4_steering = true;
+	char flow_steering_val[4] = {0};
+	if (priv_safe_try_read_file((const char*)FLOW_STEERING_MGM_ENTRY_SIZE_PARAM_FILE, flow_steering_val, sizeof(flow_steering_val)) == -1) {
+		vlog_printf(VLOG_DEBUG, "Flow steering option for mlx4 driver does not exist in current OFED version\n");
+	} else if (flow_steering_val[0] != '-' || (strtol(&flow_steering_val[1], NULL, 0) % 2) == 0) {
+		vlog_printf(VLOG_WARNING, "***************************************************************************************\n");
+		vlog_printf(VLOG_WARNING, "* VMA will not operate properly while flow steering option is disabled                *\n");
+		vlog_printf(VLOG_WARNING, "* In order to enable flow steering please restart your VMA applications after running *\n");
+		vlog_printf(VLOG_WARNING, "* the following:                                                                      *\n");
+		vlog_printf(VLOG_WARNING, "* For your information the following steps will restart your network interface        *\n");
+		vlog_printf(VLOG_WARNING, "* 1. \"echo options mlx4_core log_num_mgm_entry_size=-1 > /etc/modprobe.d/mlnx.conf\"   *\n");
+		vlog_printf(VLOG_WARNING, "* 2. Restart openibd or rdma service depending on your system configuration           *\n");
+		vlog_printf(VLOG_WARNING, "* Read more about the Flow Steering support in the VMA's User Manual                  *\n");
+		vlog_printf(VLOG_WARNING, "***************************************************************************************\n");
+	}
+}
+
 ib_ctx_handler_collection::ib_ctx_handler_collection()
 {
 	ibchc_logdbg("");
@@ -113,10 +137,15 @@ void ib_ctx_handler_collection::update_tbl(const char *ifa_name)
 			continue;
 		}
 
-		// only support mlx5 device in this mode
-		if(safe_mce_sys().enable_socketxtreme && strncmp(dev_list[i]->name, "mlx4", 4) == 0) {
-			ibchc_logdbg("Blocking offload: mlx4 interfaces in socketxtreme mode");
-			continue;
+		if (ib_ctx_handler::is_mlx4(dev_list[i]->name)) {
+			// only support mlx5 device in this mode
+			if(safe_mce_sys().enable_socketxtreme) {
+				ibchc_logdbg("Blocking offload: mlx4 interfaces in socketxtreme mode");
+				continue;
+			}
+
+			// Check if mlx4 steering is supported
+			check_flow_steering_log_num_mgm_entry_size();
 		}
 
 		/* 3. Add new ib devices */

--- a/src/vma/dev/net_device_val.cpp
+++ b/src/vma/dev/net_device_val.cpp
@@ -1565,7 +1565,7 @@ bool net_device_val::verify_enable_ipoib(const char* interface_name)
 	}
 
 #ifndef DEFINED_IBV_QP_INIT_SOURCE_QPN
-	// Dont offload mlx5 devices if source qpn is not defined.
+	// Note: mlx4 does not support this capability
 	ib_ctx_handler* ib_ctx = g_p_ib_ctx_handler_collection->get_ib_ctx(get_ifname_link());
 	if (!ib_ctx->is_mlx4()) {
 		nd_logwarn("Blocking offload: SOURCE_QPN is not supported for this driver ('%s')", interface_name);
@@ -1674,7 +1674,7 @@ bool net_device_val::verify_qp_creation(const char* ifname, enum ibv_qp_type qp_
 	qp_init_attr.recv_cq = cq;
 	qp_init_attr.send_cq = cq;
 
-	// Set source qpn for mlx5 IPoIB devices
+	// Set source qpn for non mlx4 IPoIB devices
 	if (qp_type == IBV_QPT_UD && !p_ib_ctx->is_mlx4()) {
 		unsigned char hw_addr[IPOIB_HW_ADDR_LEN];
 		get_local_ll_addr(ifname, hw_addr, IPOIB_HW_ADDR_LEN, false);

--- a/src/vma/dev/net_device_val.cpp
+++ b/src/vma/dev/net_device_val.cpp
@@ -1567,7 +1567,7 @@ bool net_device_val::verify_enable_ipoib(const char* interface_name)
 #ifndef DEFINED_IBV_QP_INIT_SOURCE_QPN
 	// Dont offload mlx5 devices if source qpn is not defined.
 	ib_ctx_handler* ib_ctx = g_p_ib_ctx_handler_collection->get_ib_ctx(get_ifname_link());
-	if (!strncmp(ib_ctx->get_ibname(), "mlx5", 4)) {
+	if (!p_ib_ctx->is_mlx4()) {
 		nd_logwarn("Blocking offload: SOURCE_QPN is not supported for this driver ('%s')", interface_name);
 		return false;
 	}
@@ -1646,7 +1646,7 @@ bool net_device_val::verify_qp_creation(const char* ifname, enum ibv_qp_type qp_
 		goto release_resources;
 	} else if (port_num > p_ib_ctx->get_ibv_device_attr()->phys_port_cnt) {
 		nd_logdbg("Invalid port for interface %s", base_ifname);
-		if (qp_type == IBV_QPT_RAW_PACKET && m_bond != NO_BOND && !strncmp(p_ib_ctx->get_ibname(), "mlx4", 4)) {
+		if (qp_type == IBV_QPT_RAW_PACKET && m_bond != NO_BOND && p_ib_ctx->is_mlx4()) {
 			print_roce_lag_warnings(get_ifname_link());
 		}
 		goto release_resources;
@@ -1675,7 +1675,7 @@ bool net_device_val::verify_qp_creation(const char* ifname, enum ibv_qp_type qp_
 	qp_init_attr.send_cq = cq;
 
 	// Set source qpn for mlx5 IPoIB devices
-	if (qp_type == IBV_QPT_UD && !strncmp(p_ib_ctx->get_ibname(), "mlx5", 4)) {
+	if (qp_type == IBV_QPT_UD && !p_ib_ctx->is_mlx4()) {
 		unsigned char hw_addr[IPOIB_HW_ADDR_LEN];
 		get_local_ll_addr(ifname, hw_addr, IPOIB_HW_ADDR_LEN, false);
 		IPoIB_addr ipoib_addr(hw_addr);

--- a/src/vma/dev/net_device_val.cpp
+++ b/src/vma/dev/net_device_val.cpp
@@ -1567,7 +1567,7 @@ bool net_device_val::verify_enable_ipoib(const char* interface_name)
 #ifndef DEFINED_IBV_QP_INIT_SOURCE_QPN
 	// Dont offload mlx5 devices if source qpn is not defined.
 	ib_ctx_handler* ib_ctx = g_p_ib_ctx_handler_collection->get_ib_ctx(get_ifname_link());
-	if (!p_ib_ctx->is_mlx4()) {
+	if (!ib_ctx->is_mlx4()) {
 		nd_logwarn("Blocking offload: SOURCE_QPN is not supported for this driver ('%s')", interface_name);
 		return false;
 	}

--- a/src/vma/dev/qp_mgr.cpp
+++ b/src/vma/dev/qp_mgr.cpp
@@ -135,7 +135,7 @@ cq_mgr* qp_mgr::handle_cq_initialization(uint32_t *num_wr, struct ibv_comp_chann
 	} catch (vma_exception& e) {
 		// This is a workaround for an issue with cq creation of mlx4 devices on
 		// upstream-driver VMs over Windows Hypervisor.
-		if (safe_mce_sys().hypervisor == mce_sys_var::HYPER_MSHV && !strncmp(m_p_ib_ctx_handler->get_ibname(), "mlx4", 4) &&
+		if (safe_mce_sys().hypervisor == mce_sys_var::HYPER_MSHV && m_p_ib_ctx_handler->is_mlx4() &&
 				*num_wr > MAX_UPSTREAM_CQ_MSHV_SIZE) {
 			qp_logdbg("cq creation failed with cq_size of %d. retrying with size of %d", *num_wr, MAX_UPSTREAM_CQ_MSHV_SIZE);
 			*num_wr = MAX_UPSTREAM_CQ_MSHV_SIZE;
@@ -724,7 +724,7 @@ void qp_mgr_ib::update_pkey_index()
 	 * Note: mlx4 does not support this capability. Disable it explicitly because dynamic check
 	 * using ibv_create_qp does not help
 	 */
-	if (strncmp(m_p_ib_ctx_handler->get_ibname(), "mlx4", 4)) {
+	if (!m_p_ib_ctx_handler->is_mlx4()) {
 		m_underly_qpn = m_p_ring->get_qpn();
 	}
 	qp_logdbg("IB: Use qpn = 0x%X for device: %s", m_underly_qpn, m_p_ib_ctx_handler->get_ibname());

--- a/src/vma/main.cpp
+++ b/src/vma/main.cpp
@@ -302,25 +302,6 @@ void check_locked_mem()
 	}
 }
 
-void check_flow_steering_log_num_mgm_entry_size()
-{
-	char flow_steering_val[4] = {0};
-	if (priv_safe_try_read_file((const char*)FLOW_STEERING_MGM_ENTRY_SIZE_PARAM_FILE, flow_steering_val, sizeof(flow_steering_val)) == -1) {
-		vlog_printf(VLOG_DEBUG, "Flow steering option for mlx4 driver does not exist in current OFED version\n");
-	}
-	else if (flow_steering_val[0] != '-' || (strtol(&flow_steering_val[1], NULL, 0) % 2) == 0) {
-		vlog_printf(VLOG_WARNING, "***************************************************************************************\n");
-		vlog_printf(VLOG_WARNING, "* VMA will not operate properly while flow steering option is disabled                *\n");
-		vlog_printf(VLOG_WARNING, "* In order to enable flow steering please restart your VMA applications after running *\n");
-		vlog_printf(VLOG_WARNING, "* the following:                                                                      *\n");
-		vlog_printf(VLOG_WARNING, "* For your information the following steps will restart your network interface        *\n");
-		vlog_printf(VLOG_WARNING, "* 1. \"echo options mlx4_core log_num_mgm_entry_size=-1 > /etc/modprobe.d/mlnx.conf\"   *\n");
-		vlog_printf(VLOG_WARNING, "* 2. Restart openibd or rdma service depending on your system configuration           *\n");
-		vlog_printf(VLOG_WARNING, "* Read more about the Flow Steering support in the VMA's User Manual                  *\n");
-		vlog_printf(VLOG_WARNING, "***************************************************************************************\n");
-	}
-}
-
 const char* thread_mode_str(thread_mode_t thread_mode)
 {
 	switch (thread_mode) {
@@ -995,7 +976,6 @@ extern "C" int main_init(void)
 	check_debug();
 	check_cpu_speed();
 	check_locked_mem();
-	check_flow_steering_log_num_mgm_entry_size();
 	check_netperf_flags();
 
 	if (*safe_mce_sys().stats_filename) {


### PR DESCRIPTION
VMA provides a warning while mlx4-steering-rules are disabled.
This warning is presented during main initialization even when no mlx4
devices are available and no socket-api functions were used.

Signed-off-by: Liran Oz <lirano@mellanox.com>