### PR TITLE
issue: 1264894 Resolve fd collection memory leaks

### DIFF
--- a/contrib/valgrind/valgrind_vma.supp
+++ b/contrib/valgrind/valgrind_vma.supp
@@ -1,33 +1,3 @@
-# libvma issues to fix
-{
-   RM #1284069
-   Memcheck:Leak
-   match-leak-kinds: definite
-   ...
-   fun:_ZN20net_device_table_mgr16create_new_entryE10ip_addressPK8observer
-   fun:_ZN15cache_table_mgrI10ip_addressP14net_device_valE17register_observerES0_PK14cache_observerPP19cache_entry_subjectIS0_S2_E
-   fun:_ZN11route_entry22register_to_net_deviceEv
-}
-{
-   RM #1284069
-   Memcheck:Leak
-   match-leak-kinds: definite
-   ...
-   fun:_ZN15neigh_table_mgr16create_new_entryE9neigh_keyPK8observer
-   fun:register_observer
-   fun:_ZN15neigh_table_mgr17register_observerE9neigh_keyPK14cache_observerPP19cache_entry_subjectIS0_P9neigh_valE
-   fun:_ZN9dst_entry13resolve_neighEv
-   fun:_ZN9dst_entry15prepare_to_sendER16vma_rate_limit_tbb
-   ...
-}
-{
-   RM #1072427
-   Memcheck:Leak
-   match-leak-kinds: definite
-   fun:_Znwm
-   fun:_ZN13fd_collection17add_cq_channel_fdEiP4ring
-   fun:_ZN11ring_simple16create_resourcesEv
-}
 ###########################################################
 # false positive librdmacm.so
 {

--- a/src/vma/proto/igmp_handler.cpp
+++ b/src/vma/proto/igmp_handler.cpp
@@ -157,7 +157,12 @@ void igmp_handler::clean_obj()
 {
 	set_cleaned();
 	m_timer_handle = NULL;
-	g_p_event_handler_manager->unregister_timers_event_and_delete(this);
+
+	if (g_p_event_handler_manager->is_running()) {
+		g_p_event_handler_manager->unregister_timers_event_and_delete(this);
+	} else {
+		cleanable_obj::clean_obj();
+	}
 }
 
 void igmp_handler::handle_timer_expired(void* user_data)

--- a/src/vma/proto/neighbour.cpp
+++ b/src/vma/proto/neighbour.cpp
@@ -280,8 +280,13 @@ void neigh_entry::clean_obj()
 	m_lock.lock();
 	set_cleaned();
 	m_timer_handle = NULL;
-	g_p_event_handler_manager->unregister_timers_event_and_delete(this);
-	m_lock.unlock();
+	if (g_p_event_handler_manager->is_running()) {
+		g_p_event_handler_manager->unregister_timers_event_and_delete(this);
+		m_lock.unlock();
+	} else {
+		m_lock.unlock();
+		cleanable_obj::clean_obj();
+	}
 }
 
 int neigh_entry::send(neigh_send_info &s_info)

--- a/src/vma/sock/pipeinfo.cpp
+++ b/src/vma/sock/pipeinfo.cpp
@@ -140,7 +140,11 @@ void pipeinfo::clean_obj()
 {
 	set_cleaned();
 	m_timer_handle = NULL;
-	g_p_event_handler_manager->unregister_timers_event_and_delete(this);
+	if (g_p_event_handler_manager->is_running()) {
+		g_p_event_handler_manager->unregister_timers_event_and_delete(this);
+	} else {
+		cleanable_obj::clean_obj();
+	}
 }
 
 int pipeinfo::fcntl(int __cmd, unsigned long int __arg)

--- a/src/vma/sock/socket_fd_api.h
+++ b/src/vma/sock/socket_fd_api.h
@@ -244,13 +244,10 @@ protected:
 	// identification information <socket fd>
 	int m_fd;
 	const uint32_t	m_n_sysvar_select_poll_os_ratio;
+	epfd_info *m_econtext;
 
 	// Calling OS receive
 	ssize_t rx_os(const rx_call_t call_type, iovec* p_iov, ssize_t sz_iov,
 		      const int flags, sockaddr *__from, socklen_t *__fromlen, struct msghdr *__msg);
-
-
-private:
-	epfd_info *m_econtext;
 };
 #endif

--- a/src/vma/sock/sockinfo_tcp.cpp
+++ b/src/vma/sock/sockinfo_tcp.cpp
@@ -582,16 +582,6 @@ void sockinfo_tcp::force_close()
 	lock_tcp_con();
 	if (!is_closable()) abort_connection();
 	unlock_tcp_con();
-
-	//print the statistics of the socket to vma_stats file
-	vma_stats_instance_remove_socket_block(m_p_socket_stats);
-
-	BULLSEYE_EXCLUDE_BLOCK_START
-	if (m_call_orig_close_on_dtor) {
-		si_tcp_logdbg("calling orig_os_close on dup %d of %d",m_call_orig_close_on_dtor, m_fd);
-		orig_os_api.close(m_call_orig_close_on_dtor);
-	}
-	BULLSEYE_EXCLUDE_BLOCK_END
 }
 
 // This method will be on syn received on the passive side of a TCP connection

--- a/src/vma/sock/sockinfo_tcp.cpp
+++ b/src/vma/sock/sockinfo_tcp.cpp
@@ -375,7 +375,12 @@ void sockinfo_tcp::clean_obj()
 		g_p_event_handler_manager->unregister_timer_event(this, m_timer_handle);
 		m_timer_handle = NULL;
 	}
-	g_p_event_handler_manager->unregister_timers_event_and_delete(this);
+
+	if (g_p_event_handler_manager->is_running()) {
+		g_p_event_handler_manager->unregister_timers_event_and_delete(this);
+	} else {
+		cleanable_obj::clean_obj();
+	}
 }
 
 bool sockinfo_tcp::prepare_listen_to_close()

--- a/src/vma/sock/sockinfo_tcp.cpp
+++ b/src/vma/sock/sockinfo_tcp.cpp
@@ -531,6 +531,10 @@ bool sockinfo_tcp::prepare_to_close(bool process_shutdown /* = false */)
 
 	do_wakeup();
 
+	if (m_econtext) {
+		m_econtext->fd_closed(m_fd);
+	}
+
 	unlock_tcp_con();
 
 	return (is_closable());

--- a/src/vma/sock/sockinfo_udp.cpp
+++ b/src/vma/sock/sockinfo_udp.cpp
@@ -2577,7 +2577,13 @@ void sockinfo_udp::push_back_m_rx_pkt_ready_list(mem_buf_desc_t* buff){
 bool sockinfo_udp::prepare_to_close(bool process_shutdown) {
 	m_lock_rcv.lock();
 	do_wakeup();
+
+	if (m_econtext) {
+		m_econtext->fd_closed(m_fd);
+	}
+
 	m_lock_rcv.unlock();
+
 	NOT_IN_USE(process_shutdown);
 	m_state = SOCKINFO_CLOSING;
 	return is_closable();


### PR DESCRIPTION
Socket objects are freed during fd collection cleanup process which
done by the internal thread using unregister_timers_event_and_delete().
Because the internal thread is stopped at this point, the sockets
are not deleted at all.

Signed-off-by: Liran Oz <lirano@mellanox.com>