### PR TITLE
issue: 1677457 Add methods mask to VMA extra api

### DIFF
--- a/src/vma/sock/sock-redirect.cpp
+++ b/src/vma/sock/sock-redirect.cpp
@@ -121,6 +121,11 @@ void assign_dlsym(T &ptr, const char *name) {
 		} \
 	}
 
+#define SET_EXTRA_API(dst, func, mask) do { \
+		vma_api->dst = func; \
+		vma_api->vma_extra_supported_mask |= mask; \
+} while(0);
+
 void get_orig_funcs()
 {
 	// Save pointer to original functions
@@ -1092,39 +1097,32 @@ int getsockopt(int __fd, int __level, int __optname,
 	if (__fd == -1 && __level == SOL_SOCKET && __optname == SO_VMA_GET_API &&
 	    __optlen && *__optlen >= sizeof(struct vma_api_t*)) {
 		DO_GLOBAL_CTORS();
+		bool enable_socketxtreme = safe_mce_sys().enable_socketxtreme;
 		srdr_logdbg("User request for VMA Extra API pointers");
 		struct vma_api_t *vma_api = new struct vma_api_t();
 
-		vma_api->register_recv_callback = vma_register_recv_callback;
-		vma_api->recvfrom_zcopy = vma_recvfrom_zcopy;
-		vma_api->free_packets = vma_free_packets;
-		vma_api->add_conf_rule = vma_add_conf_rule;
-		vma_api->thread_offload = vma_thread_offload;
-
-		vma_api->get_socket_rings_num = vma_get_socket_rings_num;
-		vma_api->get_socket_rings_fds = vma_get_socket_rings_fds;
-		vma_api->get_socket_tx_ring_fd = vma_get_socket_tx_ring_fd;
-		vma_api->vma_add_ring_profile = vma_add_ring_profile;
-		vma_api->get_socket_network_header = vma_get_socket_netowrk_header;
-		vma_api->get_ring_direct_descriptors = vma_get_ring_direct_descriptors;
-		vma_api->register_memory_on_ring = vma_reg_mr_on_ring;
-		vma_api->deregister_memory_on_ring = vma_dereg_mr_on_ring;
-		vma_api->socketxtreme_free_vma_packets = (safe_mce_sys().enable_socketxtreme ?
-				vma_socketxtreme_free_vma_packets :
-				dummy_vma_socketxtreme_free_vma_packets);
-		vma_api->socketxtreme_poll = (safe_mce_sys().enable_socketxtreme ?
-				vma_socketxtreme_poll :
-				dummy_vma_socketxtreme_poll);
-		vma_api->socketxtreme_ref_vma_buff = (safe_mce_sys().enable_socketxtreme ?
-				vma_socketxtreme_ref_vma_buff :
-				dummy_vma_socketxtreme_ref_vma_buff);
-		vma_api->socketxtreme_free_vma_buff = (safe_mce_sys().enable_socketxtreme ?
-				vma_socketxtreme_free_vma_buff :
-				dummy_vma_socketxtreme_free_vma_buff);
-		vma_api->dump_fd_stats = vma_dump_fd_stats;
-		vma_api->vma_cyclic_buffer_read = vma_cyclic_buffer_read;
-		vma_api->get_mem_info = vma_get_mem_info;
-		vma_api->vma_modify_ring = vma_modify_ring;
+		vma_api->vma_extra_supported_mask = 0;
+		SET_EXTRA_API(register_recv_callback, vma_register_recv_callback, VMA_EXTRA_API_REGISTER_RECV_CALLBACK);
+		SET_EXTRA_API(recvfrom_zcopy, vma_recvfrom_zcopy, VMA_EXTRA_API_RECVFROM_ZCOPY);
+		SET_EXTRA_API(free_packets, vma_free_packets, VMA_EXTRA_API_FREE_PACKETS);
+		SET_EXTRA_API(add_conf_rule, vma_add_conf_rule, VMA_EXTRA_API_ADD_CONF_RULE);
+		SET_EXTRA_API(thread_offload, vma_thread_offload, VMA_EXTRA_API_THREAD_OFFLOAD);
+		SET_EXTRA_API(get_socket_rings_num, vma_get_socket_rings_num, VMA_EXTRA_API_GET_SOCKET_RINGS_NUM);
+		SET_EXTRA_API(get_socket_rings_fds, vma_get_socket_rings_fds, VMA_EXTRA_API_GET_SOCKET_RINGS_FDS);
+		SET_EXTRA_API(get_socket_tx_ring_fd, vma_get_socket_tx_ring_fd, VMA_EXTRA_API_GET_SOCKET_TX_RING_FD);
+		SET_EXTRA_API(vma_add_ring_profile, vma_add_ring_profile, VMA_EXTRA_API_ADD_RING_PROFILE);
+		SET_EXTRA_API(get_socket_network_header, vma_get_socket_netowrk_header, VMA_EXTRA_API_GET_SOCKET_NETWORK_HEADER);
+		SET_EXTRA_API(get_ring_direct_descriptors, vma_get_ring_direct_descriptors, VMA_EXTRA_API_GET_RING_DIRECT_DESCRIPTORS);
+		SET_EXTRA_API(register_memory_on_ring, vma_reg_mr_on_ring, VMA_EXTRA_API_REGISTER_MEMORY_ON_RING);
+		SET_EXTRA_API(deregister_memory_on_ring, vma_dereg_mr_on_ring, VMA_EXTRA_API_REGISTER_MEMORY_ON_RING);
+		SET_EXTRA_API(socketxtreme_free_vma_packets, enable_socketxtreme ? vma_socketxtreme_free_vma_packets : dummy_vma_socketxtreme_free_vma_packets, VMA_EXTRA_API_SOCKETXTREME_FREE_VMA_PACKETS);
+		SET_EXTRA_API(socketxtreme_poll, enable_socketxtreme ? vma_socketxtreme_poll : dummy_vma_socketxtreme_poll, VMA_EXTRA_API_SOCKETXTREME_POLL);
+		SET_EXTRA_API(socketxtreme_ref_vma_buff, enable_socketxtreme ? vma_socketxtreme_ref_vma_buff : dummy_vma_socketxtreme_ref_vma_buff, VMA_EXTRA_API_SOCKETXTREME_REF_VMA_BUFF);
+		SET_EXTRA_API(socketxtreme_free_vma_buff, enable_socketxtreme ? vma_socketxtreme_free_vma_buff : dummy_vma_socketxtreme_free_vma_buff, VMA_EXTRA_API_SOCKETXTREME_FREE_VMA_BUFF);
+		SET_EXTRA_API(dump_fd_stats, vma_dump_fd_stats, VMA_EXTRA_API_DUMP_FD_STATS);
+		SET_EXTRA_API(vma_cyclic_buffer_read, vma_cyclic_buffer_read, VMA_EXTRA_API_CYCLIC_BUFFER_READ);
+		SET_EXTRA_API(get_mem_info, vma_get_mem_info, VMA_EXTRA_API_GET_MEM_INFO);
+		SET_EXTRA_API(vma_modify_ring, vma_modify_ring, VMA_EXTRA_API_MODIFY_RING);
 		*((vma_api_t**)__optval) = vma_api;
 		return 0;
 	}

--- a/src/vma/sock/sock-redirect.cpp
+++ b/src/vma/sock/sock-redirect.cpp
@@ -1114,7 +1114,7 @@ int getsockopt(int __fd, int __level, int __optname,
 		SET_EXTRA_API(get_socket_network_header, vma_get_socket_netowrk_header, VMA_EXTRA_API_GET_SOCKET_NETWORK_HEADER);
 		SET_EXTRA_API(get_ring_direct_descriptors, vma_get_ring_direct_descriptors, VMA_EXTRA_API_GET_RING_DIRECT_DESCRIPTORS);
 		SET_EXTRA_API(register_memory_on_ring, vma_reg_mr_on_ring, VMA_EXTRA_API_REGISTER_MEMORY_ON_RING);
-		SET_EXTRA_API(deregister_memory_on_ring, vma_dereg_mr_on_ring, VMA_EXTRA_API_REGISTER_MEMORY_ON_RING);
+		SET_EXTRA_API(deregister_memory_on_ring, vma_dereg_mr_on_ring, VMA_EXTRA_API_DEREGISTER_MEMORY_ON_RING);
 		SET_EXTRA_API(socketxtreme_free_vma_packets, enable_socketxtreme ? vma_socketxtreme_free_vma_packets : dummy_vma_socketxtreme_free_vma_packets, VMA_EXTRA_API_SOCKETXTREME_FREE_VMA_PACKETS);
 		SET_EXTRA_API(socketxtreme_poll, enable_socketxtreme ? vma_socketxtreme_poll : dummy_vma_socketxtreme_poll, VMA_EXTRA_API_SOCKETXTREME_POLL);
 		SET_EXTRA_API(socketxtreme_ref_vma_buff, enable_socketxtreme ? vma_socketxtreme_ref_vma_buff : dummy_vma_socketxtreme_ref_vma_buff, VMA_EXTRA_API_SOCKETXTREME_REF_VMA_BUFF);

--- a/src/vma/vma_extra.h
+++ b/src/vma/vma_extra.h
@@ -229,7 +229,7 @@ typedef enum {
  * @brief pass this struct to vma using setsockopt with @ref SO_VMA_RING_ALLOC_LOGIC
  * 	to set the allocation logic of this FD when he requests a ring.
  * 	@note ring_alloc_logic is a mandatory
- * @param comp_mask - what fields are read when processing this sturct
+ * @param comp_mask - what fields are read when processing this struct
  * 	see @ref vma_ring_alloc_logic_attr_comp_mask
  * @param ring_alloc_logic- allocation ratio to use
  * @param ring_profile_key - what ring profile to use - get the profile when
@@ -294,7 +294,7 @@ struct vma_modify_ring_attr {
 };
 
 /**
- * @param comp_mask - what fields are read when processing this sturct see @ref vma_cb_ring_attr_mask
+ * @param comp_mask - what fields are read when processing this struct see @ref vma_cb_ring_attr_mask
  * @param num - Minimum number of elements allocated in the circular buffer
  * @param hdr_bytes - Bytes separated from UDP payload which are
  * 	part of the application header
@@ -368,7 +368,7 @@ typedef enum {
 } vma_ring_type;
 
 /**
- * @param comp_mask - what fields are read when processing this sturct
+ * @param comp_mask - what fields are read when processing this struct
  * 	see @ref vma_ring_type_attr_mask
  * @param ring_type - use cyclic buffer ring or default packets ring
  *
@@ -444,6 +444,30 @@ struct vma_mlx_hw_device_data {
 	struct hw_sq_data sq_data;
 	struct hw_rq_data rq_data;
 };
+
+typedef enum {
+	VMA_EXTRA_API_REGISTER_RECV_CALLBACK         = (1 << 0),
+	VMA_EXTRA_API_RECVFROM_ZCOPY                 = (1 << 1),
+	VMA_EXTRA_API_FREE_PACKETS                   = (1 << 2),
+	VMA_EXTRA_API_ADD_CONF_RULE                  = (1 << 3),
+	VMA_EXTRA_API_THREAD_OFFLOAD                 = (1 << 4),
+	VMA_EXTRA_API_DUMP_FD_STATS                  = (1 << 5),
+	VMA_EXTRA_API_SOCKETXTREME_POLL              = (1 << 6),
+	VMA_EXTRA_API_SOCKETXTREME_FREE_VMA_PACKETS  = (1 << 7),
+	VMA_EXTRA_API_SOCKETXTREME_REF_VMA_BUFF      = (1 << 8),
+	VMA_EXTRA_API_SOCKETXTREME_FREE_VMA_BUFF     = (1 << 9),
+	VMA_EXTRA_API_GET_SOCKET_RINGS_NUM           = (1 << 10),
+	VMA_EXTRA_API_GET_SOCKET_RINGS_FDS           = (1 << 11),
+	VMA_EXTRA_API_GET_SOCKET_TX_RING_FD          = (1 << 12),
+	VMA_EXTRA_API_GET_SOCKET_NETWORK_HEADER      = (1 << 13),
+	VMA_EXTRA_API_GET_RING_DIRECT_DESCRIPTORS    = (1 << 14),
+	VMA_EXTRA_API_CYCLIC_BUFFER_READ             = (1 << 15),
+	VMA_EXTRA_API_ADD_RING_PROFILE               = (1 << 16),
+	VMA_EXTRA_API_REGISTER_MEMORY_ON_RING        = (1 << 17),
+	VMA_EXTRA_API_DEREGISTER_MEMORY_ON_RING      = (1 << 18),
+	VMA_EXTRA_API_GET_MEM_INFO                   = (1 << 19),
+	VMA_EXTRA_API_MODIFY_RING                    = (1 << 20)
+} vma_extra_api_mask;
 
 /** 
  *  
@@ -812,6 +836,12 @@ struct __attribute__ ((packed)) vma_api_t {
 	 * @return 0 on success -1 on failure
 	 */
 	int (*vma_modify_ring)(struct vma_modify_ring_attr *mr_data);
+
+	/**
+	 * Used to identify which methods were initialized by VMA as part of vma_get_api().
+	 * The value content is based on vma_extra_api_mask enum.
+	 */
+	uint64_t vma_extra_supported_mask;
 };
 
 


### PR DESCRIPTION
This adds additional mask to the extra API header so the user would
be able to query which methods were initialized by VMA as part of
vma_get_api().

Signed-off-by: Liran Oz <lirano@mellanox.com>