### PR TITLE
issue: 1909532 Enable Direct ring when DV is used

### DIFF
--- a/src/vma/dev/net_device_val.cpp
+++ b/src/vma/dev/net_device_val.cpp
@@ -1323,12 +1323,10 @@ ring* net_device_val_eth::create_ring(resource_allocation_key *key)
 						       key->get_memory_descriptor());
 			break;
 #endif
-#ifdef HAVE_DIRECT_RING
 			case VMA_RING_EXTERNAL_MEM:
 				ring = new ring_eth_direct(get_if_idx(),
 							   &prof->get_desc()->ring_ext);
 			break;
-#endif
 			default:
 				nd_logdbg("Unknown ring type");
 				break;

--- a/src/vma/dev/qp_mgr_eth_direct.cpp
+++ b/src/vma/dev/qp_mgr_eth_direct.cpp
@@ -35,8 +35,6 @@
 #include "cq_mgr_mlx5.h"
 #include "ring_simple.h"
 
-#if defined(HAVE_DIRECT_RING)
-
 #undef  MODULE_NAME
 #define MODULE_NAME 	"qp_mgr_direct"
 #define qp_logpanic 	__log_info_panic
@@ -74,9 +72,13 @@ int qp_mgr_eth_direct::prepare_ibv_qp(vma_ibv_qp_init_attr& qp_init_attr)
 	qp_init_attr.cap.max_send_sge = 1;
 	qp_init_attr.cap.max_recv_sge = 1;
 	qp_init_attr.cap.max_inline_data = 0;
+#if defined(HAVE_DIRECT_RING)
 	qp_init_attr.comp_mask |= IBV_EXP_QP_INIT_ATTR_CREATE_FLAGS;
 	qp_init_attr.exp_create_flags |= IBV_EXP_QP_CREATE_CROSS_CHANNEL;
 	qp_logdbg("using IBV_EXP_QP_CREATE_CROSS_CHANNEL in qp");
+#else
+	qp_logdbg("IBV_EXP_QP_CREATE_CROSS_CHANNEL not supported in qp");
+#endif
 	return qp_mgr_eth_mlx5::prepare_ibv_qp(qp_init_attr);
 }
 
@@ -141,5 +143,3 @@ qp_mgr_eth_direct::~qp_mgr_eth_direct()
 	delete m_p_cq_mgr_rx;
 	m_p_cq_mgr_rx = NULL;
 }
-
-#endif /* HAVE_DIRECT_RING */

--- a/src/vma/dev/qp_mgr_eth_direct.h
+++ b/src/vma/dev/qp_mgr_eth_direct.h
@@ -34,8 +34,6 @@
 
 #include "qp_mgr_eth_mlx5.h"
 
-#if defined(HAVE_DIRECT_RING)
-
 class qp_mgr_eth_direct: public qp_mgr_eth_mlx5
 {
 public:
@@ -51,7 +49,5 @@ public:
 protected:
 	virtual int		prepare_ibv_qp(vma_ibv_qp_init_attr& qp_init_attr);
 };
-
-#endif /* DEFINED_DIRECT_VERBS */
 
 #endif /* SRC_VMA_DEV_QP_MGR_ETH_DIRECT_H_ */

--- a/src/vma/dev/ring_eth_direct.cpp
+++ b/src/vma/dev/ring_eth_direct.cpp
@@ -33,8 +33,6 @@
 #include "ring_eth_direct.h"
 #include "qp_mgr_eth_direct.h"
 
-#if defined(HAVE_DIRECT_RING)
-
 #undef  MODULE_NAME
 #define MODULE_NAME		"ring_direct"
 #undef  MODULE_HDR
@@ -158,5 +156,3 @@ ring_eth_direct::~ring_eth_direct()
 	}
 	m_mr_map.clear();
 }
-
-#endif /* HAVE_DIRECT_RING */


### PR DESCRIPTION
Since cross channel is not really used the direct ring
should still be available when cross channel is not
supported

Signed-off-by: Rafi Wiener <rafiw@mellanox.com>