### PR TITLE
issue: 2016629 Add setsockopt to shutdown socket's RX side

### DIFF
--- a/src/vma/sock/sockinfo.cpp
+++ b/src/vma/sock/sockinfo.cpp
@@ -438,6 +438,10 @@ int sockinfo::setsockopt(int __level, int __optname, const void *__optval, sockl
 				si_logdbg("SOL_SOCKET, %s=\"???\" - NOT HANDLED, optval == NULL", setsockopt_so_opt_to_str(__optname));
 			}
 			break;
+		case SO_VMA_SHUTDOWN_RX:
+			shutdown_rx();
+			ret = SOCKOPT_INTERNAL_VMA_SUPPORT;
+			break;
 		default:
 			break;
 		}
@@ -1439,8 +1443,7 @@ transport_t sockinfo::find_target_family(role_t role, struct sockaddr* sock_addr
 	return target_family;
 }
 
-
-void sockinfo::destructor_helper()
+void sockinfo::shutdown_rx()
 {
 	// Unregister this receiver from all ring's in our list
 	rx_flow_map_t::iterator rx_flow_iter = m_rx_flow_map.begin();
@@ -1454,10 +1457,16 @@ void sockinfo::destructor_helper()
 	if (m_rx_nd_map.size()) {
 		destroy_nd_resources(m_so_bindtodevice_ip);
 	}
+	si_logdbg("shutdown RX");
+}
 
+void sockinfo::destructor_helper()
+{
+	shutdown_rx();
 	// Delete all dst_entry in our list
-	if (m_p_connected_dst_entry)
+	if (m_p_connected_dst_entry) {
 		delete m_p_connected_dst_entry;
+	}
 	m_p_connected_dst_entry = NULL;
 }
 

--- a/src/vma/sock/sockinfo.h
+++ b/src/vma/sock/sockinfo.h
@@ -329,6 +329,7 @@ protected:
 	virtual void		lock_rx_q() {m_lock_rcv.lock();}
 	virtual void		unlock_rx_q() {m_lock_rcv.unlock();}
 
+	void			shutdown_rx();
 	void 			destructor_helper();
 	int 			modify_ratelimit(dst_entry* p_dst_entry, struct vma_rate_limit_t &rate_limit);
 
@@ -543,6 +544,7 @@ protected:
     	case SO_VMA_RING_ALLOC_LOGIC:	return "SO_VMA_RING_ALLOC_LOGIC";
     	case SO_MAX_PACING_RATE:	return "SO_MAX_PACING_RATE";
     	case SO_VMA_FLOW_TAG:           return "SO_VMA_FLOW_TAG";
+    	case SO_VMA_SHUTDOWN_RX:        return "SO_VMA_SHUTDOWN_RX";
     	default:			break;
     	}
     	return "UNKNOWN SO opt";

--- a/src/vma/vma_extra.h
+++ b/src/vma/vma_extra.h
@@ -46,11 +46,12 @@
 /*
  * Options for setsockopt()/getsockopt()
  */
-#define SO_VMA_GET_API		2800
-#define SO_VMA_USER_DATA	2801
+#define SO_VMA_GET_API          2800
+#define SO_VMA_USER_DATA        2801
 #define SO_VMA_RING_ALLOC_LOGIC 2810
 #define SO_VMA_RING_USER_MEMORY 2811
-#define SO_VMA_FLOW_TAG	2820
+#define SO_VMA_FLOW_TAG         2820
+#define SO_VMA_SHUTDOWN_RX      2821
 
 /*
  * Flags for Dummy send API


### PR DESCRIPTION
Add new VMA socket option that closes the RX side of the socket.
This is needed to avoid steering rules creation for TX ONLY sockets.
Adding steering entries in this case hurts performance, especially for big scale cases.