### PR TITLE
issue: 2074332 Fix incorrect retransmits count

### DIFF
--- a/src/vma/lwip/tcp.c
+++ b/src/vma/lwip/tcp.c
@@ -588,8 +588,9 @@ tcp_connect(struct tcp_pcb *pcb, ip_addr_t *ipaddr, u16_t port,
   iss = tcp_next_iss();
   pcb->rcv_nxt = 0;
   pcb->snd_nxt = iss;
-  pcb->lastack = iss - 1;
-  pcb->snd_lbb = iss - 1;
+  pcb->lastack = iss;
+  pcb->snd_wl2 = iss;
+  pcb->snd_lbb = iss;
   pcb->rcv_ann_right_edge = pcb->rcv_nxt;
   pcb->snd_wnd = TCP_WND;
   /* 


### PR DESCRIPTION
tcp_connect() initializes pcb->snd_nxt and pcb->snd_lbb in such a way
that VMA counts every initial SYN segment as retransmission. A segment
is assumed retransmitted if:
    seg->seqno < pcb->snd_nxt

We can't ignore SYN segments when we count retransmits, because SYN
segment may be retransmitted itself. Besides, we want to avoid
unnecessary additional code.

To fix the issue, initialize both pcb->snd_nxt and pcb->snd_lbb to the
same number. snd_nxt will be updated in tcp_output() which is executed
under the same lock. Therefore, a race condition is not possible.

Also, initialize pcb->snd_wl2 to a proper value in tcp_connect().
This field is also initialized in tcp_pcb_init(), but becomes invalid
when tcp_connect() re-initializes parameters.

Signed-off-by: Dmytro Podgornyi <dmytrop@mellanox.com>