### PR TITLE
issue: 2239872 Keep last_unsent valid when enqueue flags

### DIFF
--- a/src/vma/lwip/tcp.c
+++ b/src/vma/lwip/tcp.c
@@ -1305,6 +1305,7 @@ tcp_pcb_purge(struct tcp_pcb *pcb)
     tcp_tx_segs_free(pcb, pcb->unsent);
     tcp_tx_segs_free(pcb, pcb->unacked);
     pcb->unacked = pcb->unsent = NULL;
+    pcb->last_unsent = NULL;
 #if TCP_OVERSIZE
     pcb->unsent_oversize = 0;
 #endif /* TCP_OVERSIZE */

--- a/src/vma/lwip/tcp_out.c
+++ b/src/vma/lwip/tcp_out.c
@@ -869,6 +869,7 @@ tcp_enqueue_flags(struct tcp_pcb *pcb, u8_t flags)
     for (useg = pcb->unsent; useg->next != NULL; useg = useg->next);
     useg->next = seg;
   }
+  pcb->last_unsent = seg;
 #if TCP_OVERSIZE
   /* The new unsent tail has no space */
   pcb->unsent_oversize = 0;


### PR DESCRIPTION
tcp_enqueue_flags() adds a segment to the tail on the unsent list, but
doesn't update last_unsent pointer. Fix this, because we have to keep
the pointer valid. Commit fe29e92 is related to this issue.