### PR TITLE
issue: 2136324 Refuse sendto() operation to zero port

### DIFF
--- a/src/vma/sock/sock-redirect.cpp
+++ b/src/vma/sock/sock-redirect.cpp
@@ -1079,7 +1079,11 @@ int connect(int __fd, const struct sockaddr *__to, socklen_t __tolen)
 	int ret = 0;
 	socket_fd_api* p_socket_object = NULL;
 	p_socket_object = fd_collection_get_sockfd(__fd);
-	if (__to && __to->sa_family == AF_INET && p_socket_object) {
+
+	/* Zero port is reserved and can not be used as destination port
+	 * but it is not checked here to be consistent with Linux behaivour
+	 */
+	if (__to && (get_sa_family(__to) == AF_INET) && p_socket_object) {
 		ret = p_socket_object->connect(__to, __tolen);
 		if (p_socket_object->isPassthrough()) {
 			handle_close(__fd, false, true);

--- a/src/vma/sock/sockinfo_udp.cpp
+++ b/src/vma/sock/sockinfo_udp.cpp
@@ -1591,6 +1591,10 @@ ssize_t sockinfo_udp::tx(vma_tx_call_attr_t &tx_arg)
 			si_udp_logdbg("to->sin_family != AF_INET (tx-ing to os)");
 			goto tx_packet_to_os;
 		}
+                if (unlikely(get_sa_port(__dst) == 0)) {
+                        si_udp_logdbg("to->sin_port == 0 (tx-ing to os)");
+                        goto tx_packet_to_os;
+                }
 
 		sock_addr dst((struct sockaddr*)__dst);
 

--- a/tests/gtest/Makefile.am
+++ b/tests/gtest/Makefile.am
@@ -38,6 +38,7 @@ gtest_SOURCES = \
 	\
 	udp/udp_base.cc \
 	udp/udp_bind.cc \
+	udp/udp_connect.cc \
 	udp/udp_send.cc \
 	udp/udp_sendto.cc \
 	\

--- a/tests/gtest/common/cmn.h
+++ b/tests/gtest/common/cmn.h
@@ -41,17 +41,18 @@ namespace cmn {
 
 class test_skip_exception : public std::exception {
 public:
-    test_skip_exception(const std::string& reason = "") : m_reason(reason) {
+    test_skip_exception(const std::string& reason = "") : m_reason("[  SKIPPED ] ") {
+        m_reason += reason;
     }
-    virtual ~test_skip_exception() throw() {
+    virtual ~test_skip_exception() _GLIBCXX_NOTHROW {
     }
 
-    virtual const char* what() const throw() {
-        return (std::string("[  SKIPPED ] ") + m_reason).c_str();
+    const char* what() const _GLIBCXX_NOTHROW {
+        return m_reason.c_str();
     }
 
 private:
-    const std::string m_reason;
+    std::string m_reason;
 };
 
 #define SKIP_TRUE(_expr, _reason) \

--- a/tests/gtest/common/sys.cc
+++ b/tests/gtest/common/sys.cc
@@ -158,7 +158,8 @@ int sys_dev2addr(char *dev, struct sockaddr_in *addr)
 
     ifr.ifr_addr.sa_family = AF_INET;
 
-    strncpy(ifr.ifr_name , dev , strlen(dev));
+    ifr.ifr_name[sizeof(ifr.ifr_name) - 1] = 0;
+    strncpy(ifr.ifr_name , dev , sys_min(strlen(dev), sizeof(ifr.ifr_name) - 1));
 
     rc = ioctl(fd, SIOCGIFADDR, &ifr);
     if (rc >= 0 && addr) {

--- a/tests/gtest/udp/udp_sendto.cc
+++ b/tests/gtest/udp/udp_sendto.cc
@@ -185,3 +185,35 @@ TEST_F(udp_sendto, ti_5) {
 
 	close(fd);
 }
+
+/**
+ * @test udp_sendto.ti_6
+ * @brief
+ *    sendto() to sero port
+ * @details
+ */
+TEST_F(udp_sendto, ti_6) {
+	int rc = EOK;
+	int fd;
+	char buf[] = "hello";
+	struct sockaddr_in addr;
+
+	fd = udp_base::sock_create();
+	ASSERT_LE(0, fd);
+
+	errno = EOK;
+	rc = bind(fd, (struct sockaddr *)&client_addr, sizeof(client_addr));
+	EXPECT_EQ(EOK, errno);
+	EXPECT_EQ(0, rc);
+
+	memcpy(&addr, &server_addr, sizeof(addr));
+	addr.sin_port = 0;
+
+	errno = EOK;
+	rc = sendto(fd, (void *)buf, sizeof(buf), 0,
+			(struct sockaddr *)&addr, sizeof(addr));
+	EXPECT_EQ(EINVAL, errno);
+	EXPECT_GT(0, rc);
+
+	close(fd);
+}

--- a/tests/gtest/vmad/vmad_hash.cc
+++ b/tests/gtest/vmad/vmad_hash.cc
@@ -74,7 +74,7 @@ TEST_F(vmad_hash, ti_2) {
 
 TEST_F(vmad_hash, ti_3) {
 	hash_t ht;
-	struct element element[] = {{12345, 1}, {-12345, 2}, {0, 3}};
+	struct element element[] = {{12345, 1}, {(hash_key_t)-12345, 2}, {0, 3}};
 	int i;
 
 	ht = hash_create(NULL, 5);
@@ -180,7 +180,7 @@ TEST_F(vmad_hash, ti_7) {
 
 TEST_F(vmad_hash, ti_8) {
 	hash_t ht;
-	struct element element[] = {{12345, 1}, {-12345, 2}, {0, 3}};
+	struct element element[] = {{12345, 1}, {(hash_key_t)-12345, 2}, {0, 3}};
 	int i;
 
 	ht = hash_create(NULL, 5);


### PR DESCRIPTION
New tests are added to check a scenario when
udp socket try to do unicast send using zero destination port.

Signed-off-by: Igor Ivanov <igor.ivanov.va@gmail.com>