### PR TITLE
issue: 1687458 Fix double free of TCP timer event

### DIFF
--- a/src/vma/sock/sockinfo_tcp.cpp
+++ b/src/vma/sock/sockinfo_tcp.cpp
@@ -322,12 +322,12 @@ sockinfo_tcp::~sockinfo_tcp()
 {
 	si_tcp_logfunc("");
 
+	lock_tcp_con();
+
 	if (!is_closable()) {
 		//prepare to close wasn't called?
 		prepare_to_close();
 	}
-
-	lock_tcp_con();
 
 	do_wakeup();
 
@@ -369,13 +369,18 @@ sockinfo_tcp::~sockinfo_tcp()
 
 void sockinfo_tcp::clean_obj()
 {
+	lock_tcp_con();
+
 	set_cleaned();
 
 	if (m_timer_handle) {
 		g_p_event_handler_manager->unregister_timer_event(this, m_timer_handle);
 		m_timer_handle = NULL;
 	}
+
 	g_p_event_handler_manager->unregister_timers_event_and_delete(this);
+
+	unlock_tcp_con();
 }
 
 bool sockinfo_tcp::prepare_listen_to_close()
@@ -566,13 +571,13 @@ void sockinfo_tcp::force_close()
 {
 	si_tcp_logdbg("can't reach dtor - force closing the socket");
 
+	lock_tcp_con();
+
 	//if the socket is not closed yet, send RST to remote host before exit.
 	//we have to do this because we don't have VMA deamon
 	//to progress connection closure after process termination
 
-	lock_tcp_con();
 	if (!is_closable()) abort_connection();
-	unlock_tcp_con();
 
 	//print the statistics of the socket to vma_stats file
 	vma_stats_instance_remove_socket_block(m_p_socket_stats);
@@ -583,6 +588,8 @@ void sockinfo_tcp::force_close()
 		orig_os_api.close(m_call_orig_close_on_dtor);
 	}
 	BULLSEYE_EXCLUDE_BLOCK_END
+
+	unlock_tcp_con();
 }
 
 // This method will be on syn received on the passive side of a TCP connection
@@ -1147,8 +1154,12 @@ void sockinfo_tcp::err_lwip_cb(void *pcb_container, err_t err)
 	}
 
 	if (conn->m_timer_handle) {
-		g_p_event_handler_manager->unregister_timer_event(conn, conn->m_timer_handle);
-		conn->m_timer_handle = NULL;
+		conn->lock_tcp_con();
+		if (conn->m_timer_handle) {
+			g_p_event_handler_manager->unregister_timer_event(conn, conn->m_timer_handle);
+			conn->m_timer_handle = NULL;
+		}
+		conn->unlock_tcp_con();
 	}
 
 	conn->do_wakeup();


### PR DESCRIPTION
Deletion of TCP timer should be protected under socket lock in
This deletion is called from two different locations:
sockinfo_tcp::clean_obj - from the internal thread context.
sockinfo_tcp::err_lwip_cb - from the application thread.

Signed-off-by: Liran Oz <lirano@mellanox.com>