### PR TITLE
issue: 2175248 Reduce usage of snprintf()

### DIFF
--- a/src/vma/dev/net_device_val.cpp
+++ b/src/vma/dev/net_device_val.cpp
@@ -112,9 +112,9 @@ void ring_alloc_logic_attr::init()
 
 	m_str[0] = '\0';
 
-#define HASH_ITER(val)				\
+#define HASH_ITER(val, type)			\
 do {						\
-	size_t x = (size_t)val;			\
+	type x = (type)val;			\
 	do {					\
 		/* m_hash * 33 + byte */	\
 		h = (h << 5) + h + (x & 0xff);	\
@@ -122,11 +122,14 @@ do {						\
 	} while (x != 0);			\
 } while (0)
 
-	HASH_ITER(m_ring_alloc_logic);
-	HASH_ITER(m_ring_profile_key);
-	HASH_ITER(m_user_id_key);
-	HASH_ITER(m_mem_desc.iov_base);
-	HASH_ITER(m_mem_desc.iov_len);
+#undef HASH_ITER
+#define HASH_ITER(val, type) h = h * 19 + (size_t)val;
+
+	HASH_ITER(m_ring_alloc_logic, size_t);
+	HASH_ITER(m_ring_profile_key, size_t);
+	HASH_ITER(m_user_id_key, uint64_t);
+	HASH_ITER(m_mem_desc.iov_base, uintptr_t);
+	HASH_ITER(m_mem_desc.iov_len, size_t);
 
 	m_hash = h;
 #undef HASH_ITER

--- a/src/vma/dev/net_device_val.cpp
+++ b/src/vma/dev/net_device_val.cpp
@@ -170,11 +170,21 @@ void ring_alloc_logic_attr::set_user_id_key(uint64_t user_id_key)
 
 const char* ring_alloc_logic_attr::to_str()
 {
+	int rc;
+
 	if (unlikely(m_str[0] == '\0')) {
-		snprintf(m_str, RING_ALLOC_STR_SIZE,
-			 "allocation logic %d profile %d key %ld user address %p "
-			 "user length %zd", m_ring_alloc_logic, m_ring_profile_key,
-			 m_user_id_key, m_mem_desc.iov_base, m_mem_desc.iov_len);
+		rc = snprintf(m_str, RING_ALLOC_STR_SIZE,
+			"allocation logic %d profile %d key %ld user address %p "
+			"user length %zd", m_ring_alloc_logic, m_ring_profile_key,
+			m_user_id_key, m_mem_desc.iov_base, m_mem_desc.iov_len);
+		if (rc < 0) {
+			/*
+			 * If snprintf() fails for unknown reason, cache a
+			 * constant string not to call snprintf() in the future
+			 */
+			strncpy(m_str, "FAILED", sizeof(m_str));
+			m_str[sizeof(m_str) - 1] = '\0';
+		}
 	}
 	return m_str;
 }

--- a/src/vma/dev/net_device_val.h
+++ b/src/vma/dev/net_device_val.h
@@ -68,6 +68,7 @@ public:
 	void set_ring_profile_key(vma_ring_profile_key profile);
 	void set_memory_descriptor(iovec &mem_desc);
 	void set_user_id_key(uint64_t user_id_key);
+	const char* to_str();
 	inline ring_logic_t get_ring_alloc_logic() { return m_ring_alloc_logic;}
 	inline vma_ring_profile_key get_ring_profile_key() { return m_ring_profile_key;}
 	inline iovec* get_memory_descriptor() { return &m_mem_desc;}
@@ -96,15 +97,9 @@ public:
 			m_hash = other.m_hash;
 			m_mem_desc.iov_base = other.m_mem_desc.iov_base;
 			m_mem_desc.iov_len = other.m_mem_desc.iov_len;
-			snprintf(m_str, RING_ALLOC_STR_SIZE, "%s", other.m_str);
+			m_str[0] = '\0';
 		}
 		return *this;
-	}
-
-	const char* to_str() const
-	{
-
-		return m_str;
 	}
 
 	size_t operator()(const ring_alloc_logic_attr *key) const

--- a/src/vma/dev/ring_allocation_logic.cpp
+++ b/src/vma/dev/ring_allocation_logic.cpp
@@ -192,8 +192,18 @@ bool ring_allocation_logic::should_migrate_ring()
 
 const char* ring_allocation_logic::to_str()
 {
+	int rc;
+
 	if (unlikely(m_str[0] == '\0')) {
-		snprintf(m_str, sizeof(m_str), "[%s=%p]", m_type, m_owner);
+		rc = snprintf(m_str, sizeof(m_str), "[%s=%p]", m_type, m_owner);
+		if (rc < 0) {
+			/*
+			 * If snprintf() fails for unknown reason, cache a
+			 * constant string not to call snprintf() in the future
+			 */
+			strncpy(m_str, "[RAL]", sizeof(m_str));
+			m_str[sizeof(m_str) - 1] = '\0';
+		}
 	}
 	return m_str;
 }

--- a/src/vma/dev/ring_allocation_logic.cpp
+++ b/src/vma/dev/ring_allocation_logic.cpp
@@ -40,7 +40,7 @@
 #undef  MODULE_HDR_INFO
 #define MODULE_HDR_INFO 	MODULE_NAME "%s:%d:%s() "
 #undef	__INFO__
-#define __INFO__		m_tostr.c_str()
+#define __INFO__		to_str()
 
 #define ral_logpanic		__log_info_panic
 #define ral_logerr		__log_info_err
@@ -50,17 +50,22 @@
 #define ral_logfunc		__log_info_func
 #define ral_logfuncall		__log_info_funcall
 
-ring_allocation_logic::ring_allocation_logic():m_ring_migration_ratio(0),
+ring_allocation_logic::ring_allocation_logic(): m_owner(NULL),
+						m_ring_migration_ratio(0),
 						m_source(-1),
 						m_migration_try_count(0),
 						m_migration_candidate(0),
 						m_active(true),
-						m_res_key() {}
+						m_res_key()
+{
+	m_str[0] = '\0';
+	m_type = "";
+}
 
 ring_allocation_logic::ring_allocation_logic(ring_logic_t allocation_logic,
 					     int ring_migration_ratio, source_t source,
 					     resource_allocation_key &ring_profile):
-	m_tostr("base"), m_ring_migration_ratio(ring_migration_ratio),
+	m_owner(NULL), m_ring_migration_ratio(ring_migration_ratio),
 	m_source(source), m_migration_try_count(ring_migration_ratio)
 {
 	if (ring_profile.get_ring_alloc_logic() == RING_LOGIC_PER_INTERFACE &&
@@ -70,6 +75,9 @@ ring_allocation_logic::ring_allocation_logic(ring_logic_t allocation_logic,
 	m_res_key = resource_allocation_key(ring_profile);
 	m_migration_candidate = 0;
 	m_res_key.set_user_id_key(calc_res_key_by_logic());
+
+	m_str[0] = '\0';
+	m_type = "";
 
 	m_active = true;
 }
@@ -180,6 +188,14 @@ bool ring_allocation_logic::should_migrate_ring()
 	m_migration_candidate = 0;
 
 	return true;
+}
+
+const char* ring_allocation_logic::to_str()
+{
+	if (unlikely(m_str[0] == '\0')) {
+		snprintf(m_str, sizeof(m_str), "[%s=%p]", m_type, m_owner);
+	}
+	return m_str;
 }
 
 cpu_manager g_cpu_manager;

--- a/src/vma/dev/ring_allocation_logic.h
+++ b/src/vma/dev/ring_allocation_logic.h
@@ -41,8 +41,7 @@
 #include "vma_extra.h"
 
 #define CANDIDATE_STABILITY_ROUNDS 20
-
-#define RAL_TOSTR(to, type, owner) {char buf[100];sprintf(buf, "[%s=%p]",(type),(owner));(to) = buf;}
+#define RAL_STR_MAX_LENGTH 100
 
 #define MAX_CPU CPU_SETSIZE
 #define NO_CPU -1
@@ -83,8 +82,12 @@ public:
 	bool			is_logic_support_migration() { return m_res_key.get_ring_alloc_logic() >= RING_LOGIC_PER_THREAD && m_ring_migration_ratio > 0;}
 	uint64_t		calc_res_key_by_logic();
 	inline void		enable_migration(bool active) { m_active = active; }
+	const char*		to_str();
+
 protected:
-	string			m_tostr;
+	char			m_str[RAL_STR_MAX_LENGTH];
+	const char*		m_type;
+	const void*		m_owner;
 
 private:
 	int			m_ring_migration_ratio;
@@ -103,7 +106,8 @@ public:
 		ring_allocation_logic(safe_mce_sys().ring_allocation_logic_rx,
 				      safe_mce_sys().ring_migration_ratio_rx,
 				      source, ring_profile) {
-		RAL_TOSTR(m_tostr, "Rx", owner);
+		m_type = "Rx";
+		m_owner = owner;
 	}
 };
 
@@ -115,7 +119,8 @@ public:
 		ring_allocation_logic(safe_mce_sys().ring_allocation_logic_tx,
 				      safe_mce_sys().ring_migration_ratio_tx,
 				      source, ring_profile) {
-		RAL_TOSTR(m_tostr, "Tx",owner);
+		m_type = "Tx";
+		m_owner = owner;
 	}
 };
 

--- a/src/vma/dev/ring_allocation_logic.h
+++ b/src/vma/dev/ring_allocation_logic.h
@@ -41,7 +41,7 @@
 #include "vma_extra.h"
 
 #define CANDIDATE_STABILITY_ROUNDS 20
-#define RAL_STR_MAX_LENGTH 100
+#define RAL_STR_MAX_LENGTH 32
 
 #define MAX_CPU CPU_SETSIZE
 #define NO_CPU -1

--- a/src/vma/proto/flow_tuple.cpp
+++ b/src/vma/proto/flow_tuple.cpp
@@ -35,6 +35,7 @@
 #include "flow_tuple.h"
 #include <vma/util/vtypes.h>
 #include <vlogger/vlogger.h>
+#include <tr1/unordered_map> /* hash */
 
 
 #define MODULE_NAME "flow_tuple"
@@ -43,7 +44,7 @@
 flow_tuple::flow_tuple() :
 		m_dst_ip(INADDR_ANY), m_src_ip(INADDR_ANY), m_dst_port(INPORT_ANY), m_src_port(INPORT_ANY), m_protocol(PROTO_UNDEFINED)
 {
-	m_str[0] = '\0';
+	set_str();
 }
 
 flow_tuple::flow_tuple(sock_addr& dst, sock_addr& src, in_protocol_t protocol)
@@ -83,7 +84,7 @@ flow_tuple& flow_tuple::operator=(const flow_tuple &ft)
 	m_dst_port = ft.m_dst_port;
 	m_src_ip = ft.m_src_ip;
 	m_src_port = ft.m_src_port;
-	strncpy(m_str, ft.m_str, sizeof(m_str));
+	set_str();
 
 	return *this;
 }
@@ -118,21 +119,53 @@ bool flow_tuple::is_3_tuple()
 	return (m_src_ip == INADDR_ANY && m_src_port == INPORT_ANY);
 }
 
+size_t flow_tuple::hash(void)
+{
+	std::tr1::hash<uint64_t> _hash;
+	uint64_t val;
+
+	val = ((((uint64_t)m_dst_ip ^ ((uint64_t)m_dst_port << 16ULL)) << 32ULL) |
+		(((uint64_t)m_src_ip ^ ((uint64_t)m_src_port << 16ULL)))) ^
+		((uint64_t)m_protocol << 30ULL);
+	return _hash(val);
+}
+
 void flow_tuple::set_str()
 {
-	/* cppcheck-suppress wrongPrintfScanfArgNum */
-	snprintf(m_str, sizeof(m_str), "dst:%hhu.%hhu.%hhu.%hhu:%hu, src:%hhu.%hhu.%hhu.%hhu:%hu, proto:%s",
+	m_str[0] = '\0';
+}
+
+const char* flow_tuple::to_str()
+{
+	if (unlikely(m_str[0] == '\0')) {
+		/* cppcheck-suppress wrongPrintfScanfArgNum */
+		snprintf(m_str, sizeof(m_str),
+			"dst:%hhu.%hhu.%hhu.%hhu:%hu, "
+			"src:%hhu.%hhu.%hhu.%hhu:%hu, proto:%s",
 			NIPQUAD(m_dst_ip), ntohs(m_dst_port),
 			NIPQUAD(m_src_ip), ntohs(m_src_port),
 			__vma_get_protocol_str(m_protocol));
+	}
+	return m_str;
 }
 
-void flow_tuple_with_local_if::set_str()
+size_t flow_tuple_with_local_if::hash(void)
 {
-	char addr_str[32] = { 0 };
+	return flow_tuple::hash() ^ m_local_if;
+}
 
-	/* cppcheck-suppress wrongPrintfScanfArgNum */
-	snprintf(addr_str, sizeof(addr_str), ", if:%hhu.%hhu.%hhu.%hhu",
-		NIPQUAD(m_local_if));
-	strcat(m_str, addr_str);
+const char* flow_tuple_with_local_if::to_str()
+{
+	if (unlikely(m_str[0] == '\0')) {
+		/* cppcheck-suppress wrongPrintfScanfArgNum */
+		snprintf(m_str, sizeof(m_str),
+			"dst:%hhu.%hhu.%hhu.%hhu:%hu, "
+			"src:%hhu.%hhu.%hhu.%hhu:%hu, proto:%s, "
+			"if:%hhu.%hhu.%hhu.%hhu",
+			NIPQUAD(m_dst_ip), ntohs(m_dst_port),
+			NIPQUAD(m_src_ip), ntohs(m_src_port),
+			__vma_get_protocol_str(m_protocol),
+			NIPQUAD(m_local_if));
+	}
+	return m_str;
 };

--- a/src/vma/proto/flow_tuple.cpp
+++ b/src/vma/proto/flow_tuple.cpp
@@ -137,14 +137,24 @@ void flow_tuple::set_str()
 
 const char* flow_tuple::to_str()
 {
+	int rc;
+
 	if (unlikely(m_str[0] == '\0')) {
 		/* cppcheck-suppress wrongPrintfScanfArgNum */
-		snprintf(m_str, sizeof(m_str),
+		rc = snprintf(m_str, sizeof(m_str),
 			"dst:%hhu.%hhu.%hhu.%hhu:%hu, "
 			"src:%hhu.%hhu.%hhu.%hhu:%hu, proto:%s",
 			NIPQUAD(m_dst_ip), ntohs(m_dst_port),
 			NIPQUAD(m_src_ip), ntohs(m_src_port),
 			__vma_get_protocol_str(m_protocol));
+		if (rc < 0) {
+			/*
+			 * If snprintf() fails for unknown reason, cache a
+			 * constant string not to call snprintf() in the future
+			 */
+			strncpy(m_str, "FAILED", sizeof(m_str));
+			m_str[sizeof(m_str) - 1] = '\0';
+		}
 	}
 	return m_str;
 }
@@ -156,9 +166,11 @@ size_t flow_tuple_with_local_if::hash(void)
 
 const char* flow_tuple_with_local_if::to_str()
 {
+	int rc;
+
 	if (unlikely(m_str[0] == '\0')) {
 		/* cppcheck-suppress wrongPrintfScanfArgNum */
-		snprintf(m_str, sizeof(m_str),
+		rc = snprintf(m_str, sizeof(m_str),
 			"dst:%hhu.%hhu.%hhu.%hhu:%hu, "
 			"src:%hhu.%hhu.%hhu.%hhu:%hu, proto:%s, "
 			"if:%hhu.%hhu.%hhu.%hhu",
@@ -166,6 +178,14 @@ const char* flow_tuple_with_local_if::to_str()
 			NIPQUAD(m_src_ip), ntohs(m_src_port),
 			__vma_get_protocol_str(m_protocol),
 			NIPQUAD(m_local_if));
+		if (rc < 0) {
+			/*
+			 * If snprintf() fails for unknown reason, cache a
+			 * constant string not to call snprintf() in the future
+			 */
+			strncpy(m_str, "FAILED", sizeof(m_str));
+			m_str[sizeof(m_str) - 1] = '\0';
+		}
 	}
 	return m_str;
 };

--- a/src/vma/proto/flow_tuple.h
+++ b/src/vma/proto/flow_tuple.h
@@ -90,15 +90,8 @@ public:
 		return m_protocol < other.m_protocol;
 	}
 
-	virtual size_t hash(void)
-	{
-		uint8_t csum = 0;
-		uint8_t* pval = (uint8_t*)this;
-		for (size_t i = 0; i < (sizeof(flow_tuple) - sizeof(m_str)); ++i, ++pval) { csum ^= *pval; }
-		return csum;
-	}
-
-	const char*	to_str() { return m_str; };
+	virtual size_t		hash(void);
+	virtual const char*	to_str();
 
 protected:
 	in_addr_t	m_dst_ip;
@@ -108,7 +101,7 @@ protected:
 	in_protocol_t 	m_protocol;
 
 	char		m_str[STR_MAX_LENGTH];
-	virtual void 	set_str();
+	void		set_str();
 };
 
 typedef std::list<flow_tuple> flow_tuple_list_t;
@@ -139,17 +132,11 @@ public:
 		return (*((flow_tuple*)this) < ((flow_tuple)other));
 	}
 
-	virtual size_t 	hash(void)
-	{
-		uint8_t csum = 0;
-		uint8_t* pval = (uint8_t*)this;
-		for (size_t i = 0; i < (sizeof(flow_tuple_with_local_if) - sizeof(m_str)); ++i, ++pval) { csum ^= *pval; }
-		return csum;
-	}
+	virtual size_t		hash(void);
+	virtual const char*	to_str();
 
 protected:
 	in_addr_t	m_local_if;
-	virtual void 	set_str();
 };
 
 

--- a/src/vma/proto/route_rule_table_key.h
+++ b/src/vma/proto/route_rule_table_key.h
@@ -93,26 +93,13 @@ class hash<route_rule_table_key>
 public:
 	size_t operator()(const route_rule_table_key &key) const
 	{
-		hash<string>_hash;
-		char s[40] = {0};
-		/*
-		Build string from exist parameter (destination IP, source IP, TOS)
-		which is unique for different route-rule entries.
-		*/
-		/* cppcheck-suppress wrongPrintfScanfArgNum */
-		sprintf(s, "%d.%d.%d.%d", NIPQUAD(key.get_dst_ip()));
-		if (key.get_src_ip()) {
-			char sx[20] = {0};
-			/* cppcheck-suppress wrongPrintfScanfArgNum */
-			sprintf(sx, " %d.%d.%d.%d", NIPQUAD(key.get_src_ip()));
-			strcat(s, sx);
-		}
-		if (key.get_tos()) {
-			char sx[20] = {0};
-			sprintf(sx, " %u", key.get_tos());
-			strcat(s, sx);
-		}
-		return _hash(std::string(s));// Use built in hash function for string input.
+		hash<uint64_t>_hash;
+		uint64_t val;
+
+		val = ((uint64_t)key.get_dst_ip() << 32ULL) |
+			((uint64_t)key.get_src_ip() ^
+			((uint64_t)key.get_tos() << 24ULL));
+		return _hash(val);
 	}
 };
 }}


### PR DESCRIPTION
snprintf() is relatively expensive function and makes significant impact
on performance in CPS scenario. Don't build debug strings unless they're
used with respective log level.

Also, don't use snprintf() for hash calculation. Integer arithmetics is
more appropriate.