### PR TITLE
feature: 1858709 Add option to daemon to set spoofed SYN retry interval on cleanup

### DIFF
--- a/tools/daemon/daemon.h
+++ b/tools/daemon/daemon.h
@@ -143,6 +143,7 @@ struct module_cfg {
 	                                     * reaction on spoofed SYN
 	                                     * 1 - form and send internal RST
 	                                     * based on SeqNo */
+		int retry_interval;         /**< daemon time interval between spoofed SYN packets */
 	} opt;
 	volatile sig_atomic_t sig;
 	const char *lock_file;


### PR DESCRIPTION
Added an option to the vma daemon to set the spoofed SYN retry interval (in milliseconds) on cleanup, which defaults to 1 second. The reason we wanted a reduced interval is because we have local servers which we expect to respond much faster than 1sec. This feature would provide this flexibility to users elegantly rather than needing to change the source code of the provided library.  