### PR TITLE
Issue: 2269696 Provide ibv_pd for DPCP adapter

### DIFF
--- a/src/vma/dev/ib_ctx_handler.cpp
+++ b/src/vma/dev/ib_ctx_handler.cpp
@@ -312,7 +312,7 @@ dpcp::adapter* ib_ctx_handler::set_dpcp_adapter()
 					goto err;
 				}
 
-				adapter->set_pd(out_pd.pdn);
+				adapter->set_pd(out_pd.pdn, pd);
 				status = adapter->open();
 				if (dpcp::DPCP_OK != status) {
 					ibch_logerr("failed opening dpcp adapter %s got %d",


### PR DESCRIPTION
So far DevX doesn't support GPU memory registration so to use ibv_reg_mr
in DPCP it should have struct ibv_pd*. set_pd method was extended for
optional second parameter with ibv_pd* which was set in VMA.

Signed-off-by: Oleg Kuporosov <olegk@mellanox.com>