### PR TITLE
lwip/tcp.c: remove unused and duplicated code

### DIFF
--- a/src/vma/lwip/tcp.c
+++ b/src/vma/lwip/tcp.c
@@ -329,7 +329,6 @@ tcp_abandon(struct tcp_pcb *pcb, int reset)
 {
   u32_t seqno, ackno;
   u16_t remote_port, local_port;
-  ip_addr_t remote_ip, local_ip;
 #if LWIP_CALLBACK_API  
   tcp_err_fn errf;
 #endif /* LWIP_CALLBACK_API */
@@ -347,8 +346,6 @@ tcp_abandon(struct tcp_pcb *pcb, int reset)
     int send_rst = reset && (get_tcp_state(pcb) != CLOSED);
     seqno = pcb->snd_nxt;
     ackno = pcb->rcv_nxt;
-    ip_addr_copy(local_ip, pcb->local_ip);
-    ip_addr_copy(remote_ip, pcb->remote_ip);
     local_port = pcb->local_port;
     remote_port = pcb->remote_port;
 #if LWIP_CALLBACK_API
@@ -356,27 +353,12 @@ tcp_abandon(struct tcp_pcb *pcb, int reset)
 #endif /* LWIP_CALLBACK_API */
     errf_arg = pcb->my_container;
     tcp_pcb_remove(pcb);
-    if (pcb->unacked != NULL) {
-      tcp_tx_segs_free(pcb, pcb->unacked);
-      pcb->unacked = NULL;
-    }
-    if (pcb->unsent != NULL) {
-      tcp_tx_segs_free(pcb, pcb->unsent);
-      pcb->unsent = NULL;
-    }
-#if TCP_QUEUE_OOSEQ    
-    if (pcb->ooseq != NULL) {
-      tcp_segs_free(pcb, pcb->ooseq);
-    }
-#endif /* TCP_QUEUE_OOSEQ */
     TCP_EVENT_ERR(errf, errf_arg, ERR_ABRT);
     if (send_rst) {
       LWIP_DEBUGF(TCP_RST_DEBUG, ("tcp_abandon: sending RST\n"));
       tcp_rst(seqno, ackno, local_port, remote_port, pcb);
     }
   }
-  (void)local_ip;  /* Fix warning -Wunused-but-set-variable */
-  (void)remote_ip; /* Fix warning -Wunused-but-set-variable */
 }
 
 /**

--- a/src/vma/lwip/tcp.h
+++ b/src/vma/lwip/tcp.h
@@ -58,7 +58,6 @@ typedef err_t (*ip_output_fn)(struct pbuf *p, void* p_conn, u16_t flags);
 #else
 typedef err_t (*ip_output_fn)(struct pbuf *p, void* p_conn, int is_rexmit, u8_t is_dummy);
 #endif /* LWIP_TSO */
-void register_ip_output(ip_output_fn fn);
 
 typedef ssize_t (*sys_readv_fn)(int __fd, const struct iovec *iov, int iovcnt);
 void register_sys_readv(sys_readv_fn fn);

--- a/src/vma/lwip/tcp_out.c
+++ b/src/vma/lwip/tcp_out.c
@@ -106,13 +106,6 @@ void register_sys_now(sys_now_fn fn)
 }
 
 #if LWIP_3RD_PARTY_L3
-ip_output_fn external_ip_output;
-
-void register_ip_output(ip_output_fn fn)
-{
-    external_ip_output = fn;
-}
-
 ip_route_mtu_fn external_ip_route_mtu;
 
 void register_ip_route_mtu(ip_route_mtu_fn fn)
@@ -1785,7 +1778,7 @@ tcp_output_segment(struct tcp_seg *seg, struct tcp_pcb *pcb)
  * most other segment output functions.
  *
  * The pcb is given only when its valid and from an output context.
- * It is used with the external_ip_output function.
+ * It is used with the pcb->ip_output() function.
  *
  * @param seqno the sequence number to use for the outgoing segment
  * @param ackno the acknowledge number to use for the outgoing segment
@@ -1828,7 +1821,6 @@ tcp_rst(u32_t seqno, u32_t ackno, u16_t local_port, u16_t remote_port, struct tc
 #else
   if(pcb) pcb->ip_output(p, pcb, 0, 0);
 #endif /* LWIP_TSO */
-  /* external_ip_output(p, NULL, local_ip, remote_ip, TCP_TTL, 0, IP_PROTO_TCP) */;
   tcp_tx_pbuf_free(pcb, p);
   LWIP_DEBUGF(TCP_RST_DEBUG, ("tcp_rst: seqno %"U32_F" ackno %"U32_F".\n", seqno, ackno));
 }

--- a/src/vma/proto/vma_lwip.cpp
+++ b/src/vma/proto/vma_lwip.cpp
@@ -120,7 +120,6 @@ vma_lwip::vma_lwip()
 	register_tcp_tx_pbuf_free(sockinfo_tcp::tcp_tx_pbuf_free);
 	register_tcp_seg_alloc(sockinfo_tcp::tcp_seg_alloc);
 	register_tcp_seg_free(sockinfo_tcp::tcp_seg_free);
-	register_ip_output(sockinfo_tcp::ip_output);
 	register_tcp_state_observer(sockinfo_tcp::tcp_state_observer);
 	register_ip_route_mtu(sockinfo_tcp::get_route_mtu);
 	register_sys_now(sys_now);


### PR DESCRIPTION
tcp_abandon() calls tcp_pcb_remove() which calls tcp_pcb_purge(). Since
we can abandon only non LISTEN sockets, all segments lists are
guaranteed to be empty after tcp_pcb_remove(). Checking them is an
extra code.

external_ip_output() is not used anywhere and the code around this
function is dead.