### PR TITLE
issue: 1973965 VMA:Sockperf, epoll, TP, non-blocked and TCP, VMA_STAT…

### DIFF
--- a/src/stats/stats_printer.cpp
+++ b/src/stats/stats_printer.cpp
@@ -140,9 +140,9 @@ void print_full_stats(socket_stats_t* p_si_stats, mc_grp_info_t* p_mc_grp_info, 
 	//
 	// Socket statistics
 	//
-	if (p_si_stats->counters.n_tx_sent_byte_count || p_si_stats->counters.n_tx_sent_pkt_count || p_si_stats->counters.n_tx_drops || p_si_stats->counters.n_tx_errors)
+	if (p_si_stats->counters.n_tx_sent_byte_count || p_si_stats->counters.n_tx_sent_pkt_count || p_si_stats->counters.n_tx_eagain || p_si_stats->counters.n_tx_errors)
 	{
-		fprintf(filename, "Tx Offload: %u / %u / %u / %u [kilobytes/packets/drops/errors]%s\n", p_si_stats->counters.n_tx_sent_byte_count/BYTES_TRAFFIC_UNIT,p_si_stats->counters.n_tx_sent_pkt_count, p_si_stats->counters.n_tx_drops, p_si_stats->counters.n_tx_errors, post_fix);
+		fprintf(filename, "Tx Offload: %u / %u / %u / %u [kilobytes/packets/eagains/errors]%s\n", p_si_stats->counters.n_tx_sent_byte_count/BYTES_TRAFFIC_UNIT,p_si_stats->counters.n_tx_sent_pkt_count, p_si_stats->counters.n_tx_eagain, p_si_stats->counters.n_tx_errors, post_fix);
 		b_any_activiy = true;
 	}
 	if (p_si_stats->counters.n_tx_os_bytes || p_si_stats->counters.n_tx_os_packets || p_si_stats->counters.n_tx_os_eagain || p_si_stats->counters.n_tx_os_errors)

--- a/src/stats/stats_reader.cpp
+++ b/src/stats/stats_reader.cpp
@@ -176,7 +176,7 @@ void update_delta_stat(socket_stats_t* p_curr_stat, socket_stats_t* p_prev_stat)
 	int delay = INTERVAL;
 	p_prev_stat->counters.n_tx_sent_byte_count = (p_curr_stat->counters.n_tx_sent_byte_count - p_prev_stat->counters.n_tx_sent_byte_count) / delay;
 	p_prev_stat->counters.n_tx_sent_pkt_count = (p_curr_stat->counters.n_tx_sent_pkt_count - p_prev_stat->counters.n_tx_sent_pkt_count) / delay;
-	p_prev_stat->counters.n_tx_drops = (p_curr_stat->counters.n_tx_drops - p_prev_stat->counters.n_tx_drops) / delay;
+	p_prev_stat->counters.n_tx_eagain = (p_curr_stat->counters.n_tx_eagain - p_prev_stat->counters.n_tx_eagain) / delay;
 	p_prev_stat->counters.n_tx_errors = (p_curr_stat->counters.n_tx_errors - p_prev_stat->counters.n_tx_errors) / delay;
 	p_prev_stat->counters.n_tx_dummy = (p_curr_stat->counters.n_tx_dummy - p_prev_stat->counters.n_tx_dummy) / delay;
 	p_prev_stat->counters.n_tx_os_bytes = (p_curr_stat->counters.n_tx_os_bytes - p_prev_stat->counters.n_tx_os_bytes) / delay;
@@ -387,7 +387,7 @@ void print_basic_stats(socket_stats_t* p_stats)
 			p_stats->counters.n_rx_os_eagain,p_stats->counters.n_rx_os_errors);
 	
 	printf(TX_SHORT_VIEW," ", "Tx:",p_stats->counters.n_tx_sent_pkt_count,
-			p_stats->counters.n_tx_sent_byte_count/BYTES_TRAFFIC_UNIT,p_stats->counters.n_tx_drops,
+			p_stats->counters.n_tx_sent_byte_count/BYTES_TRAFFIC_UNIT,p_stats->counters.n_tx_eagain,
 			p_stats->counters.n_tx_errors," ",
 			p_stats->counters.n_tx_os_packets,p_stats->counters.n_tx_os_bytes / BYTES_TRAFFIC_UNIT,
 			p_stats->counters.n_tx_os_eagain,p_stats->counters.n_tx_os_errors);
@@ -413,7 +413,7 @@ void print_medium_total_stats(socket_stats_t* p_stats)
 			p_stats->counters.n_rx_os_eagain,p_stats->counters.n_rx_os_errors);
 	
 	printf(TX_MEDIUM_VIEW," ", "Tx:",p_stats->counters.n_tx_sent_pkt_count,
-			p_stats->counters.n_tx_sent_byte_count/BYTES_TRAFFIC_UNIT,p_stats->counters.n_tx_drops,
+			p_stats->counters.n_tx_sent_byte_count/BYTES_TRAFFIC_UNIT,p_stats->counters.n_tx_eagain,
 			p_stats->counters.n_tx_errors," ",
 			p_stats->counters.n_tx_os_packets,p_stats->counters.n_tx_os_bytes / BYTES_TRAFFIC_UNIT,
 			p_stats->counters.n_tx_os_eagain,p_stats->counters.n_tx_os_errors);

--- a/src/vma/sock/pipeinfo.cpp
+++ b/src/vma/sock/pipeinfo.cpp
@@ -329,8 +329,8 @@ void pipeinfo::write_lbm_pipe_enhance()
 void pipeinfo::statistics_print()
 {
 	bool b_any_activiy = false;
-	if (m_p_socket_stats->counters.n_tx_sent_byte_count || m_p_socket_stats->counters.n_tx_sent_pkt_count || m_p_socket_stats->counters.n_tx_errors || m_p_socket_stats->counters.n_tx_drops) {
-		pi_logdbg_no_funcname("Tx Offload: %d KB / %d / %d / %d [bytes/packets/errors/drops]", m_p_socket_stats->counters.n_tx_sent_byte_count/1024, m_p_socket_stats->counters.n_tx_sent_pkt_count, m_p_socket_stats->counters.n_tx_errors, m_p_socket_stats->counters.n_tx_drops);
+	if (m_p_socket_stats->counters.n_tx_sent_byte_count || m_p_socket_stats->counters.n_tx_sent_pkt_count || m_p_socket_stats->counters.n_tx_errors || m_p_socket_stats->counters.n_tx_eagain) {
+		pi_logdbg_no_funcname("Tx Offload: %d KB / %d / %d / %d [bytes/packets/errors/eagains]", m_p_socket_stats->counters.n_tx_sent_byte_count/1024, m_p_socket_stats->counters.n_tx_sent_pkt_count, m_p_socket_stats->counters.n_tx_errors, m_p_socket_stats->counters.n_tx_eagain);
 		b_any_activiy = true;
 	}
 	if (m_p_socket_stats->counters.n_tx_os_bytes || m_p_socket_stats->counters.n_tx_os_packets || m_p_socket_stats->counters.n_tx_os_errors) {

--- a/src/vma/sock/sockinfo.cpp
+++ b/src/vma/sock/sockinfo.cpp
@@ -1125,8 +1125,8 @@ void sockinfo::statistics_print(vlog_levels_t log_level /* = VLOG_DEBUG */)
 	if (m_p_socket_stats->ring_alloc_logic_tx == RING_LOGIC_PER_USER_ID)
 		vlog_printf(log_level, "TX Ring User ID : %lu\n", m_p_socket_stats->ring_user_id_tx);
 
-	if (m_p_socket_stats->counters.n_tx_sent_byte_count || m_p_socket_stats->counters.n_tx_sent_pkt_count || m_p_socket_stats->counters.n_tx_errors || m_p_socket_stats->counters.n_tx_drops ) {
-		vlog_printf(log_level, "Tx Offload : %d KB / %d / %d / %d [bytes/packets/drops/errors]\n", m_p_socket_stats->counters.n_tx_sent_byte_count/1024, m_p_socket_stats->counters.n_tx_sent_pkt_count, m_p_socket_stats->counters.n_tx_drops, m_p_socket_stats->counters.n_tx_errors);
+	if (m_p_socket_stats->counters.n_tx_sent_byte_count || m_p_socket_stats->counters.n_tx_sent_pkt_count || m_p_socket_stats->counters.n_tx_errors || m_p_socket_stats->counters.n_tx_eagain ) {
+		vlog_printf(log_level, "Tx Offload : %d KB / %d / %d / %d [bytes/packets/eagains/errors]\n", m_p_socket_stats->counters.n_tx_sent_byte_count/1024, m_p_socket_stats->counters.n_tx_sent_pkt_count, m_p_socket_stats->counters.n_tx_eagain, m_p_socket_stats->counters.n_tx_errors);
 		b_any_activity = true;
 	}
 	if (m_p_socket_stats->counters.n_tx_os_bytes || m_p_socket_stats->counters.n_tx_os_packets || m_p_socket_stats->counters.n_tx_os_errors) {

--- a/src/vma/sock/sockinfo_tcp.cpp
+++ b/src/vma/sock/sockinfo_tcp.cpp
@@ -964,7 +964,7 @@ err:
 
 	// nothing send  nb mode or got some other error
 	if (errno == EAGAIN)
-		m_p_socket_stats->counters.n_tx_drops++;
+		m_p_socket_stats->counters.n_tx_eagain++;
 	else
 		m_p_socket_stats->counters.n_tx_errors++;
 	unlock_tcp_con();

--- a/src/vma/util/vma_stats.h
+++ b/src/vma/util/vma_stats.h
@@ -155,7 +155,7 @@ typedef struct {
 	uint32_t    n_tx_sent_pkt_count;
 	uint32_t    n_tx_sent_byte_count;
 	uint32_t    n_tx_errors;
-	uint32_t    n_tx_drops;
+	uint32_t    n_tx_eagain;
 	uint32_t    n_tx_retransmits;
 	uint32_t    n_tx_os_packets;
 	uint32_t    n_tx_os_bytes;


### PR DESCRIPTION
…S_FILE shows a dropped packets in client side

The name dropped packets is misleading, where the real and actual there are EAGAIN packets,
which are nit dropped ones, but ones which still not ACKED.

Therefore in order to resolve the issue, the drops renamed to eagains.

Signed-off-by: Nahum Kilim <nahum@mellanox.com>