### PR TITLE
issue: 2181872 Modify --with-dpcp configuration option

### DIFF
--- a/config/m4/dpcp.m4
+++ b/config/m4/dpcp.m4
@@ -15,16 +15,21 @@ AC_ARG_WITH([dpcp],
     [],
     [with_dpcp=no]
 )
-if test -z "$with_dpcp" || test "$with_dpcp" = "yes"; then
-    with_dpcp=/usr
-fi
 
-FUNC_CHECK_WITHDIR([dpcp], [$with_dpcp], [include/mellanox/dpcp.h])
+if test "x$vma_cv_directverbs" != x3 && test "x$with_dpcp" != xno; then
+    AC_MSG_ERROR([dpcp can be used under RDMA-core subsystem only])
+fi
 
 vma_cv_dpcp=0
 AS_IF([test "x$with_dpcp" == xno],
     [],
     [
+    if test -z "$with_dpcp" || test "$with_dpcp" = "yes"; then
+        with_dpcp=/usr
+    fi
+
+    FUNC_CHECK_WITHDIR([dpcp], [$with_dpcp], [include/mellanox/dpcp.h])
+
     vma_cv_dpcp_save_CPPFLAGS="$CPPFLAGS"
     vma_cv_dpcp_save_CXXFLAGS="$CXXFLAGS"
     vma_cv_dpcp_save_CFLAGS="$CFLAGS"
@@ -68,6 +73,8 @@ if test "$vma_cv_dpcp" -ne 0; then
     AC_DEFINE_UNQUOTED([DEFINED_DPCP], [1], [Define to 1 to use DPCP])
     AC_MSG_RESULT([yes])
 else
-    AC_MSG_RESULT([no])
+    AS_IF([test "x$with_dpcp" == xno],
+        [AC_MSG_RESULT([no])],
+        [AC_MSG_ERROR([dpcp support requested but not present])])
 fi
 ])

--- a/configure.ac
+++ b/configure.ac
@@ -287,6 +287,7 @@ AC_MSG_RESULT($ac_cv_ofed_path)
 VERBS_CAPABILITY_SETUP()
 OPT_VMA_LOGGING()
 PROF_IBPROF_SETUP()
+DPCP_CAPABILITY_SETUP()
 
 # Enable internal performance counters
 # Note: uncomment setup to activate this ability
@@ -347,12 +348,6 @@ if test "x$enable_tso" = xyes -a "x$vma_cv_attribute_ex_OPCODE_TSO" = xyes; then
     AC_MSG_RESULT([yes])
 else
     AC_MSG_RESULT([no])
-fi
-
-# DPCP Library support
-#
-if test "x$vma_cv_directverbs" == x3; then
-    DPCP_CAPABILITY_SETUP()
 fi
 
 AC_MSG_CHECKING([for md5 version of VMA statistics is])


### PR DESCRIPTION
1. If user attempts to enable dpcp in OFED with MLNX_LIBS configuration
he should see recommendation to use OFED with UPSTREAM_LIBS configuration.
2. Report error in case dpcp is not installed but user set --with-dpcp

Signed-off-by: Igor Ivanov <igor.ivanov.va@gmail.com>