### PR TITLE
issue: 2233349 Detect default hugepage size

### DIFF
--- a/src/vma/dev/allocator.cpp
+++ b/src/vma/dev/allocator.cpp
@@ -158,7 +158,15 @@ uint32_t vma_allocator::find_lkey_by_ib_ctx(ib_ctx_handler *p_ib_ctx_h) const
 
 bool vma_allocator::hugetlb_alloc(size_t sz_bytes)
 {
-	const size_t hugepagemask = 4 * 1024 * 1024 - 1;
+	static size_t hugepagemask = 0;
+
+	if (!hugepagemask) {
+		hugepagemask = default_huge_page_size();
+		if (!hugepagemask) {
+			return false;
+		}
+		hugepagemask -= 1;
+	}
 
 	m_length = (sz_bytes + hugepagemask) & (~hugepagemask);
 

--- a/src/vma/util/utils.cpp
+++ b/src/vma/util/utils.cpp
@@ -1017,6 +1017,34 @@ bool validate_user_has_cap_net_raw_privliges()
 #endif
 }
 
+size_t default_huge_page_size(void)
+{
+	static size_t hugepage_sz = 0;
+#ifdef MAP_HUGETLB
+
+	if (!hugepage_sz) {
+		char str[1024];
+		unsigned long sz;
+		FILE *file;
+
+		file = fopen("/proc/meminfo", "rt");
+		if (file) {
+			while (fgets(str, sizeof(str), file) != NULL) {
+				if (sscanf(str, "Hugepagesize:   %8lu kB", &sz) == 1) {
+					hugepage_sz = sz * 1024;
+					break;
+				}
+			}
+			fclose(file);
+		}
+	}
+#endif
+
+	__log_dbg("Detect default Hugepage size: %d", hugepage_sz);
+
+	return hugepage_sz;
+}
+
 int validate_tso(int if_index)
 {
 #ifdef HAVE_LINUX_ETHTOOL_H

--- a/src/vma/util/utils.h
+++ b/src/vma/util/utils.h
@@ -280,6 +280,8 @@ int validate_raw_qp_privliges();
 
 bool validate_user_has_cap_net_raw_privliges();
 
+size_t default_huge_page_size(void);
+
 /**
  * Get TSO support using interface index
  *


### PR DESCRIPTION
These changes allow dynamically discover the huge page size,
knowing that some systems have different sizes 2M,4M,1G etc.
It can look at /proc/meminfo:   cat /proc/meminfo | grep Hugepagesize to get
the current pagesize for use with mmap()/munmap() if MAP_HUGETLB is to be used.

Signed-off-by: Igor Ivanov <igor.ivanov.va@gmail.com>