### PR TITLE
issue: 1701456 Enable mlx4 flow steering warning for VM

### DIFF
--- a/src/vma/dev/ib_ctx_handler_collection.cpp
+++ b/src/vma/dev/ib_ctx_handler_collection.cpp
@@ -65,15 +65,27 @@ void check_flow_steering_log_num_mgm_entry_size()
 	if (priv_safe_try_read_file((const char*)FLOW_STEERING_MGM_ENTRY_SIZE_PARAM_FILE, flow_steering_val, sizeof(flow_steering_val)) == -1) {
 		vlog_printf(VLOG_DEBUG, "Flow steering option for mlx4 driver does not exist in current OFED version\n");
 	} else if (flow_steering_val[0] != '-' || (strtol(&flow_steering_val[1], NULL, 0) % 2) == 0) {
-		vlog_printf(VLOG_WARNING, "***************************************************************************************\n");
-		vlog_printf(VLOG_WARNING, "* VMA will not operate properly while flow steering option is disabled                *\n");
-		vlog_printf(VLOG_WARNING, "* In order to enable flow steering please restart your VMA applications after running *\n");
-		vlog_printf(VLOG_WARNING, "* the following:                                                                      *\n");
-		vlog_printf(VLOG_WARNING, "* For your information the following steps will restart your network interface        *\n");
-		vlog_printf(VLOG_WARNING, "* 1. \"echo options mlx4_core log_num_mgm_entry_size=-1 > /etc/modprobe.d/mlnx.conf\"   *\n");
-		vlog_printf(VLOG_WARNING, "* 2. Restart openibd or rdma service depending on your system configuration           *\n");
-		vlog_printf(VLOG_WARNING, "* Read more about the Flow Steering support in the VMA's User Manual                  *\n");
-		vlog_printf(VLOG_WARNING, "***************************************************************************************\n");
+		char module_info[3] = {0};
+		if (!run_and_retreive_system_command("modinfo mlx4_core > /dev/null 2>&1 ; echo $?",
+				module_info, sizeof(module_info)) &&
+				(strlen(module_info) > 0)) {
+			if (module_info[0] == '0') {
+				vlog_printf(VLOG_WARNING, "***************************************************************************************\n");
+				vlog_printf(VLOG_WARNING, "* VMA will not operate properly while flow steering option is disabled                *\n");
+				vlog_printf(VLOG_WARNING, "* In order to enable flow steering please restart your VMA applications after running *\n");
+				vlog_printf(VLOG_WARNING, "* the following:                                                                      *\n");
+				vlog_printf(VLOG_WARNING, "* For your information the following steps will restart your network interface        *\n");
+				vlog_printf(VLOG_WARNING, "* 1. \"echo options mlx4_core log_num_mgm_entry_size=-1 > /etc/modprobe.d/mlnx.conf\"   *\n");
+				vlog_printf(VLOG_WARNING, "* 2. Restart openibd or rdma service depending on your system configuration           *\n");
+				vlog_printf(VLOG_WARNING, "* Read more about the Flow Steering support in the VMA's User Manual                  *\n");
+				vlog_printf(VLOG_WARNING, "***************************************************************************************\n");
+			} else {
+				vlog_printf(VLOG_DEBUG, "***************************************************************************************\n");
+				vlog_printf(VLOG_DEBUG, "* VMA will not operate properly while flow steering option is disabled                *\n");
+				vlog_printf(VLOG_DEBUG, "* Read more about the Flow Steering support in the VMA's User Manual                  *\n");
+				vlog_printf(VLOG_DEBUG, "***************************************************************************************\n");
+			}
+		}
 	}
 }
 
@@ -145,10 +157,7 @@ void ib_ctx_handler_collection::update_tbl(const char *ifa_name)
 			}
 
 			// Check if mlx4 steering creation is supported.
-			// Those setting are passed to the VM by the Hypervisor - NO NEED to specify the param on the VM.
-			if (safe_mce_sys().hypervisor == mce_sys_var::HYPER_NONE) {
-				check_flow_steering_log_num_mgm_entry_size();
-			}
+			check_flow_steering_log_num_mgm_entry_size();
 		}
 
 		/* 3. Add new ib devices */


### PR DESCRIPTION
These changes detect if mlx4_core module is build in kernel and
report debug output in this case. When mlx4_core is separate
module detailed warning is reported.

Signed-off-by: Igor Ivanov <igor.ivanov.va@gmail.com>