### PR TITLE
issue: 1734068 Fix inaccurate timer_handler unregistration

### DIFF
--- a/src/utils/lock_wrapper.h
+++ b/src/utils/lock_wrapper.h
@@ -263,7 +263,7 @@ public:
 	inline int is_locked_by_me() {
 		DEFINED_NO_THREAD_LOCK_RETURN_1
 		pthread_t self = pthread_self();
-		return (m_owner == self && m_lock_count);
+		return ((m_owner == self && m_lock_count) ? m_lock_count : 0);
 	};
 
 protected:

--- a/src/vma/event/delta_timer.cpp
+++ b/src/vma/event/delta_timer.cpp
@@ -80,7 +80,8 @@ timer::~timer()
 void timer::add_new_timer(unsigned int timeout_msec, timer_node_t* node, timer_handler* handler, void* user_data, timer_req_type_t req_type)
 {
 	memset(node, 0, sizeof(*node));
-	atomic_set(&node->ref, 0);
+
+	node->lock_timer=lock_spin("timer");
 	node->handler = handler;
 	node->req_type = req_type;
 	node->user_data = user_data;
@@ -235,10 +236,12 @@ void timer::process_registered_timers()
 	while (iter && (iter->delta_time_msec == 0)) {
 		tmr_logfuncall("timer expired on %p", iter->handler);
 
-		if (iter->handler && (0 == atomic_fetch_and_inc(&iter->ref))){
-			iter->handler->handle_timer_expired(iter->user_data);
+		if (!iter->lock_timer.trylock()){
+			if (iter->handler) {
+				iter->handler->handle_timer_expired(iter->user_data);
+			}
+			iter->lock_timer.unlock();
 		}
-		atomic_fetch_and_dec(&iter->ref);
 		next_iter = iter->next;
 
 		switch (iter->req_type) {

--- a/src/vma/event/delta_timer.h
+++ b/src/vma/event/delta_timer.h
@@ -55,9 +55,10 @@ enum timer_req_type_t {
 struct timer_node_t {
 	unsigned int            delta_time_msec;/* delta time from the previous node (millisec) */
 	unsigned int            orig_time_msec;	/* the orig timer requested (saved in order to re-register periodic timers) */
-	timer_handler*          handler;	/* link to the context registered */  
+	atomic_t                ref;            /* control thread-safe access to handler */
+	timer_handler*          handler;	    /* link to the context registered */
 	void*                   user_data;
-	timers_group*		group;
+	timers_group*           group;
 	timer_req_type_t        req_type;
 	struct timer_node_t*    next;
 	struct timer_node_t*    prev;

--- a/src/vma/event/delta_timer.h
+++ b/src/vma/event/delta_timer.h
@@ -35,6 +35,7 @@
 #define DELTA_TIMER_H
 
 #include <time.h>
+#include "utils/lock_wrapper.h"
 
 #define INFINITE_TIMEOUT (-1)
 
@@ -53,10 +54,10 @@ enum timer_req_type_t {
 };
 
 struct timer_node_t {
-	unsigned int            delta_time_msec;/* delta time from the previous node (millisec) */
-	unsigned int            orig_time_msec;	/* the orig timer requested (saved in order to re-register periodic timers) */
-	atomic_t                ref;            /* control thread-safe access to handler */
-	timer_handler*          handler;	    /* link to the context registered */
+	unsigned int            delta_time_msec; /* delta time from the previous node (millisec) */
+	unsigned int            orig_time_msec;	 /* the orig timer requested (saved in order to re-register periodic timers) */
+	lock_spin               lock_timer;      /* control thread-safe access to handler */
+	timer_handler*          handler;         /* link to the context registered */
 	void*                   user_data;
 	timers_group*           group;
 	timer_req_type_t        req_type;

--- a/src/vma/event/delta_timer.h
+++ b/src/vma/event/delta_timer.h
@@ -54,10 +54,17 @@ enum timer_req_type_t {
 };
 
 struct timer_node_t {
-	unsigned int            delta_time_msec; /* delta time from the previous node (millisec) */
-	unsigned int            orig_time_msec;	 /* the orig timer requested (saved in order to re-register periodic timers) */
-	lock_spin               lock_timer;      /* control thread-safe access to handler */
-	timer_handler*          handler;         /* link to the context registered */
+	/* delta time from the previous node (millisec) */
+	unsigned int            delta_time_msec;
+	/* the orig timer requested (saved in order to re-register periodic timers) */
+	unsigned int            orig_time_msec;
+	/* control thread-safe access to handler. Recursive because unregister_timer_event()
+	 * can be called from handle_timer_expired()
+	 * that is under trylock() inside process_registered_timers
+	 */
+	lock_spin_recursive     lock_timer;
+	/* link to the context registered */
+	timer_handler*          handler;
 	void*                   user_data;
 	timers_group*           group;
 	timer_req_type_t        req_type;

--- a/src/vma/event/event_handler_manager.cpp
+++ b/src/vma/event/event_handler_manager.cpp
@@ -146,11 +146,10 @@ void event_handler_manager::unregister_timer_event(timer_handler* handler, void*
 	 * and time for this timer node is expired. In this case there is no guarantee
 	 * to operate with timer_handler object.
 	 * See timer::process_registered_timers()
+	 * Do just lock() to protect timer_handler inside process_registered_timers()
 	 */
 	timer_node_t* timer_node = (timer_node_t*)node;
-	while (0 != atomic_fetch_and_inc(&timer_node->ref)) {
-		atomic_fetch_and_dec(&timer_node->ref);
-	}
+	timer_node->lock_timer.lock();
 
 	post_new_reg_action(reg_action);
 }

--- a/src/vma/sock/sockinfo_tcp.cpp
+++ b/src/vma/sock/sockinfo_tcp.cpp
@@ -4511,6 +4511,7 @@ tcp_timers_collection::tcp_timers_collection(int period, int resolution)
 	m_n_period = period;
 	m_n_resolution = resolution;
 	m_n_intervals_size = period/resolution;
+	m_timer_handle = NULL;
 	m_p_intervals = new timer_node_t*[m_n_intervals_size];
 	BULLSEYE_EXCLUDE_BLOCK_START
 	if (!m_p_intervals) {
@@ -4550,8 +4551,12 @@ void tcp_timers_collection::free_tta_resources(void)
 
 void tcp_timers_collection::clean_obj()
 {
-	set_cleaned();
+	if (is_cleaned()) {
+		return ;
+	}
 
+	set_cleaned();
+	m_timer_handle = NULL;
 	if (g_p_event_handler_manager->is_running()) {
 		g_p_event_handler_manager->unregister_timers_event_and_delete(this);
 	} else {
@@ -4589,7 +4594,7 @@ void tcp_timers_collection::add_new_timer(timer_node_t* node, timer_handler* han
 	m_n_next_insert_bucket = (m_n_next_insert_bucket + 1) % m_n_intervals_size;
 
 	if (m_n_count == 0) {
-		g_p_event_handler_manager->register_timer_event(m_n_resolution , this, PERIODIC_TIMER, NULL);
+		m_timer_handle = g_p_event_handler_manager->register_timer_event(m_n_resolution , this, PERIODIC_TIMER, NULL);
 	}
 	m_n_count++;
 
@@ -4619,7 +4624,10 @@ void tcp_timers_collection::remove_timer(timer_node_t* node)
 
 	m_n_count--;
 	if (m_n_count == 0) {
-		g_p_event_handler_manager->unregister_timer_event(this, NULL);
+		if (m_timer_handle) {
+			g_p_event_handler_manager->unregister_timer_event(this, m_timer_handle);
+			m_timer_handle = NULL;
+		}
 	}
 
 	__log_dbg("TCP timer handler [%p] was removed", node->handler);

--- a/src/vma/sock/sockinfo_tcp.cpp
+++ b/src/vma/sock/sockinfo_tcp.cpp
@@ -1153,6 +1153,12 @@ void sockinfo_tcp::err_lwip_cb(void *pcb_container, err_t err)
 		conn->m_sock_state = TCP_SOCK_INITED;
 	}
 
+	/* In general VMA should avoid calling unregister_timer_event() for the same timer handle twice.
+	 * It is protected by checking m_timer_handle for NULL value that should be under lock.
+	 * In order to save locking time a quick check is done first to ensure that indeed the specific
+	 * timer has not been freed (avoiding the lock/unlock).
+	 * The 2nd check is to avoid a race of the timer been freed while the lock has been taken.
+	 */
 	if (conn->m_timer_handle) {
 		conn->lock_tcp_con();
 		if (conn->m_timer_handle) {

--- a/src/vma/sock/sockinfo_tcp.h
+++ b/src/vma/sock/sockinfo_tcp.h
@@ -495,10 +495,12 @@ protected:
 	void remove_timer(timer_node_t* node);
 
 private:
+	void* m_timer_handle;
+	timer_node_t** m_p_intervals;
+
 	int m_n_period;
 	int m_n_resolution;
 	int m_n_intervals_size;
-	timer_node_t** m_p_intervals;
 	int m_n_location;
 	int m_n_count;
 	int m_n_next_insert_bucket;


### PR DESCRIPTION
Special protection is needed to avoid scenario when deregistration is done
during timer_handler object destruction, timer node itself is not removed
and time for this timer node is expired. In this case there is no guarantee
to operate with timer_handler object.
So assign orig_time_msec field to maximum value;

Signed-off-by: Igor Ivanov <igor.ivanov.va@gmail.com>