### PR TITLE
issue: 2234519 Remove disable_raw_qp_enforcement option for rdma-core

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -1068,23 +1068,6 @@ VMA_TRACELEVEL variable value is set to 4 or more.
 In order to fix it - set VMA_TRACELEVEL to it's default value: 3
 
 
-* Ethernet RAW_PACKET_QP limited to privilege users
-
- VMA WARNING: ******************************************************************************
- VMA WARNING: * Verbs RAW_PACKET QP type creation is limited for root user access          *
- VMA WARNING: * Working in this mode might causes VMA malfunction over Ethernet interfaces *
- VMA WARNING: * WARNING: the following steps will restart your network interface!          *
- VMA WARNING: * 1. "echo options ib_uverbs disable_raw_qp_enforcement=1 > /etc/modprobe.d/ib_uverbs.conf" *
- VMA WARNING: * 2. "/etc/init.d/openibd restart"                                           *
- VMA WARNING: * Read the RAW_PACKET QP root access enforcement section in the VMA's User Manual for more information *
- VMA WARNING: ******************************************************************************
-This warning message means that VMA tried to create a HW QP resource over Eth
-interface while the kernel requires this operation to be done only by privileged
-users. root can enable this for regular users as well by:
- 1. "echo options ib_uverbs disable_raw_qp_enforcement=1 > /etc/modprobe.d/ib_uverbs.conf"
- 2. Restart openibd or rdma service depending on your system configuration
-
-
 * CAP_NET_RAW and root access
 
 VMA_WARNING: ******************************************************************************

--- a/src/vma/dev/net_device_val.cpp
+++ b/src/vma/dev/net_device_val.cpp
@@ -1723,6 +1723,7 @@ bool net_device_val::verify_qp_creation(const char* ifname, enum ibv_qp_type qp_
 		nd_logdbg("QP creation failed on interface %s (errno=%d %m), Traffic will not be offloaded", ifname, errno);
 qp_failure:
 		int err = errno; //verify_raw_qp_privliges can overwrite errno so keep it before the call
+#if defined(DEFINED_VERBS_VERSION) && (DEFINED_VERBS_VERSION == 2)
 		if (validate_raw_qp_privliges() == 0) {
 			// MLNX_OFED raw_qp_privliges file exist with bad value
 			vlog_printf(VLOG_WARNING,"*******************************************************************************************************\n");
@@ -1733,8 +1734,9 @@ qp_failure:
 			vlog_printf(VLOG_WARNING,"* 2. Restart openibd or rdma service depending on your system configuration\n");
 			vlog_printf(VLOG_WARNING,"* Read the RAW_PACKET QP root access enforcement section in the VMA's User Manual for more information\n");
 			vlog_printf(VLOG_WARNING,"******************************************************************************************************\n");
-		}
-		else if (validate_user_has_cap_net_raw_privliges() == 0 || err == EPERM) {
+		} else
+#endif /* DEFINED_VERBS_VERSION */
+		if (validate_user_has_cap_net_raw_privliges() == 0 || err == EPERM) {
 			vlog_printf(VLOG_WARNING,"*******************************************************************************************************\n");
 			vlog_printf(VLOG_WARNING,"* Interface %s will not be offloaded.\n", ifname);
 			vlog_printf(VLOG_WARNING,"* Offloaded resources are restricted to root or user with CAP_NET_RAW privileges\n");

--- a/src/vma/util/sys_vars.h
+++ b/src/vma/util/sys_vars.h
@@ -729,7 +729,9 @@ extern mce_sys_var & safe_mce_sys();
 #define L2_ADDR_FILE_FMT                                "/sys/class/net/%.*s/address"
 #define L2_BR_ADDR_FILE_FMT                                   "/sys/class/net/%.*s/broadcast"
 #define OPER_STATE_PARAM_FILE				"/sys/class/net/%s/operstate"
+#if defined(DEFINED_VERBS_VERSION) && (DEFINED_VERBS_VERSION == 2)
 #define RAW_QP_PRIVLIGES_PARAM_FILE			"/sys/module/ib_uverbs/parameters/disable_raw_qp_enforcement"
+#endif /* DEFINED_VERBS_VERSION */
 #define FLOW_STEERING_MGM_ENTRY_SIZE_PARAM_FILE		"/sys/module/mlx4_core/parameters/log_num_mgm_entry_size"
 #define VIRTUAL_DEVICE_FOLDER			"/sys/devices/virtual/net/%s/"
 #define BOND_DEVICE_FILE				"/proc/net/bonding/%s"

--- a/src/vma/util/utils.cpp
+++ b/src/vma/util/utils.cpp
@@ -979,6 +979,7 @@ int validate_ipoib_prop(const char* ifname, unsigned int ifflags,
 	}
 }
 
+#if defined(DEFINED_VERBS_VERSION) && (DEFINED_VERBS_VERSION == 2)
 //NOTE RAW_QP_PRIVLIGES_PARAM_FILE does not exist on upstream drivers
 int validate_raw_qp_privliges()
 {
@@ -992,6 +993,7 @@ int validate_raw_qp_privliges()
 	}
 	return 1;
 }
+#endif /* DEFINED_VERBS_VERSION */
 
 bool validate_user_has_cap_net_raw_privliges()
 {

--- a/src/vma/util/utils.h
+++ b/src/vma/util/utils.h
@@ -274,7 +274,9 @@ int validate_ipoib_prop(const char* ifname, unsigned int ifflags,
 		const char prop_file[], const char *expected_val,
 		int val_size, char *filename, char* base_ifname);
 
+#if defined(DEFINED_VERBS_VERSION) && (DEFINED_VERBS_VERSION == 2)
 int validate_raw_qp_privliges();
+#endif /* DEFINED_VERBS_VERSION */
 
 bool validate_user_has_cap_net_raw_privliges();
 


### PR DESCRIPTION
rdma-core stack does not use capability to force root privileges
during raw qp creation.
So it means that user should not be confused non workable advice.

Signed-off-by: Igor Ivanov <igor.ivanov.va@gmail.com>