### PR TITLE
issue: 1682300 Fix double free in free_libvma_resources

### DIFF
--- a/src/vma/main.cpp
+++ b/src/vma/main.cpp
@@ -874,12 +874,10 @@ int do_global_ctors()
 	}
 	catch (const vma_exception& error) {
 		vlog_printf(VLOG_DETAILS, "Error: %s", error.what());
-		free_libvma_resources();
 		return -1;
 	}
 	catch (const std::exception& error ) {
 		vlog_printf(VLOG_ERROR, "%s", error.what());
-		free_libvma_resources();
 		return -1;
 	}
 	return 0;

--- a/src/vma/main.cpp
+++ b/src/vma/main.cpp
@@ -241,6 +241,7 @@ static int free_libvma_resources()
 		//cosmetics - remove when adding iomux block
 		fprintf(g_stats_file, "======================================================\n");
 		fclose (g_stats_file);
+		g_stats_file = NULL;
 	}
 
 	return 0;


### PR DESCRIPTION
g_stats_file should be set to null during free library resources
procedure.

Signed-off-by: Liran Oz <lirano@mellanox.com>