### PR TITLE
issue: 2101233 VMA shows irrelevant warning: error '/usr/lib/libvma.s…

### DIFF
--- a/src/vma/sock/sock-redirect.cpp
+++ b/src/vma/sock/sock-redirect.cpp
@@ -113,9 +113,15 @@ void assign_dlsym(T &ptr, const char *name) {
 		dlerror(); \
 		assign_dlsym(orig_os_api.__name, #__name); \
 		char *dlerror_str = dlerror(); \
-		if (dlerror_str) { \
-			__log_warn("dlsym returned with error '%s' when looking for '%s'", \
+		if (!orig_os_api.__name || dlerror_str) { \
+			if (strcmp("fcntl64", #__name) != 0) { \
+				__log_warn("dlsym returned with error '%s' when looking for '%s'", \
 			           dlerror_str, #__name); \
+			} \
+			else { \
+				__log_dbg("dlsym returned with error '%s' when looking for '%s'", \
+					dlerror_str, #__name); \
+			} \
 		} else { \
 			__log_dbg("dlsym found %p for '%s()'", orig_os_api.__name , #__name); \
 		} \
@@ -150,6 +156,7 @@ void get_orig_funcs()
 	GET_ORIG_FUNC(setsockopt);
 	GET_ORIG_FUNC(getsockopt);
 	GET_ORIG_FUNC(fcntl);
+	GET_ORIG_FUNC(fcntl64);
 	GET_ORIG_FUNC(ioctl);
 	GET_ORIG_FUNC(getsockname);
 	GET_ORIG_FUNC(getpeername);
@@ -1234,6 +1241,63 @@ int fcntl(int __fd, int __cmd, ...)
 		srdr_logfunc_exit("failed (errno=%d %m)", errno);
 	return res;
 }
+
+/* Do the file control operation described by CMD on FD.
+   The remaining arguments are interpreted depending on CMD.
+
+   This function is a cancellation point and therefore not marked with
+   __THROW.
+   NOTE: VMA throw will never occur during handling of any command.
+   VMA will only throw in case VMA doesn't know to handle a command and the
+   user requested explicitly that VMA will throw an exception in such a case
+   by setting VMA_EXCEPTION_HANDLING accordingly (see README.txt)
+   */
+
+extern "C"
+int fcntl64(int __fd, int __cmd, ...)
+{
+	srdr_logfunc_entry("fd=%d, cmd=%d", __fd, __cmd);
+
+	int res = -1;
+	va_list va;
+	va_start(va, __cmd);
+	unsigned long int arg = va_arg(va, unsigned long int);
+	va_end(va);
+
+	int ret = 0;
+	socket_fd_api* p_socket_object = NULL;
+	p_socket_object = fd_collection_get_sockfd(__fd);
+	BULLSEYE_EXCLUDE_BLOCK_START
+	if (!orig_os_api.fcntl64) get_orig_funcs();
+	BULLSEYE_EXCLUDE_BLOCK_END
+	if (p_socket_object && orig_os_api.fcntl64) {
+		VERIFY_PASSTROUGH_CHANGED(res, p_socket_object->fcntl64(__cmd, arg));
+	}
+	else {
+			if (!orig_os_api.fcntl64) {
+				srdr_logfunc_exit("failed (errno=%d %m)", errno);
+				VLOG_PRINTF_ONCE_THEN_ALWAYS(VLOG_ERROR, VLOG_DEBUG,
+					"fcntl64 was not found during runtime. Set %s to appripriate debug level to see datails. Ignoring...", SYS_VAR_LOG_LEVEL,
+					__fd, __cmd);
+				errno = EOPNOTSUPP;
+				return -1;
+			}
+			else {
+				res = orig_os_api.fcntl64(__fd, __cmd, arg);
+			}
+	}
+
+	if (__cmd == F_DUPFD) {
+		handle_close(__fd);
+	}
+
+	if (ret >= 0)
+		srdr_logfunc_exit("returned with %d", ret);
+	else
+		srdr_logfunc_exit("failed (errno=%d %m)", errno);
+	return res;
+}
+
 
 /* Perform the I/O control operation specified by REQUEST on FD.
    One argument may follow; its presence and type depend on REQUEST.


### PR DESCRIPTION
…o: undefined symbol: fcntl64' when looking for 'fcntl64'

VMA WARNING: srdr:153:get_orig_funcs() dlsym returned with error '/usr/lib/libvma.so: undefined symbol: fcntl64' when looking for 'fcntl64'

Signed-off-by: Nahum Kilim <nahum@mellanox.com>