### PR TITLE
issue: 1772805 Fix return code for non blocking recv()

### DIFF
--- a/src/vma/dev/net_device_table_mgr.cpp
+++ b/src/vma/dev/net_device_table_mgr.cpp
@@ -491,7 +491,7 @@ int net_device_table_mgr::global_ring_wait_for_notification_and_process_element(
 				// Handle the CQ notification channel
 				int ret = p_ready_ring->wait_for_notification_and_process_element(fd, p_poll_sn, pv_fd_ready_array);
 				if (ret < 0) {
-					if (errno == EAGAIN || errno == EBUSY) {
+					if (errno == EAGAIN) {
 						ndtm_logdbg("Error in ring[%d]->wait_for_notification_and_process_element() of %p (errno=%d %m)", event_idx, p_ready_ring, errno);
 					}
 					else {
@@ -531,7 +531,7 @@ int net_device_table_mgr::global_ring_drain_and_procces()
 	net_device_map_index_t::iterator net_dev_iter;
         for (net_dev_iter=m_net_device_map_index.begin(); m_net_device_map_index.end() != net_dev_iter; net_dev_iter++) {
 		int ret = net_dev_iter->second->ring_drain_and_proccess();
-		if (ret < 0 && errno!= EBUSY) {
+		if (ret < 0 && errno != EAGAIN) {
 			ndtm_logerr("Error in ring[%p]->drain() (errno=%d %m)", net_dev_iter->second, errno);
 			return ret;
 		}

--- a/src/vma/dev/ring_bond.cpp
+++ b/src/vma/dev/ring_bond.cpp
@@ -430,7 +430,7 @@ int ring_bond::get_max_tx_inline()
 int ring_bond::poll_and_process_element_rx(uint64_t* p_cq_poll_sn, void* pv_fd_ready_array /*NULL*/)
 {
 	if (m_lock_ring_rx.trylock()) {
-		errno = EBUSY;
+		errno = EAGAIN;
 		return 0;
 	}
 
@@ -456,7 +456,7 @@ int ring_bond::poll_and_process_element_rx(uint64_t* p_cq_poll_sn, void* pv_fd_r
 int ring_bond::drain_and_proccess()
 {
 	if (m_lock_ring_rx.trylock()) {
-		errno = EBUSY;
+		errno = EAGAIN;
 		return 0;
 	}
 
@@ -482,7 +482,7 @@ int ring_bond::drain_and_proccess()
 
 int ring_bond::wait_for_notification_and_process_element(int cq_channel_fd, uint64_t* p_cq_poll_sn, void* pv_fd_ready_array /*NULL*/) {
 	if(m_lock_ring_rx.trylock()) {
-		errno = EBUSY;
+		errno = EAGAIN;
 		return -1;
 	}
 
@@ -508,12 +508,12 @@ int ring_bond::request_notification(cq_type_t cq_type, uint64_t poll_sn)
 {
 	if (likely(CQT_RX == cq_type)) {
 		if (m_lock_ring_rx.trylock()) {
-			errno = EBUSY;
+			errno = EAGAIN;
 			return 1;
 		}
 	} else {
 		if (m_lock_ring_tx.trylock()) {
-			errno = EBUSY;
+			errno = EAGAIN;
 			return 1;
 		}
 	}
@@ -557,7 +557,7 @@ bool ring_bond::reclaim_recv_buffers(descq_t *rx_reuse)
 	uint32_t i = 0;
 
 	if(m_lock_ring_rx.trylock()) {
-		errno = EBUSY;
+		errno = EAGAIN;
 		return false;
 	}
 

--- a/src/vma/dev/ring_simple.cpp
+++ b/src/vma/dev/ring_simple.cpp
@@ -56,7 +56,7 @@
 
 #define RING_TRY_LOCK_RUN_AND_UPDATE_RET(__lock__, __func_and_params__) \
 		if (!__lock__.trylock()) { ret = __func_and_params__; __lock__.unlock(); } \
-		else { errno = EBUSY; }
+		else { errno = EAGAIN; }
 
 /**/
 /** inlining functions can only help if they are implemented before their usage **/

--- a/src/vma/iomux/epfd_info.cpp
+++ b/src/vma/iomux/epfd_info.cpp
@@ -624,7 +624,7 @@ int epfd_info::ring_poll_and_process_element(uint64_t *p_poll_sn, void* pv_fd_re
 
 	m_ring_map_lock.unlock();
 
-	if (m_sysvar_thread_mode == THREAD_MODE_PLENTY && ret_total == 0 && errno == EBUSY) pthread_yield();
+	if (m_sysvar_thread_mode == THREAD_MODE_PLENTY && ret_total == 0 && errno == EAGAIN) pthread_yield();
 
 	if (ret_total) {
 		__log_func("ret_total=%d", ret_total);
@@ -685,7 +685,7 @@ int epfd_info::ring_wait_for_notification_and_process_element(uint64_t *p_poll_s
 			// Handle the CQ notification channel
 			int ret = p_ready_ring->wait_for_notification_and_process_element(fd, p_poll_sn, pv_fd_ready_array);
 			if (ret < 0) {
-				if (errno == EAGAIN || errno == EBUSY) {
+				if (errno == EAGAIN) {
 					__log_dbg("Error in ring->wait_for_notification_and_process_element() of %p (errno=%d %m)", p_ready_ring, errno);
 				}
 				else {

--- a/src/vma/sock/sockinfo_tcp.cpp
+++ b/src/vma/sock/sockinfo_tcp.cpp
@@ -736,6 +736,7 @@ void sockinfo_tcp::put_agent_msg(void *arg)
 
 ssize_t sockinfo_tcp::tx(const tx_call_t call_type, const iovec* p_iov, const ssize_t sz_iov, const int flags, const struct sockaddr *__to, const socklen_t __tolen)
 {
+	int errno_tmp = errno;
 	int total_tx = 0;
 	unsigned tx_size;
 	err_t err;
@@ -929,6 +930,8 @@ done:
 #ifdef VMA_TIME_MEASURE	
 	TAKE_T_TX_END;
 #endif
+	/* Restore errno on function entry in case success */
+	errno = errno_tmp;
 
 	return total_tx; 
 
@@ -1788,6 +1791,7 @@ int sockinfo_tcp::handle_rx_error(bool is_blocking)
 //
 ssize_t sockinfo_tcp::rx(const rx_call_t call_type, iovec* p_iov, ssize_t sz_iov, int* p_flags, sockaddr *__from, socklen_t *__fromlen, struct msghdr *__msg)
 {
+	int errno_tmp = errno;
 	int total_rx = 0;
 	int poll_count = 0;
 	int bytes_to_tcp_recved;
@@ -1865,6 +1869,8 @@ ssize_t sockinfo_tcp::rx(const rx_call_t call_type, iovec* p_iov, ssize_t sz_iov
 	if (0 < total_rx)
 		TAKE_T_RX_END;
 #endif
+	/* Restore errno on function entry in case success */
+	errno = errno_tmp;
 
 	return total_rx;
 }

--- a/src/vma/sock/sockinfo_tcp.h
+++ b/src/vma/sock/sockinfo_tcp.h
@@ -365,7 +365,7 @@ private:
 	 */
 	virtual void handle_ip_pktinfo(struct cmsg_state *) {};
 
-	int handle_rx_error();
+	int handle_rx_error(bool is_blocking);
 
 	/** Function prototype for tcp error callback functions. Called when the pcb
 	 * receives a RST or is unexpectedly closed for any other reason.


### PR DESCRIPTION
Convert EBUSY internal errno to EAGAIN.
Few customers report EBUSY errno in case recv() is called on non-blocked socket.
Probably EAGAIN or EWOULDBLOCK is better to return according
man http://man7.org/linux/man-pages/man2/recvmsg.2.html
Formally EBUSY can be returned on any socket api but in fact socket application
does not know how to react on this.

Signed-off-by: Igor Ivanov <igor.ivanov.va@gmail.com>