### PR TITLE
issue: 1679709 Fix missing update of CQ consumer index

### DIFF
--- a/src/vma/dev/cq_mgr.cpp
+++ b/src/vma/dev/cq_mgr.cpp
@@ -933,6 +933,7 @@ cq_mgr* get_cq_mgr_from_cq_event(struct ibv_comp_channel* p_cq_channel)
 	}
 	else {
 		p_cq_mgr = (cq_mgr*)p_context; // Save the cq_mgr
+		p_cq_mgr->get_cq_event();
 		ibv_ack_cq_events(p_cq_hndl, 1); // Ack the ibv event
 	} ENDIF_VERBS_FAILURE;
 

--- a/src/vma/dev/cq_mgr.h
+++ b/src/vma/dev/cq_mgr.h
@@ -175,6 +175,7 @@ public:
 	void 	unmap_vlan_and_qpn(int qp_num, uint16_t vlan_id);
 
 	virtual bool fill_cq_hw_descriptors(struct hw_cq_data &data) {NOT_IN_USE(data);return false;};
+	virtual void get_cq_event() {};
 
 protected:
 
@@ -226,8 +227,6 @@ protected:
 	const uint32_t		m_n_sysvar_rx_prefetch_bytes_before_poll;
 	const uint32_t		m_n_sysvar_rx_prefetch_bytes;
 	size_t			m_sz_transport_header;
-
-protected:
 	ib_ctx_handler*		m_p_ib_ctx_handler;
 	const uint32_t		m_n_sysvar_rx_num_wr_to_post_recv;
 private:
@@ -269,8 +268,6 @@ private:
 	virtual int	req_notify_cq() {
 		return ibv_req_notify_cq(m_p_ibv_cq, 0);
 	};
-
-	virtual void	get_cq_event() {};
 };
 
 // Helper gunction to extract the Tx cq_mgr from the CQ event,

--- a/src/vma/dev/cq_mgr_mlx5.h
+++ b/src/vma/dev/cq_mgr_mlx5.h
@@ -71,6 +71,7 @@ public:
 	virtual void                add_qp_tx(qp_mgr* qp);
 	virtual uint32_t            clean_cq();
 	virtual bool                fill_cq_hw_descriptors(struct hw_cq_data &data);
+	virtual void                get_cq_event() { vma_ib_mlx5_get_cq_event(&m_mlx5_cq); };
 
 protected:
 	qp_mgr_eth_mlx5*            m_qp;
@@ -89,10 +90,6 @@ private:
 
 	virtual int	req_notify_cq() {
 		return vma_ib_mlx5_req_notify_cq(&m_mlx5_cq, 0);
-	};
-
-	virtual void	get_cq_event() {
-		vma_ib_mlx5_get_cq_event(&m_mlx5_cq);
 	};
 };
 

--- a/src/vma/ib/mlx5/ib_mlx5.h
+++ b/src/vma/ib/mlx5/ib_mlx5.h
@@ -122,10 +122,7 @@ int vma_ib_mlx5_post_recv(vma_ib_mlx5_qp_t *mlx5_qp, struct ibv_recv_wr *wr, str
 
 int vma_ib_mlx5_get_cq(struct ibv_cq *cq, vma_ib_mlx5_cq_t *mlx5_cq);
 int vma_ib_mlx5_req_notify_cq(vma_ib_mlx5_cq_t *mlx5_cq, int solicited);
-static inline void vma_ib_mlx5_get_cq_event(vma_ib_mlx5_cq_t *mlx5_cq)
-{
-	mlx5_cq->cq_sn++;
-}
+void vma_ib_mlx5_get_cq_event(vma_ib_mlx5_cq_t *mlx5_cq);
 
 #endif /* DEFINED_DIRECT_VERBS */
 

--- a/src/vma/ib/mlx5/ib_mlx5_dv.cpp
+++ b/src/vma/ib/mlx5/ib_mlx5_dv.cpp
@@ -77,4 +77,9 @@ int vma_ib_mlx5_req_notify_cq(vma_ib_mlx5_cq_t *mlx5_cq, int solicited)
 	return 0;
 }
 
+void vma_ib_mlx5_get_cq_event(vma_ib_mlx5_cq_t *mlx5_cq)
+{
+	mlx5_cq->cq_sn++;
+}
+
 #endif /* (DEFINED_DIRECT_VERBS == 3) */

--- a/src/vma/ib/mlx5/ib_mlx5_hw.cpp
+++ b/src/vma/ib/mlx5/ib_mlx5_hw.cpp
@@ -112,6 +112,7 @@ int vma_ib_mlx5_req_notify_cq(vma_ib_mlx5_cq_t *mlx5_cq, int solicited)
 
 void vma_ib_mlx5_get_cq_event(vma_ib_mlx5_cq_t *)
 {
+	// no need in operation with cq_sn as far as it is managed by driver code for now
 }
 
 #endif /* (DEFINED_DIRECT_VERBS == 2) */

--- a/src/vma/ib/mlx5/ib_mlx5_hw.cpp
+++ b/src/vma/ib/mlx5/ib_mlx5_hw.cpp
@@ -110,4 +110,8 @@ int vma_ib_mlx5_req_notify_cq(vma_ib_mlx5_cq_t *mlx5_cq, int solicited)
 	return ibv_req_notify_cq(mlx5_cq->cq, solicited);
 }
 
+void vma_ib_mlx5_get_cq_event(vma_ib_mlx5_cq_t *)
+{
+}
+
 #endif /* (DEFINED_DIRECT_VERBS == 2) */


### PR DESCRIPTION
CQ consumer index should be updated before calling
ibv_ack_cq_events.
This only affects mlx5dv CQs.

Signed-off-by: Liran Oz <lirano@mellanox.com>