### PR TITLE
issue: 2132032 Fix UDP rx unicast processing

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -144,6 +144,7 @@ Example:
  VMA DETAILS: Rx CQ Drain Rate               Disabled                   [VMA_RX_CQ_DRAIN_RATE_NSEC]
  VMA DETAILS: GRO max streams                32                         [VMA_GRO_STREAMS_MAX]
  VMA DETAILS: TCP 3T rules                   Disabled                   [VMA_TCP_3T_RULES]
+ VMA DETAILS: UDP 3T rules                   Enabled                    [VMA_UDP_3T_RULES]
  VMA DETAILS: ETH MC L2 only rules           Disabled                   [VMA_ETH_MC_L2_ONLY_RULES]
  VMA DETAILS: Force Flowtag for MC           Disabled                   [VMA_MC_FORCE_FLOWTAG]
  VMA DETAILS: Select Poll (usec)             100000                     [VMA_SELECT_POLL]
@@ -602,6 +603,15 @@ VMA_TCP_3T_RULES
 Use only 3 tuple rules for TCP, instead of using 5 tuple rules.
 This can improve performance for a server with listen socket which accept many
 connections.
+Default: 0 (Disable)
+
+VMA_UDP_3T_RULES
+This parameter can be relevant in case application uses connected udp sockets.
+3 tuple rules are used in hardware flow steering rule when the parameter is enabled and
+5 tuple flow steering rule when it is disabled.
+Enabling this option can reduce hardware flow steering resources.
+But when it is disabled application might see benefits in latency and cycles per packet.
+Default: 1 (Enable)
 
 VMA_ETH_MC_L2_ONLY_RULES
 Use only L2 rules for Ethernet Multicast.

--- a/src/vma/dev/ring_slave.cpp
+++ b/src/vma/dev/ring_slave.cpp
@@ -190,18 +190,21 @@ bool ring_slave::attach_flow(flow_tuple& flow_spec_5t, pkt_rcvr_sink *sink)
 	 */
 	m_lock_ring_rx.lock();
 
-	/* Get the appropriate hash map (tcp, uc or mc) from the 5t details */
+	/* Get the appropriate hash map (tcp, uc or mc) from the 5t details
+	 * TODO: Consider unification of following code.
+	 */
 	if (flow_spec_5t.is_udp_uc()) {
-		flow_spec_udp_uc_key_t key_udp_uc(flow_spec_5t.get_dst_ip(), flow_spec_5t.get_src_ip(),
+		flow_spec_4t_key_t rfs_key(flow_spec_5t.get_dst_ip(), flow_spec_5t.get_src_ip(),
 				flow_spec_5t.get_dst_port(), flow_spec_5t.get_src_port());
 		rule_key_t rule_key(flow_spec_5t.get_dst_ip(), flow_spec_5t.get_dst_port());
 		rfs_rule_filter* dst_port_filter = NULL;
-
-		rule_filter_map_t::iterator dst_port_filter_iter = m_udp_uc_dst_port_attach_map.find(rule_key.key);
-		if (dst_port_filter_iter == m_udp_uc_dst_port_attach_map.end()) {
-			m_udp_uc_dst_port_attach_map[rule_key.key].counter = 1;
-		} else {
-			m_udp_uc_dst_port_attach_map[rule_key.key].counter = ((dst_port_filter_iter->second.counter) + 1);
+		if (safe_mce_sys().udp_3t_rules) {
+			rule_filter_map_t::iterator dst_port_iter = m_udp_uc_dst_port_attach_map.find(rule_key.key);
+			if (dst_port_iter == m_udp_uc_dst_port_attach_map.end()) {
+				m_udp_uc_dst_port_attach_map[rule_key.key].counter = 1;
+			} else {
+				m_udp_uc_dst_port_attach_map[rule_key.key].counter = ((dst_port_iter->second.counter) + 1);
+			}
 		}
 
 		if (flow_tag_id && si->flow_in_reuse()) {
@@ -209,12 +212,14 @@ bool ring_slave::attach_flow(flow_tuple& flow_spec_5t, pkt_rcvr_sink *sink)
 			ring_logdbg("UC flow tag for socketinfo=%p is disabled: SO_REUSEADDR or SO_REUSEPORT were enabled", si);
 		}
 
-		p_rfs = m_flow_udp_uc_map.get(key_udp_uc, NULL);
+		p_rfs = m_flow_udp_uc_map.get(rfs_key, NULL);
 		if (p_rfs == NULL) {
 			// No rfs object exists so a new one must be created and inserted in the flow map
 			m_lock_ring_rx.unlock();
-			flow_tuple tcp_3t_only(flow_spec_5t.get_dst_ip(), flow_spec_5t.get_dst_port(), 0, 0, flow_spec_5t.get_protocol());
-			dst_port_filter = new rfs_rule_filter(m_udp_uc_dst_port_attach_map, rule_key.key, tcp_3t_only);
+			if (safe_mce_sys().tcp_3t_rules) {
+				flow_tuple tcp_3t_only(flow_spec_5t.get_dst_ip(), flow_spec_5t.get_dst_port(), 0, 0, flow_spec_5t.get_protocol());
+				dst_port_filter = new rfs_rule_filter(m_udp_uc_dst_port_attach_map, rule_key.key, tcp_3t_only);
+			}
 			try {
 				p_tmp_rfs = new (std::nothrow)rfs_uc(&flow_spec_5t, this, dst_port_filter, flow_tag_id);
 			} catch(vma_exception& e) {
@@ -228,16 +233,16 @@ bool ring_slave::attach_flow(flow_tuple& flow_spec_5t, pkt_rcvr_sink *sink)
 			}
 			BULLSEYE_EXCLUDE_BLOCK_END
 			m_lock_ring_rx.lock();
-			p_rfs = m_flow_udp_uc_map.get(key_udp_uc, NULL);
+			p_rfs = m_flow_udp_uc_map.get(rfs_key, NULL);
 			if (p_rfs) {
 				delete p_tmp_rfs;
 			} else {
 				p_rfs = p_tmp_rfs;
-				m_flow_udp_uc_map.set(key_udp_uc, p_rfs);
+				m_flow_udp_uc_map.set(rfs_key, p_rfs);
 			}
 		}
 	} else if (flow_spec_5t.is_udp_mc()) {
-		flow_spec_udp_key_t key_udp_mc(flow_spec_5t.get_dst_ip(), flow_spec_5t.get_dst_port());
+		flow_spec_2t_key_t key_udp_mc(flow_spec_5t.get_dst_ip(), flow_spec_5t.get_dst_port());
 
 		if (flow_tag_id) {
 			if (m_b_sysvar_mc_force_flowtag || !si->flow_in_reuse()) {
@@ -287,25 +292,25 @@ bool ring_slave::attach_flow(flow_tuple& flow_spec_5t, pkt_rcvr_sink *sink)
 			}
 		}
 	} else if (flow_spec_5t.is_tcp()) {
-		flow_spec_tcp_key_t key_tcp(flow_spec_5t.get_dst_ip(), flow_spec_5t.get_src_ip(),
+		flow_spec_4t_key_t rfs_key(flow_spec_5t.get_dst_ip(), flow_spec_5t.get_src_ip(),
 				flow_spec_5t.get_dst_port(), flow_spec_5t.get_src_port());
 		rule_key_t rule_key(flow_spec_5t.get_dst_ip(), flow_spec_5t.get_dst_port());
-		rfs_rule_filter* tcp_dst_port_filter = NULL;
+		rfs_rule_filter* dst_port_filter = NULL;
 		if (safe_mce_sys().tcp_3t_rules) {
-			rule_filter_map_t::iterator tcp_dst_port_iter = m_tcp_dst_port_attach_map.find(rule_key.key);
-			if (tcp_dst_port_iter == m_tcp_dst_port_attach_map.end()) {
+			rule_filter_map_t::iterator dst_port_iter = m_tcp_dst_port_attach_map.find(rule_key.key);
+			if (dst_port_iter == m_tcp_dst_port_attach_map.end()) {
 				m_tcp_dst_port_attach_map[rule_key.key].counter = 1;
 			} else {
-				m_tcp_dst_port_attach_map[rule_key.key].counter = ((tcp_dst_port_iter->second.counter) + 1);
+				m_tcp_dst_port_attach_map[rule_key.key].counter = ((dst_port_iter->second.counter) + 1);
 			}
 		}
 
-		p_rfs = m_flow_tcp_map.get(key_tcp, NULL);
+		p_rfs = m_flow_tcp_map.get(rfs_key, NULL);
 		if (p_rfs == NULL) {		// It means that no rfs object exists so I need to create a new one and insert it to the flow map
 			m_lock_ring_rx.unlock();
 			if (safe_mce_sys().tcp_3t_rules) {
 				flow_tuple tcp_3t_only(flow_spec_5t.get_dst_ip(), flow_spec_5t.get_dst_port(), 0, 0, flow_spec_5t.get_protocol());
-				tcp_dst_port_filter = new rfs_rule_filter(m_tcp_dst_port_attach_map, rule_key.key, tcp_3t_only);
+				dst_port_filter = new rfs_rule_filter(m_tcp_dst_port_attach_map, rule_key.key, tcp_3t_only);
 			}
 			if(safe_mce_sys().gro_streams_max && flow_spec_5t.is_5_tuple() && is_simple()) {
 				// When the gro mechanism is being used, packets must be processed in the rfs
@@ -314,10 +319,10 @@ bool ring_slave::attach_flow(flow_tuple& flow_spec_5t, pkt_rcvr_sink *sink)
 					flow_tag_id = FLOW_TAG_MASK;
 					ring_logdbg("flow_tag_id = %d is disabled to enable TCP GRO socket to be processed on RFS!", flow_tag_id);
 				}
-				p_tmp_rfs = new (std::nothrow)rfs_uc_tcp_gro(&flow_spec_5t, this, tcp_dst_port_filter, flow_tag_id);
+				p_tmp_rfs = new (std::nothrow)rfs_uc_tcp_gro(&flow_spec_5t, this, dst_port_filter, flow_tag_id);
 			} else {
 				try {
-					p_tmp_rfs = new (std::nothrow)rfs_uc(&flow_spec_5t, this, tcp_dst_port_filter, flow_tag_id);
+					p_tmp_rfs = new (std::nothrow)rfs_uc(&flow_spec_5t, this, dst_port_filter, flow_tag_id);
 				} catch(vma_exception& e) {
 					ring_logerr("%s", e.message);
 					return false;
@@ -331,12 +336,12 @@ bool ring_slave::attach_flow(flow_tuple& flow_spec_5t, pkt_rcvr_sink *sink)
 			BULLSEYE_EXCLUDE_BLOCK_END
 			/* coverity[double_lock] TODO: RM#1049980 */
 			m_lock_ring_rx.lock();
-			p_rfs = m_flow_tcp_map.get(key_tcp, NULL);
+			p_rfs = m_flow_tcp_map.get(rfs_key, NULL);
 			if (p_rfs) {
 				delete p_tmp_rfs;
 			} else {
 				p_rfs = p_tmp_rfs;
-				m_flow_tcp_map.set(key_tcp, p_rfs);
+				m_flow_tcp_map.set(rfs_key, p_rfs);
 			}
 		}
 	BULLSEYE_EXCLUDE_BLOCK_START
@@ -370,21 +375,23 @@ bool ring_slave::detach_flow(flow_tuple& flow_spec_5t, pkt_rcvr_sink* sink)
 
 	auto_unlocker lock(m_lock_ring_rx);
 
-	/* Get the appropriate hash map (tcp, uc or mc) from the 5t details */
+	/* Get the appropriate hash map (tcp, uc or mc) from the 5t details
+	 * TODO: Consider unification of following code.
+	 */
 	if (flow_spec_5t.is_udp_uc()) {
 		int keep_in_map = 1;
-		flow_spec_udp_uc_key_t key_tcp(flow_spec_5t.get_dst_ip(), flow_spec_5t.get_src_ip(),
+		flow_spec_4t_key_t rfs_key(flow_spec_5t.get_dst_ip(), flow_spec_5t.get_src_ip(),
 				flow_spec_5t.get_dst_port(), flow_spec_5t.get_src_port());
 		rule_key_t rule_key(flow_spec_5t.get_dst_ip(), flow_spec_5t.get_dst_port());
-		rule_filter_map_t::iterator dst_port_iter = m_udp_uc_dst_port_attach_map.find(rule_key.key);
-
-		if (dst_port_iter == m_udp_uc_dst_port_attach_map.end()) {
-			ring_logdbg("Could not find matching counter for UDP src port!");
-		} else {
-			keep_in_map = m_udp_uc_dst_port_attach_map[rule_key.key].counter = MAX(0 , ((dst_port_iter->second.counter) - 1));
+		if (safe_mce_sys().udp_3t_rules) {
+			rule_filter_map_t::iterator dst_port_iter = m_udp_uc_dst_port_attach_map.find(rule_key.key);
+			if (dst_port_iter == m_udp_uc_dst_port_attach_map.end()) {
+				ring_logdbg("Could not find matching counter for UDP src port!");
+			} else {
+				keep_in_map = m_udp_uc_dst_port_attach_map[rule_key.key].counter = MAX(0 , ((dst_port_iter->second.counter) - 1));
+			}
 		}
-
-		p_rfs = m_flow_udp_uc_map.get(key_tcp, NULL);
+		p_rfs = m_flow_udp_uc_map.get(rfs_key, NULL);
 		BULLSEYE_EXCLUDE_BLOCK_START
 		if (p_rfs == NULL) {
 			ring_logdbg("Could not find rfs object to detach!");
@@ -398,7 +405,7 @@ bool ring_slave::detach_flow(flow_tuple& flow_spec_5t, pkt_rcvr_sink* sink)
 		}
 		if (p_rfs->get_num_of_sinks() == 0) {
 			BULLSEYE_EXCLUDE_BLOCK_START
-			if (!(m_flow_udp_uc_map.del(key_tcp))) {
+			if (!(m_flow_udp_uc_map.del(rfs_key))) {
 				ring_logdbg("Could not find rfs object to delete in ring udp hash map!");
 			}
 			BULLSEYE_EXCLUDE_BLOCK_END
@@ -406,7 +413,7 @@ bool ring_slave::detach_flow(flow_tuple& flow_spec_5t, pkt_rcvr_sink* sink)
 		}
 	} else if (flow_spec_5t.is_udp_mc()) {
 		int keep_in_map = 1;
-		flow_spec_udp_key_t key_udp_mc(flow_spec_5t.get_dst_ip(), flow_spec_5t.get_dst_port());
+		flow_spec_2t_key_t key_udp_mc(flow_spec_5t.get_dst_ip(), flow_spec_5t.get_dst_port());
 		if (m_transport_type == VMA_TRANSPORT_IB || m_b_sysvar_eth_mc_l2_only_rules) {
 			rule_filter_map_t::iterator l2_mc_iter = m_l2_mc_ip_attach_map.find(key_udp_mc.dst_ip);
 			BULLSEYE_EXCLUDE_BLOCK_START
@@ -438,20 +445,20 @@ bool ring_slave::detach_flow(flow_tuple& flow_spec_5t, pkt_rcvr_sink* sink)
 		}
 	} else if (flow_spec_5t.is_tcp()) {
 		int keep_in_map = 1;
-		flow_spec_tcp_key_t key_tcp(flow_spec_5t.get_dst_ip(), flow_spec_5t.get_src_ip(),
+		flow_spec_4t_key_t rfs_key(flow_spec_5t.get_dst_ip(), flow_spec_5t.get_src_ip(),
 				flow_spec_5t.get_dst_port(), flow_spec_5t.get_src_port());
 		rule_key_t rule_key(flow_spec_5t.get_dst_ip(), flow_spec_5t.get_dst_port());
 		if (safe_mce_sys().tcp_3t_rules) {
-			rule_filter_map_t::iterator tcp_dst_port_iter = m_tcp_dst_port_attach_map.find(rule_key.key);
+			rule_filter_map_t::iterator dst_port_iter = m_tcp_dst_port_attach_map.find(rule_key.key);
 			BULLSEYE_EXCLUDE_BLOCK_START
-			if (tcp_dst_port_iter == m_tcp_dst_port_attach_map.end()) {
+			if (dst_port_iter == m_tcp_dst_port_attach_map.end()) {
 				ring_logdbg("Could not find matching counter for TCP src port!");
 				BULLSEYE_EXCLUDE_BLOCK_END
 			} else {
-				keep_in_map = m_tcp_dst_port_attach_map[rule_key.key].counter = MAX(0 , ((tcp_dst_port_iter->second.counter) - 1));
+				keep_in_map = m_tcp_dst_port_attach_map[rule_key.key].counter = MAX(0 , ((dst_port_iter->second.counter) - 1));
 			}
 		}
-		p_rfs = m_flow_tcp_map.get(key_tcp, NULL);
+		p_rfs = m_flow_tcp_map.get(rfs_key, NULL);
 		BULLSEYE_EXCLUDE_BLOCK_START
 		if (p_rfs == NULL) {
 			ring_logdbg("Could not find rfs object to detach!");
@@ -465,7 +472,7 @@ bool ring_slave::detach_flow(flow_tuple& flow_spec_5t, pkt_rcvr_sink* sink)
 		}
 		if (p_rfs->get_num_of_sinks() == 0) {
 			BULLSEYE_EXCLUDE_BLOCK_START
-			if (!(m_flow_tcp_map.del(key_tcp))) {
+			if (!(m_flow_tcp_map.del(rfs_key))) {
 				ring_logdbg("Could not find rfs object to delete in ring tcp hash map!");
 			}
 			BULLSEYE_EXCLUDE_BLOCK_END
@@ -562,7 +569,7 @@ bool ring_slave::rx_process_buffer(mem_buf_desc_t* p_rx_wc_buf_desc, void* pv_fd
 			ring_logfunc("FAST PATH Rx packet info: transport_header_len: %d, IP_header_len: %d L3 proto: %d flow_tag_id: %d",
 				transport_header_len, p_ip_h->ihl, p_ip_h->protocol, p_rx_wc_buf_desc->rx.flow_tag_id);
 
-			if (likely(p_ip_h->protocol==IPPROTO_TCP)) {
+			if (likely(p_ip_h->protocol == IPPROTO_TCP)) {
 				p_tcp_h = (struct tcphdr*)((uint8_t*)p_ip_h + ip_hdr_len);
 
 				// Update the L3 and L4 info
@@ -595,7 +602,7 @@ bool ring_slave::rx_process_buffer(mem_buf_desc_t* p_rx_wc_buf_desc, void* pv_fd
 
 			}
 
-			if (likely(p_ip_h->protocol==IPPROTO_UDP)) {
+			if (likely(p_ip_h->protocol == IPPROTO_UDP)) {
 				p_udp_h = (struct udphdr*)((uint8_t*)p_ip_h + ip_hdr_len);
 
 				// Update the L3 and L4 info
@@ -827,17 +834,17 @@ bool ring_slave::rx_process_buffer(mem_buf_desc_t* p_rx_wc_buf_desc, void* pv_fd
 
 		// Find the relevant hash map and pass the packet to the rfs for dispatching
 		if (!(IN_MULTICAST_N(p_rx_wc_buf_desc->rx.dst.sin_addr.s_addr))) {      // This is UDP UC packet
-			p_rfs = m_flow_udp_uc_map.get(flow_spec_udp_uc_key_t(p_rx_wc_buf_desc->rx.dst.sin_addr.s_addr,
+			p_rfs = m_flow_udp_uc_map.get(flow_spec_4t_key_t(p_rx_wc_buf_desc->rx.dst.sin_addr.s_addr,
 					p_rx_wc_buf_desc->rx.src.sin_addr.s_addr, p_rx_wc_buf_desc->rx.dst.sin_port,
 					p_rx_wc_buf_desc->rx.src.sin_port), NULL);
 
 			// If we didn't find a match for 5T, look for a match with 3T
 			if (unlikely(p_rfs == NULL)) {
-				p_rfs = m_flow_udp_uc_map.get(flow_spec_udp_uc_key_t(p_rx_wc_buf_desc->rx.dst.sin_addr.s_addr, 0,
+				p_rfs = m_flow_udp_uc_map.get(flow_spec_4t_key_t(p_rx_wc_buf_desc->rx.dst.sin_addr.s_addr, 0,
 						p_rx_wc_buf_desc->rx.dst.sin_port, 0), NULL);
 			}
 		} else {        // This is UDP MC packet
-			p_rfs = m_flow_udp_mc_map.get(flow_spec_udp_key_t(p_rx_wc_buf_desc->rx.dst.sin_addr.s_addr,
+			p_rfs = m_flow_udp_mc_map.get(flow_spec_2t_key_t(p_rx_wc_buf_desc->rx.dst.sin_addr.s_addr,
 				p_rx_wc_buf_desc->rx.dst.sin_port), NULL);
 		}
 	}
@@ -875,13 +882,13 @@ bool ring_slave::rx_process_buffer(mem_buf_desc_t* p_rx_wc_buf_desc, void* pv_fd
 		p_rx_wc_buf_desc->rx.tcp.p_tcp_h = p_tcp_h;
 
 		// Find the relevant hash map and pass the packet to the rfs for dispatching
-		p_rfs = m_flow_tcp_map.get(flow_spec_tcp_key_t(p_rx_wc_buf_desc->rx.dst.sin_addr.s_addr,
+		p_rfs = m_flow_tcp_map.get(flow_spec_4t_key_t(p_rx_wc_buf_desc->rx.dst.sin_addr.s_addr,
 				p_rx_wc_buf_desc->rx.src.sin_addr.s_addr, p_rx_wc_buf_desc->rx.dst.sin_port,
 				p_rx_wc_buf_desc->rx.src.sin_port), NULL);
 
 		// If we didn't find a match for 5T, look for a match with 3T
 		if (unlikely(p_rfs == NULL)) {
-			p_rfs = m_flow_tcp_map.get(flow_spec_tcp_key_t(p_rx_wc_buf_desc->rx.dst.sin_addr.s_addr, 0,
+			p_rfs = m_flow_tcp_map.get(flow_spec_4t_key_t(p_rx_wc_buf_desc->rx.dst.sin_addr.s_addr, 0,
 					p_rx_wc_buf_desc->rx.dst.sin_port, 0), NULL);
 		}
 	}
@@ -926,10 +933,10 @@ bool ring_slave::rx_process_buffer(mem_buf_desc_t* p_rx_wc_buf_desc, void* pv_fd
 
 void ring_slave::flow_udp_del_all()
 {
-	flow_spec_udp_uc_key_t map_key_udp_uc;
-	flow_spec_udp_uc_map_t::iterator itr_udp_uc;
-	flow_spec_udp_key_t map_key_udp;
-	flow_spec_udp_map_t::iterator itr_udp;
+	flow_spec_4t_key_t map_key_udp_uc;
+	flow_spec_4t_map_t::iterator itr_udp_uc;
+	flow_spec_2t_key_t map_key_udp;
+	flow_spec_2t_map_t::iterator itr_udp;
 
 	itr_udp_uc = m_flow_udp_uc_map.begin();
 	while (itr_udp_uc != m_flow_udp_uc_map.end()) {
@@ -960,8 +967,8 @@ void ring_slave::flow_udp_del_all()
 
 void ring_slave::flow_tcp_del_all()
 {
-	flow_spec_tcp_key_t map_key_tcp;
-	flow_spec_tcp_map_t::iterator itr_tcp;
+	flow_spec_4t_key_t map_key_tcp;
+	flow_spec_4t_map_t::iterator itr_tcp;
 
 	while ((itr_tcp = m_flow_tcp_map.begin()) != m_flow_tcp_map.end()) {
 		rfs *p_rfs = itr_tcp->second;

--- a/src/vma/dev/ring_slave.h
+++ b/src/vma/dev/ring_slave.h
@@ -115,6 +115,9 @@ struct rule_key_t {
 	}
 };
 
+typedef flow_spec_tcp_key_t flow_spec_udp_uc_key_t;
+typedef flow_spec_tcp_map_t flow_spec_udp_uc_map_t;
+
 typedef std::tr1::unordered_map<uint64_t, struct counter_and_ibv_flows> rule_filter_map_t;
 
 
@@ -155,13 +158,14 @@ protected:
 
 	flow_spec_tcp_map_t	m_flow_tcp_map;
 	flow_spec_udp_map_t	m_flow_udp_mc_map;
-	flow_spec_udp_map_t	m_flow_udp_uc_map;
+	flow_spec_udp_uc_map_t	m_flow_udp_uc_map;
 
 	// For IB MC flow, the port is zeroed in the ibv_flow_spec when calling to ibv_flow_spec().
 	// It means that for every MC group, even if we have sockets with different ports - only one rule in the HW.
 	// So the hash map below keeps track of the number of sockets per rule so we know when to call ibv_attach and ibv_detach
 	rule_filter_map_t	m_l2_mc_ip_attach_map;
 	rule_filter_map_t	m_tcp_dst_port_attach_map;
+	rule_filter_map_t	m_udp_uc_dst_port_attach_map;
 
 	descq_t             m_tx_pool;
 	transport_type_t    m_transport_type; /* transport ETH/IB */

--- a/src/vma/dev/ring_slave.h
+++ b/src/vma/dev/ring_slave.h
@@ -39,59 +39,59 @@
 
 class rfs;
 
-typedef struct __attribute__((packed)) flow_spec_udp_key_t {
+typedef struct __attribute__((packed)) flow_spec_2t_key_t {
   in_addr_t	dst_ip;
   in_port_t	dst_port;
 
-  flow_spec_udp_key_t () {
-    flow_spec_udp_key_helper(INADDR_ANY, INPORT_ANY);
+  flow_spec_2t_key_t () {
+    flow_spec_2t_key_helper(INADDR_ANY, INPORT_ANY);
   } //Default constructor
-  flow_spec_udp_key_t (in_addr_t d_ip, in_addr_t d_port) {
-    flow_spec_udp_key_helper(d_ip, d_port);
+  flow_spec_2t_key_t (in_addr_t d_ip, in_addr_t d_port) {
+    flow_spec_2t_key_helper(d_ip, d_port);
   }//Constructor
-  void flow_spec_udp_key_helper(in_addr_t d_ip, in_addr_t d_port) {
+  void flow_spec_2t_key_helper(in_addr_t d_ip, in_addr_t d_port) {
     memset(this, 0, sizeof(*this));// Silencing coverity
     dst_ip = d_ip;
     dst_port = d_port;
   };
-} flow_spec_udp_key_t;
+} flow_spec_2t_key_t;
 
-typedef struct __attribute__((packed)) flow_spec_tcp_key_t {
+typedef struct __attribute__((packed)) flow_spec_4t_key_t {
   in_addr_t	dst_ip;
   in_addr_t	src_ip;
   in_port_t	dst_port;
   in_port_t	src_port;
 
-  flow_spec_tcp_key_t () {
-  	flow_spec_tcp_key_helper (INADDR_ANY, INADDR_ANY, INPORT_ANY, INPORT_ANY);
+  flow_spec_4t_key_t () {
+  	flow_spec_4t_key_helper (INADDR_ANY, INADDR_ANY, INPORT_ANY, INPORT_ANY);
   } //Default constructor
-  flow_spec_tcp_key_t (in_addr_t d_ip, in_addr_t s_ip, in_addr_t d_port, in_addr_t s_port) {
-  	flow_spec_tcp_key_helper (d_ip, s_ip, d_port, s_port);
+  flow_spec_4t_key_t (in_addr_t d_ip, in_addr_t s_ip, in_addr_t d_port, in_addr_t s_port) {
+  	flow_spec_4t_key_helper (d_ip, s_ip, d_port, s_port);
   }//Constructor
-  void flow_spec_tcp_key_helper(in_addr_t d_ip, in_addr_t s_ip, in_addr_t d_port, in_addr_t s_port) {
+  void flow_spec_4t_key_helper(in_addr_t d_ip, in_addr_t s_ip, in_addr_t d_port, in_addr_t s_port) {
     memset(this, 0, sizeof(*this));// Silencing coverity
     dst_ip = d_ip;
     src_ip = s_ip;
     dst_port = d_port;
     src_port = s_port;
   };
-} flow_spec_tcp_key_t;
+} flow_spec_4t_key_t;
 
 
 /* UDP flow to rfs object hash map */
 inline bool
-operator==(flow_spec_udp_key_t const& key1, flow_spec_udp_key_t const& key2)
+operator==(flow_spec_2t_key_t const& key1, flow_spec_2t_key_t const& key2)
 {
 	return 	(key1.dst_port == key2.dst_port) &&
 		(key1.dst_ip == key2.dst_ip);
 }
 
-typedef hash_map<flow_spec_udp_key_t, rfs*> flow_spec_udp_map_t;
+typedef hash_map<flow_spec_2t_key_t, rfs*> flow_spec_2t_map_t;
 
 
 /* TCP flow to rfs object hash map */
 inline bool
-operator==(flow_spec_tcp_key_t const& key1, flow_spec_tcp_key_t const& key2)
+operator==(flow_spec_4t_key_t const& key1, flow_spec_4t_key_t const& key2)
 {
 	return	(key1.src_port == key2.src_port) &&
 		(key1.src_ip == key2.src_ip) &&
@@ -99,7 +99,7 @@ operator==(flow_spec_tcp_key_t const& key1, flow_spec_tcp_key_t const& key2)
 		(key1.dst_ip == key2.dst_ip);
 }
 
-typedef hash_map<flow_spec_tcp_key_t, rfs*> flow_spec_tcp_map_t;
+typedef hash_map<flow_spec_4t_key_t, rfs*> flow_spec_4t_map_t;
 
 struct counter_and_ibv_flows {
 	int counter;
@@ -114,9 +114,6 @@ struct rule_key_t {
 		key = (uint64_t) addr << 32 | port;
 	}
 };
-
-typedef flow_spec_tcp_key_t flow_spec_udp_uc_key_t;
-typedef flow_spec_tcp_map_t flow_spec_udp_uc_map_t;
 
 typedef std::tr1::unordered_map<uint64_t, struct counter_and_ibv_flows> rule_filter_map_t;
 
@@ -156,9 +153,9 @@ protected:
 	void			flow_udp_del_all();
 	void			flow_tcp_del_all();
 
-	flow_spec_tcp_map_t	m_flow_tcp_map;
-	flow_spec_udp_map_t	m_flow_udp_mc_map;
-	flow_spec_udp_uc_map_t	m_flow_udp_uc_map;
+	flow_spec_4t_map_t	m_flow_tcp_map;
+	flow_spec_2t_map_t	m_flow_udp_mc_map;
+	flow_spec_4t_map_t	m_flow_udp_uc_map;
 
 	// For IB MC flow, the port is zeroed in the ibv_flow_spec when calling to ibv_flow_spec().
 	// It means that for every MC group, even if we have sockets with different ports - only one rule in the HW.

--- a/src/vma/dev/ring_slave.h
+++ b/src/vma/dev/ring_slave.h
@@ -164,11 +164,12 @@ protected:
 	rule_filter_map_t	m_tcp_dst_port_attach_map;
 	rule_filter_map_t	m_udp_uc_dst_port_attach_map;
 
+	lock_spin_recursive	m_lock_ring_rx;
+	lock_spin_recursive	m_lock_ring_tx;
+
 	descq_t             m_tx_pool;
 	transport_type_t    m_transport_type; /* transport ETH/IB */
 	ring_stats_t*       m_p_ring_stat;
-	lock_spin_recursive	m_lock_ring_rx;
-	lock_spin_recursive	m_lock_ring_tx;
 	in_addr_t           m_local_if;
 	uint16_t            m_partition;
 	bool                m_flow_tag_enabled;

--- a/src/vma/main.cpp
+++ b/src/vma/main.cpp
@@ -479,6 +479,7 @@ void print_vma_global_settings()
 	VLOG_PARAM_NUMBER("GRO max streams", safe_mce_sys().gro_streams_max, MCE_DEFAULT_GRO_STREAMS_MAX, SYS_VAR_GRO_STREAMS_MAX);
 
 	VLOG_PARAM_STRING("TCP 3T rules", safe_mce_sys().tcp_3t_rules, MCE_DEFAULT_TCP_3T_RULES, SYS_VAR_TCP_3T_RULES, safe_mce_sys().tcp_3t_rules ? "Enabled " : "Disabled");
+	VLOG_PARAM_STRING("UDP 3T rules", safe_mce_sys().udp_3t_rules, MCE_DEFAULT_UDP_3T_RULES, SYS_VAR_UDP_3T_RULES, safe_mce_sys().udp_3t_rules ? "Enabled " : "Disabled");
 	VLOG_PARAM_STRING("ETH MC L2 only rules", safe_mce_sys().eth_mc_l2_only_rules, MCE_DEFAULT_ETH_MC_L2_ONLY_RULES, SYS_VAR_ETH_MC_L2_ONLY_RULES, safe_mce_sys().eth_mc_l2_only_rules ? "Enabled " : "Disabled");
 	VLOG_PARAM_STRING("Force Flowtag for MC", safe_mce_sys().mc_force_flowtag, MCE_DEFAULT_MC_FORCE_FLOWTAG, SYS_VAR_MC_FORCE_FLOWTAG, safe_mce_sys().mc_force_flowtag ? "Enabled " : "Disabled");
 

--- a/src/vma/sock/sockinfo.cpp
+++ b/src/vma/sock/sockinfo.cpp
@@ -117,6 +117,14 @@ sockinfo::sockinfo(int fd):
 	m_socketxtreme.ec.clear();
 	m_socketxtreme.completion = NULL;
 	m_socketxtreme.last_buff_lst = NULL;
+
+	m_connected.set_in_addr(INADDR_ANY);
+	m_connected.set_in_port(INPORT_ANY);
+	m_connected.set_sa_family(AF_INET);
+
+	m_bound.set_in_addr(INADDR_ANY);
+	m_bound.set_in_port(INPORT_ANY);
+	m_bound.set_sa_family(AF_INET);
 }
 
 sockinfo::~sockinfo()

--- a/src/vma/sock/sockinfo.cpp
+++ b/src/vma/sock/sockinfo.cpp
@@ -89,7 +89,6 @@ sockinfo::sockinfo(int fd):
 		m_flow_tag_id(0),
 		m_flow_tag_enabled(false),
 		m_n_uc_ttl(safe_mce_sys().sysctl_reader.get_net_ipv4_ttl()),
-		m_tcp_flow_is_5t(false),
 		m_p_rings_fds(NULL)
 
 {

--- a/src/vma/sock/sockinfo.h
+++ b/src/vma/sock/sockinfo.h
@@ -325,7 +325,6 @@ protected:
 	// According to bounded information we need to attach to all UC relevant flows
 	// If local_ip is ANY then we need to attach to all offloaded interfaces OR to the one our connected_ip is routed to
 	bool			attach_as_uc_receiver(role_t role, bool skip_rules = false);
-	virtual void		set_rx_packet_processor(void) = 0;
 	transport_t 		find_target_family(role_t role, struct sockaddr *sock_addr_first, struct sockaddr *sock_addr_second = NULL);
 
 	// This callback will notify that socket is ready to receive and map the cq.

--- a/src/vma/sock/sockinfo.h
+++ b/src/vma/sock/sockinfo.h
@@ -181,8 +181,6 @@ public:
 	virtual int add_epoll_context(epfd_info *epfd);
 	virtual void remove_epoll_context(epfd_info *epfd);
 
-	inline bool tcp_flow_is_5t(void) { return m_tcp_flow_is_5t; }
-	inline void set_tcp_flow_is_5t(void) { m_tcp_flow_is_5t = true; }
 	inline bool set_flow_tag(uint32_t flow_tag_id) {
 		if (flow_tag_id && (flow_tag_id != FLOW_TAG_MASK)) {
 			m_flow_tag_id = flow_tag_id;
@@ -277,7 +275,6 @@ protected:
 	uint32_t		m_flow_tag_id;	// Flow Tag for this socket
 	bool			m_flow_tag_enabled; // for this socket
 	uint8_t			m_n_uc_ttl; // time to live
-	bool			m_tcp_flow_is_5t; // to bypass packet analysis
 
 	int*			m_p_rings_fds;
 	virtual void 		set_blocking(bool is_blocked);

--- a/src/vma/sock/sockinfo_tcp.h
+++ b/src/vma/sock/sockinfo_tcp.h
@@ -179,7 +179,6 @@ public:
 
 	virtual void update_header_field(data_updater *updater);
 	virtual bool rx_input_cb(mem_buf_desc_t* p_rx_pkt_mem_buf_desc_info, void* pv_fd_ready_array);
-	virtual void set_rx_packet_processor(void) { }
 
 	static struct pbuf * tcp_tx_pbuf_alloc(void* p_conn);
 	static void tcp_tx_pbuf_free(void* p_conn, struct pbuf *p_buff);

--- a/src/vma/sock/sockinfo_udp.cpp
+++ b/src/vma/sock/sockinfo_udp.cpp
@@ -637,7 +637,6 @@ int sockinfo_udp::on_sockname_change(struct sockaddr *__name, socklen_t __namele
 		m_bound.set_in_addr(bound_if);
 		m_p_socket_stats->bound_if = bound_if;
 	}
-
 	// Check if this is the new 'name' (local port) of the socket
 	if ((m_is_connected || is_bound_modified) && bound_port != INPORT_ANY) {
 

--- a/src/vma/sock/sockinfo_udp.cpp
+++ b/src/vma/sock/sockinfo_udp.cpp
@@ -503,21 +503,6 @@ int sockinfo_udp::connect(const struct sockaddr *__to, socklen_t __tolen)
 		m_connected.set_in_port(INPORT_ANY);
 		m_p_socket_stats->connected_port = m_connected.get_in_port();
 
-/* TODO ALEXR REMOVE ME - DONE IN DST_ENTRY
-
-	if (ZERONET_N(connect_to.get_in_addr())) {
-		si_udp_logdbg("VMA does not offload zero net IP address");
-		si_udp_logdbg("'connect()' to zero net address [%s] will be handled by the OS", connect_to.to_str());
-		return 0; // zero returned from orig_connect()
-	}
-
-	if (LOOPBACK_N(connect_to.get_in_addr())) {
-		si_udp_logdbg("VMA does not offload local loopback IP address");
-		si_udp_logdbg("'connect()' to local loopback address [%s] will be handled by the OS", connect_to.to_str());
-		return 0; // zero returned from orig_connect()
-	}
-*/
-
 		in_addr_t dst_ip = connect_to.get_in_addr();
 		in_port_t dst_port = connect_to.get_in_port();
 
@@ -596,6 +581,7 @@ int sockinfo_udp::connect(const struct sockaddr *__to, socklen_t __tolen)
 		m_p_connected_dst_entry->prepare_to_send(m_so_ratelimit, false, true);
 		return 0;
 	}
+
 	return 0;
 }
 
@@ -674,6 +660,11 @@ int sockinfo_udp::on_sockname_change(struct sockaddr *__name, socklen_t __namele
 		// Attach UDP port pending MC groups to offloaded interface (set by ADD_MEMBERSHIP before bind() was called)
 		handle_pending_mreq();
 	}
+
+	/* Update rx processing after changing m_is_connected, m_sockopt_mapped, m_multicast
+	 * It can be done at setsockopt(), bind() and connect()
+	 */
+	set_rx_packet_processor();
 
 	return 0;
 }

--- a/src/vma/sock/sockinfo_udp.cpp
+++ b/src/vma/sock/sockinfo_udp.cpp
@@ -639,7 +639,7 @@ int sockinfo_udp::on_sockname_change(struct sockaddr *__name, socklen_t __namele
 	}
 
 	// Check if this is the new 'name' (local port) of the socket
-	if (is_bound_modified && bound_port != INPORT_ANY) {
+	if ((m_is_connected || is_bound_modified) && bound_port != INPORT_ANY) {
 
 		// Attach UDP unicast port to offloaded interface
 		// 1. Check if local_if is offloadable OR is on INADDR_ANY which means attach to ALL

--- a/src/vma/sock/sockinfo_udp.h
+++ b/src/vma/sock/sockinfo_udp.h
@@ -164,7 +164,6 @@ public:
 	{
 		return (this->*m_rx_packet_processor)(p_rx_wc_buf_desc, pv_fd_ready_array);
 	}
-	inline void set_rx_packet_processor(void);
 
 	// This call will handle all rdma related events (bind->listen->connect_req->accept)
 	virtual void statistics_print(vlog_levels_t log_level = VLOG_DEBUG);
@@ -242,6 +241,7 @@ private:
 	int mc_change_membership_end_helper(in_addr_t mc_grp, int optname, in_addr_t mc_src = 0);
 	int mc_change_pending_mreq(const mc_pending_pram *p_mc_pram);
 	int on_sockname_change(struct sockaddr *__name, socklen_t __namelen);
+	inline void set_rx_packet_processor(void);
 	void handle_pending_mreq();
 	void original_os_setsockopt_helper( void* pram, int pram_size, int optname);
 	/* helper functions */

--- a/src/vma/sock/sockinfo_udp.h
+++ b/src/vma/sock/sockinfo_udp.h
@@ -151,19 +151,15 @@ public:
 	void rx_del_ring_cb(flow_tuple_with_local_if& flow_key, ring* p_ring, bool is_migration = false);
 	virtual int rx_verify_available_data();
 
-	// This callback will handle ready rx packet notification from any ib_conn_mgr
 	/**
-	 *	Method sockinfo_udp::rx_process_packet run packet processor
-	 *	with inspection, in case packet is OK, completion for SOCKETXTREME mode
+	 *	This callback will handle ready rx packet notification,
+	 *	in case packet is OK, completion for SOCKETXTREME mode
 	 *	will be filled or in other cases packet go to ready queue.
 	 *	If packet to be discarded, packet ref. counter will not be
 	 *	incremented and method returns false.
 	 *	Normally it is single point from sockinfo to be called from ring level.
 	 */
-	inline bool rx_input_cb(mem_buf_desc_t* p_rx_wc_buf_desc, void* pv_fd_ready_array)
-	{
-		return (this->*m_rx_packet_processor)(p_rx_wc_buf_desc, pv_fd_ready_array);
-	}
+	bool rx_input_cb(mem_buf_desc_t* p_desc, void* pv_fd_ready_array);
 
 	// This call will handle all rdma related events (bind->listen->connect_req->accept)
 	virtual void statistics_print(vlog_levels_t log_level = VLOG_DEBUG);
@@ -189,15 +185,6 @@ private:
 			return port == r_port;
 		}
 	};
-
-/*	in_addr_t 	m_bound_if;
-	in_port_t 	m_bound_port;
-	in_addr_t 	m_connected_ip;
-	in_port_t 	m_connected_port;
-*/
-	typedef bool (sockinfo_udp::* udp_rx_packet_processor_t)(mem_buf_desc_t* p_desc, void* pv_fd_ready_array);
-
-	udp_rx_packet_processor_t	m_rx_packet_processor; // to inspect and process incoming packet
 
 	in_addr_t 	m_mc_tx_if;
 	bool 		m_b_mc_tx_loop;
@@ -241,7 +228,6 @@ private:
 	int mc_change_membership_end_helper(in_addr_t mc_grp, int optname, in_addr_t mc_src = 0);
 	int mc_change_pending_mreq(const mc_pending_pram *p_mc_pram);
 	int on_sockname_change(struct sockaddr *__name, socklen_t __namelen);
-	inline void set_rx_packet_processor(void);
 	void handle_pending_mreq();
 	void original_os_setsockopt_helper( void* pram, int pram_size, int optname);
 	/* helper functions */
@@ -289,11 +275,6 @@ private:
 		}
     }
 
-	inline bool	rx_process_udp_packet_full(mem_buf_desc_t* p_desc, void* pv_fd_ready_array);
-	inline bool	rx_process_udp_packet_partial(mem_buf_desc_t* p_desc, void* pv_fd_ready_array);
-	inline bool	inspect_uc_packet(mem_buf_desc_t* p_desc);
-	inline bool	inspect_connected(mem_buf_desc_t* p_desc);
-	inline bool	inspect_mc_packet(mem_buf_desc_t* p_desc);
 	inline vma_recv_callback_retval_t inspect_by_user_cb(mem_buf_desc_t* p_desc);
 	inline void	fill_completion(mem_buf_desc_t* p_desc);
 	inline void	update_ready(mem_buf_desc_t* p_rx_wc_buf_desc, void* pv_fd_ready_array, vma_recv_callback_retval_t cb_ret);

--- a/src/vma/util/sys_vars.cpp
+++ b/src/vma/util/sys_vars.cpp
@@ -561,6 +561,7 @@ void mce_sys_var::get_env_params()
 	gro_streams_max		= MCE_DEFAULT_GRO_STREAMS_MAX;
 
 	tcp_3t_rules		= MCE_DEFAULT_TCP_3T_RULES;
+	udp_3t_rules		= MCE_DEFAULT_UDP_3T_RULES;
 	eth_mc_l2_only_rules	= MCE_DEFAULT_ETH_MC_L2_ONLY_RULES;
 	mc_force_flowtag	= MCE_DEFAULT_MC_FORCE_FLOWTAG;
 
@@ -991,6 +992,9 @@ void mce_sys_var::get_env_params()
 
 	if ((env_ptr = getenv(SYS_VAR_TCP_3T_RULES)) != NULL)
 		tcp_3t_rules = atoi(env_ptr) ? true : false;
+
+	if ((env_ptr = getenv(SYS_VAR_UDP_3T_RULES)) != NULL)
+		udp_3t_rules = atoi(env_ptr) ? true : false;
 
 	if ((env_ptr = getenv(SYS_VAR_ETH_MC_L2_ONLY_RULES)) != NULL)
 		eth_mc_l2_only_rules = atoi(env_ptr) ? true : false;

--- a/src/vma/util/sys_vars.h
+++ b/src/vma/util/sys_vars.h
@@ -359,6 +359,7 @@ public:
 	uint32_t	gro_streams_max;
 
 	bool		tcp_3t_rules;
+	bool		udp_3t_rules;
 	bool		eth_mc_l2_only_rules;
 	bool		mc_force_flowtag;
 
@@ -500,6 +501,7 @@ extern mce_sys_var & safe_mce_sys();
 #define SYS_VAR_RX_CQ_DRAIN_RATE_NSEC			"VMA_RX_CQ_DRAIN_RATE_NSEC"
 #define SYS_VAR_GRO_STREAMS_MAX				"VMA_GRO_STREAMS_MAX"
 #define SYS_VAR_TCP_3T_RULES				"VMA_TCP_3T_RULES"
+#define SYS_VAR_UDP_3T_RULES				"VMA_UDP_3T_RULES"
 #define SYS_VAR_ETH_MC_L2_ONLY_RULES			"VMA_ETH_MC_L2_ONLY_RULES"
 #define SYS_VAR_MC_FORCE_FLOWTAG			"VMA_MC_FORCE_FLOWTAG"
 
@@ -619,6 +621,7 @@ extern mce_sys_var & safe_mce_sys();
 #define MCE_DEFAULT_RX_CQ_DRAIN_RATE			(MCE_RX_CQ_DRAIN_RATE_DISABLED)
 #define MCE_DEFAULT_GRO_STREAMS_MAX			(32)
 #define MCE_DEFAULT_TCP_3T_RULES			(false)
+#define MCE_DEFAULT_UDP_3T_RULES			(true)
 #define MCE_DEFAULT_ETH_MC_L2_ONLY_RULES		(false)
 #define MCE_DEFAULT_MC_FORCE_FLOWTAG			(false)
 #define MCE_DEFAULT_SELECT_NUM_POLLS			(100000)


### PR DESCRIPTION
Issue relates managing UDP unicast traffic in case several sockets are bound
to the same IP:PORT using reuse address option. In this case all traffic
come to the single top socket.
This logic is used in iperf as an example.

Flow description:
server logic:
1. create listen socket listen_sock and bind to IP:PORT and reuse addr
2. do recvfrom(), get peer address using listen_sock
3. sock1 = listen_sock
3. do connect() using peer address and sock1
4. do step #1 getting new fd value for listen_sock
5. do write() using sock1
6. ...

Signed-off-by: Igor Ivanov <igor.ivanov.va@gmail.com>