### PR TITLE
issue: 2076916 Fix sendfile() processing in lwip

### DIFF
--- a/src/vma/lwip/tcp_out.c
+++ b/src/vma/lwip/tcp_out.c
@@ -555,10 +555,10 @@ tcp_write(struct tcp_pcb *pcb, const void *arg, u32_t len, u8_t apiflags)
      * the end.
      */
 #if LWIP_TSO
-    if ((pos < len) && (space > 0) && (pcb->last_unsent->len > 0) &&
+    if (!(apiflags & TCP_WRITE_FILE) && (pos < len) && (space > 0) && (pcb->last_unsent->len > 0) &&
         (tot_p < (int)pcb->tso.max_send_sge)) {
 #else
-    if ((pos < len) && (space > 0) && (pcb->last_unsent->len > 0)) {
+    if (!(apiflags & TCP_WRITE_FILE) && (pos < len) && (space > 0) && (pcb->last_unsent->len > 0)) {
 #endif /* LWIP_TSO */
 
       u16_t seglen = space < len - pos ? space : len - pos;


### PR DESCRIPTION
Avoid 1,2 phases in tcp_write() function in case TCP_WRITE_FILE
flag is set. Both phases uses memcopy that should not be done
in this case for current implementation.
In fact memcpy can be replaced with sys_read() operation in
considered flow but gain is not expected.

Signed-off-by: Igor Ivanov <igor.ivanov.va@gmail.com>