### PR TITLE
issue: 2069198 Disable BF usage for Azure

### DIFF
--- a/src/vma/dev/qp_mgr_eth_mlx5.cpp
+++ b/src/vma/dev/qp_mgr_eth_mlx5.cpp
@@ -89,8 +89,8 @@ static bool is_bf(struct ibv_context *ib_ctx)
 	static off_t offset = VMA_MLX5_MMAP_GET_WC_PAGES_CMD << VMA_MLX5_IB_MMAP_CMD_SHIFT;
 	char *env;
 
-	/* This limitation is done for RM: 1557652, 1894523, 1914464 */
-	if (safe_mce_sys().hypervisor == mce_sys_var::HYPER_KVM) {
+	/* This limitation is done for RM: 1557652, 1894523, 1914464, 2069198 */
+	if (safe_mce_sys().hypervisor != mce_sys_var::HYPER_NONE) {
 		return false;
 	}
 


### PR DESCRIPTION
A SIGSEGV is an error(signal) caused during COPY_64B_NT in
case m_db_method == MLX5_DB_METHOD_BF.

Signed-off-by: Igor Ivanov <igor.ivanov.va@gmail.com>