### PR TITLE
issue: 2336523 Return RX pbufs to cq_mgr instead of global pool

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001-2020 Mellanox Technologies, Ltd. All rights reserved.
+ * Copyright (c) 2001-2021 Mellanox Technologies, Ltd. All rights reserved.
  *
  * This software is available to you under a choice of one of two
  * licenses.  You may choose to be licensed under the terms of the GNU

--- a/Makefile.am
+++ b/Makefile.am
@@ -22,8 +22,6 @@ mydoc_DATA = README.txt journal.txt VMA_VERSION
 
 install-exec-hook:
 	if type systemctl >/dev/null 2>&1; then \
-		cp $(top_builddir)/contrib/scripts/vma.init $(DESTDIR)$(sbindir)/vma; \
-		chmod 755 $(DESTDIR)$(sbindir)/vma; \
 		mkdir -p $(DESTDIR)$(prefix)/lib/systemd/system/; \
 		cp $(top_builddir)/contrib/scripts/vma.service $(DESTDIR)$(prefix)/lib/systemd/system/vma.service; \
 		chmod 644 $(DESTDIR)$(prefix)/lib/systemd/system/vma.service; \
@@ -35,7 +33,6 @@ install-exec-hook:
 
 uninstall-hook:
 	if type systemctl >/dev/null 2>&1; then \
-		rm -rf $(DESTDIR)$(sbindir)/vma; \
 		rm -rf $(DESTDIR)$(prefix)/lib/systemd/system/vma.service; \
 	else \
 		rm -rf $(DESTDIR)$(sysconfdir)/init.d/vma; \

--- a/config/m4/dpcp.m4
+++ b/config/m4/dpcp.m4
@@ -1,6 +1,6 @@
 # dpcp.m4 - Library to operate with DevX
 # 
-# Copyright (C) Mellanox Technologies Ltd. 2001-2020.  ALL RIGHTS RESERVED.
+# Copyright (C) Mellanox Technologies Ltd. 2001-2021. ALL RIGHTS RESERVED.
 # See file LICENSE for terms.
 #
 

--- a/config/m4/func.m4
+++ b/config/m4/func.m4
@@ -1,6 +1,6 @@
 # func.m4 - Collection of functions
 # 
-# Copyright (C) Mellanox Technologies Ltd. 2001-2020.  ALL RIGHTS RESERVED.
+# Copyright (C) Mellanox Technologies Ltd. 2001-2021. ALL RIGHTS RESERVED.
 # See file LICENSE for terms.
 #
 

--- a/config/m4/nl.m4
+++ b/config/m4/nl.m4
@@ -1,6 +1,6 @@
 # nl.m4 - Detect nl package
 #
-# Copyright (C) Mellanox Technologies Ltd. 2001-2020.  ALL RIGHTS RESERVED.
+# Copyright (C) Mellanox Technologies Ltd. 2001-2021. ALL RIGHTS RESERVED.
 # See file LICENSE for terms.
 #
 

--- a/config/m4/opt.m4
+++ b/config/m4/opt.m4
@@ -1,6 +1,6 @@
 # opt.m4 - Macros to control optimization
 # 
-# Copyright (C) Mellanox Technologies Ltd. 2001-2020.  ALL RIGHTS RESERVED.
+# Copyright (C) Mellanox Technologies Ltd. 2001-2021. ALL RIGHTS RESERVED.
 # See file LICENSE for terms.
 #
 

--- a/config/m4/prof.m4
+++ b/config/m4/prof.m4
@@ -1,6 +1,6 @@
 # prof.m4 - Profiling, instrumentation
 # 
-# Copyright (C) Mellanox Technologies Ltd. 2001-2020.  ALL RIGHTS RESERVED.
+# Copyright (C) Mellanox Technologies Ltd. 2001-2021. ALL RIGHTS RESERVED.
 # See file LICENSE for terms.
 #
 

--- a/config/m4/verbs.m4
+++ b/config/m4/verbs.m4
@@ -1,6 +1,6 @@
 # verbs.m4 - Parsing verbs capabilities
 #
-# Copyright (C) Mellanox Technologies Ltd. 2001-2020.  ALL RIGHTS RESERVED.
+# Copyright (C) Mellanox Technologies Ltd. 2001-2021. ALL RIGHTS RESERVED.
 # See file LICENSE for terms.
 #
 

--- a/configure.ac
+++ b/configure.ac
@@ -144,8 +144,12 @@ AC_MSG_CHECKING([for compiler])
 case $CC in
     gcc*|g++*)
         AC_MSG_RESULT([gcc])
-        CFLAGS="$CFLAGS -Wall -Wextra -Werror -Wundef -ffunction-sections -fdata-sections -Wsequence-point -pipe -Winit-self -Wmissing-include-dirs"
-        CXXFLAGS="$CXXFLAGS -Wshadow -Wall -Wextra -Werror -Wundef -ffunction-sections -fdata-sections -Wsequence-point -pipe -Winit-self -Wmissing-include-dirs"
+        CFLAGS="$CFLAGS -Wall -Wextra -Werror -Wundef \
+                -ffunction-sections -fdata-sections -Wsequence-point -pipe -Winit-self -Wmissing-include-dirs \
+                -Wno-free-nonheap-object "
+        CXXFLAGS="$CXXFLAGS -Wshadow -Wall -Wextra -Werror -Wundef \
+                -ffunction-sections -fdata-sections -Wsequence-point -pipe -Winit-self -Wmissing-include-dirs \
+                -Wno-free-nonheap-object "
         ;;
     icc*|icpc*)
         AC_MSG_RESULT([icc])

--- a/contrib/scripts/libvma.spec.in
+++ b/contrib/scripts/libvma.spec.in
@@ -19,10 +19,6 @@ License: GPLv2 or BSD
 Url: https://github.com/Mellanox/%{name}
 Source0: %{url}/archive/%{version}/%{name}-%{version}.tar.gz
 
-%if 0%{?rhl}%{?fedora} == 0
-BuildRoot: %(mktemp -ud %{_tmppath}/%{name}-%{version}-%{release}-XXXXXX)
-%endif
-
 # libvma currently supports only the following architectures
 ExclusiveArch: x86_64 ppc64le ppc64 aarch64
 
@@ -90,9 +86,6 @@ cp -f src/vma/.libs/%{name}.so %{name}-debug.so
 %{make_build}
 
 %install
-%if 0%{?rhl}%{?fedora} == 0
-[ "${RPM_BUILD_ROOT}" != "/" -a -d ${RPM_BUILD_ROOT} ] && rm -rf ${RPM_BUILD_ROOT}
-%endif
 
 %{make_build} DESTDIR=${RPM_BUILD_ROOT} install
 
@@ -133,11 +126,6 @@ if [ $1 = 0 ]; then
         %{_libdir}/lsb/remove_initd %{_sysconfdir}/init.d/vma
     fi
 fi
-
-%clean
-%if 0%{?rhl}%{?fedora} == 0
-[ "${RPM_BUILD_ROOT}" != "/" -a -d ${RPM_BUILD_ROOT} ] && rm -rf ${RPM_BUILD_ROOT}
-%endif
 
 %postun
 %{run_ldconfig}

--- a/contrib/scripts/libvma.spec.in
+++ b/contrib/scripts/libvma.spec.in
@@ -139,9 +139,6 @@ fi
 %doc %{_pkgdocdir}/journal.txt
 %doc %{_pkgdocdir}/VMA_VERSION
 %config(noreplace) %{_sysconfdir}/libvma.conf
-%dir %{_sysconfdir}/security
-%dir %{_sysconfdir}/security/limits.d
-%config(noreplace) %{_sysconfdir}/security/limits.d/30-libvma-limits.conf
 %{_sbindir}/vmad
 %if "%{use_systemd}" == "1"
 %{_prefix}/lib/systemd/system/vma.service

--- a/contrib/scripts/libvma.spec.in
+++ b/contrib/scripts/libvma.spec.in
@@ -32,6 +32,7 @@ BuildRequires: systemd-rpm-macros
 BuildRequires: pkgconfig(libnl-3.0)
 BuildRequires: pkgconfig(libnl-route-3.0)
 %endif
+BuildRequires: make
 
 %description
 libvma is a LD_PRELOAD-able library that boosts performance of TCP and
@@ -82,24 +83,34 @@ cp -f src/vma/.libs/%{name}.so %{name}-debug.so
 %endif
 
 %configure --docdir=%{_pkgdocdir} \
-	%{?configure_options}
+           %{?configure_options}
 %{make_build}
 
 %install
-%{make_install}
+%{make_build} DESTDIR=${RPM_BUILD_ROOT} install
 
 find $RPM_BUILD_ROOT%{_libdir} -name '*.la' -delete
+%if "%{use_systemd}" == "1"
+install -D -m 644 contrib/scripts/vma.service $RPM_BUILD_ROOT/%{_prefix}/lib/systemd/system/vma.service
+%endif
 
 %if %{use_rel} > 0
 install -m 755 ./%{name}-debug.so $RPM_BUILD_ROOT/%{_libdir}/%{name}-debug.so
 %endif
 
 %post
+%if 0%{?fedora} || 0%{?rhel} > 7
+# https://fedoraproject.org/wiki/Changes/Removing_ldconfig_scriptlets
+%else
 %{run_ldconfig}
-
+%endif
 if [ $1 = 1 ]; then
     if type systemctl >/dev/null 2>&1; then
-        systemctl --no-reload enable vma.service >/dev/null 2>&1 || true
+        %if 0%{?suse_version}
+        %service_add_post vma.service
+        %else
+        %systemd_post vma.service
+        %endif
     elif [ -e /sbin/chkconfig ]; then
         /sbin/chkconfig --add vma
     elif [ -e /usr/sbin/update-rc.d ]; then
@@ -112,8 +123,11 @@ fi
 %preun
 if [ $1 = 0 ]; then
     if type systemctl >/dev/null 2>&1; then
-        systemctl --no-reload disable vma.service >/dev/null 2>&1 || true
-        systemctl stop vma.service || true
+        %if 0%{?suse_version}
+        %service_del_preun vma.service
+        %else
+        %systemd_preun vma.service
+        %endif
     elif [ -e /sbin/chkconfig ]; then
         %{_sysconfdir}/init.d/vma stop
         /sbin/chkconfig --del vma
@@ -127,9 +141,17 @@ if [ $1 = 0 ]; then
 fi
 
 %postun
+%if 0%{?fedora} || 0%{?rhel} > 7
+# https://fedoraproject.org/wiki/Changes/Removing_ldconfig_scriptlets
+%else
 %{run_ldconfig}
+%endif
 if type systemctl >/dev/null 2>&1; then
-    systemctl --system daemon-reload >/dev/null 2>&1 || true
+        %if 0%{?suse_version}
+        %service_del_postun vma.service
+        %else
+        %systemd_postun_with_restart vma.service
+        %endif
 fi
 
 %files
@@ -142,7 +164,6 @@ fi
 %{_sbindir}/vmad
 %if "%{use_systemd}" == "1"
 %{_prefix}/lib/systemd/system/vma.service
-%{_sbindir}/vma
 %else
 %{_sysconfdir}/init.d/vma
 %endif
@@ -164,6 +185,9 @@ fi
 %{_mandir}/man8/vma_stats.*
 
 %changelog
+* Mon Nov 23 2020 Igor Ivanov <igor.ivanov.va@gmail.com> 9.2.1-1
+- Improve systemd support
+
 * Fri Apr 17 2020 Igor Ivanov <igor.ivanov.va@gmail.com> 9.0.2-1
 - Align with Fedora guidelines
 

--- a/contrib/scripts/libvma.spec.in
+++ b/contrib/scripts/libvma.spec.in
@@ -1,5 +1,4 @@
 %{!?configure_options: %global configure_options %{nil}}
-%{!?use_extralib: %global use_extralib @VMA_LIBRARY_RELEASE@}
 %{!?use_rel: %global use_rel @VMA_LIBRARY_RELEASE@}
 
 %{!?make_build: %global make_build %{__make} %{?_smp_mflags} %{?mflags} V=1}
@@ -27,10 +26,11 @@ BuildRequires: automake
 BuildRequires: autoconf
 BuildRequires: libtool
 BuildRequires: gcc-c++
-BuildRequires: libibverbs-devel
 BuildRequires: rdma-core-devel
+BuildRequires: systemd-rpm-macros
 %if 0%{?rhel} >= 7 || 0%{?fedora} >= 24 || 0%{?suse_version} >= 1500
-BuildRequires: libnl3-devel
+BuildRequires: pkgconfig(libnl-3.0)
+BuildRequires: pkgconfig(libnl-route-3.0)
 %endif
 
 %description
@@ -73,7 +73,7 @@ if [ ! -e configure ] && [ -e autogen.sh ]; then
     VMA_RELEASE=%{use_rel} ./autogen.sh
 fi
 
-%if %{use_extralib} > 0
+%if %{use_rel} > 0
 %configure --enable-opt-log=none \
            %{?configure_options}
 %{make_build}
@@ -86,12 +86,11 @@ cp -f src/vma/.libs/%{name}.so %{name}-debug.so
 %{make_build}
 
 %install
-
-%{make_build} DESTDIR=${RPM_BUILD_ROOT} install
+%{make_install}
 
 find $RPM_BUILD_ROOT%{_libdir} -name '*.la' -delete
 
-%if %{use_extralib} > 0
+%if %{use_rel} > 0
 install -m 755 ./%{name}-debug.so $RPM_BUILD_ROOT/%{_libdir}/%{name}-debug.so
 %endif
 
@@ -159,7 +158,7 @@ fi
 %files devel
 %dir %{_includedir}/mellanox
 %{_includedir}/mellanox/vma_extra.h
-%if %{use_extralib} > 0
+%if %{use_rel} > 0
 %{_libdir}/%{name}-debug.so
 %endif
 

--- a/contrib/scripts/vma.init.in
+++ b/contrib/scripts/vma.init.in
@@ -1,6 +1,6 @@
 #!/bin/bash
 #
-# Copyright (C) Mellanox Technologies Ltd. 2001-2020.  ALL RIGHTS RESERVED.
+# Copyright (C) Mellanox Technologies Ltd. 2001-2021. ALL RIGHTS RESERVED.
 # See file LICENSE for terms.
 #
 # vma:         Start the VMA Daemon

--- a/contrib/scripts/vma.service.in
+++ b/contrib/scripts/vma.service.in
@@ -1,14 +1,11 @@
 [Unit]
-Description=VMA Daemon. Version: @VERSION@-@VMA_LIBRARY_RELEASE@
-After=network.target syslog.target
-Requires=network.target
+Description=VMA Daemon
+After=network.target
 
 [Service]
 Type=forking
 Restart=on-failure
-ExecStart=@prefix@/sbin/vma start
-ExecStop=@prefix@/sbin/vma stop
-ExecReload=@prefix@/sbin/vma restart
+ExecStart=@prefix@/sbin/vmad
 RestartForceExitStatus=1 SIGTERM
 
 [Install]

--- a/contrib/test_jenkins.sh
+++ b/contrib/test_jenkins.sh
@@ -2,7 +2,7 @@
 #
 # Testing script for VMA, to run from Jenkins CI
 #
-# Copyright (C) Mellanox Technologies Ltd. 2001-2020.  ALL RIGHTS RESERVED.
+# Copyright (C) Mellanox Technologies Ltd. 2001-2021. ALL RIGHTS RESERVED.
 #
 # See file LICENSE for terms.
 #

--- a/debian/copyright
+++ b/debian/copyright
@@ -3,7 +3,7 @@ Upstream-Name: libvma
 Source: https://github.com/Mellanox/libvma
 
 Files: *
-Copyright: 2001-2020 Mellanox Technologies, Ltd.
+Copyright: 2001-2021 Mellanox Technologies, Ltd.
 License: GPLv2-and-2BSD
 
 Files:

--- a/src/state_machine/main.cpp
+++ b/src/state_machine/main.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001-2020 Mellanox Technologies, Ltd. All rights reserved.
+ * Copyright (c) 2001-2021 Mellanox Technologies, Ltd. All rights reserved.
  *
  * This software is available to you under a choice of one of two
  * licenses.  You may choose to be licensed under the terms of the GNU

--- a/src/state_machine/sm.cpp
+++ b/src/state_machine/sm.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001-2020 Mellanox Technologies, Ltd. All rights reserved.
+ * Copyright (c) 2001-2021 Mellanox Technologies, Ltd. All rights reserved.
  *
  * This software is available to you under a choice of one of two
  * licenses.  You may choose to be licensed under the terms of the GNU

--- a/src/state_machine/sm.h
+++ b/src/state_machine/sm.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001-2020 Mellanox Technologies, Ltd. All rights reserved.
+ * Copyright (c) 2001-2021 Mellanox Technologies, Ltd. All rights reserved.
  *
  * This software is available to you under a choice of one of two
  * licenses.  You may choose to be licensed under the terms of the GNU

--- a/src/state_machine/sm_fifo.cpp
+++ b/src/state_machine/sm_fifo.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001-2020 Mellanox Technologies, Ltd. All rights reserved.
+ * Copyright (c) 2001-2021 Mellanox Technologies, Ltd. All rights reserved.
  *
  * This software is available to you under a choice of one of two
  * licenses.  You may choose to be licensed under the terms of the GNU

--- a/src/state_machine/sm_fifo.h
+++ b/src/state_machine/sm_fifo.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001-2020 Mellanox Technologies, Ltd. All rights reserved.
+ * Copyright (c) 2001-2021 Mellanox Technologies, Ltd. All rights reserved.
  *
  * This software is available to you under a choice of one of two
  * licenses.  You may choose to be licensed under the terms of the GNU

--- a/src/stats/stats_data_reader.h
+++ b/src/stats/stats_data_reader.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001-2020 Mellanox Technologies, Ltd. All rights reserved.
+ * Copyright (c) 2001-2021 Mellanox Technologies, Ltd. All rights reserved.
  *
  * This software is available to you under a choice of one of two
  * licenses.  You may choose to be licensed under the terms of the GNU

--- a/src/stats/stats_printer.cpp
+++ b/src/stats/stats_printer.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001-2020 Mellanox Technologies, Ltd. All rights reserved.
+ * Copyright (c) 2001-2021 Mellanox Technologies, Ltd. All rights reserved.
  *
  * This software is available to you under a choice of one of two
  * licenses.  You may choose to be licensed under the terms of the GNU

--- a/src/stats/stats_publisher.cpp
+++ b/src/stats/stats_publisher.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001-2020 Mellanox Technologies, Ltd. All rights reserved.
+ * Copyright (c) 2001-2021 Mellanox Technologies, Ltd. All rights reserved.
  *
  * This software is available to you under a choice of one of two
  * licenses.  You may choose to be licensed under the terms of the GNU

--- a/src/stats/stats_reader.cpp
+++ b/src/stats/stats_reader.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001-2020 Mellanox Technologies, Ltd. All rights reserved.
+ * Copyright (c) 2001-2021 Mellanox Technologies, Ltd. All rights reserved.
  *
  * This software is available to you under a choice of one of two
  * licenses.  You may choose to be licensed under the terms of the GNU

--- a/src/utils/asm-arm64.h
+++ b/src/utils/asm-arm64.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001-2020 Mellanox Technologies, Ltd. All rights reserved.
+ * Copyright (c) 2001-2021 Mellanox Technologies, Ltd. All rights reserved.
  *
  * This software is available to you under a choice of one of two
  * licenses.  You may choose to be licensed under the terms of the GNU

--- a/src/utils/asm-ppc64.h
+++ b/src/utils/asm-ppc64.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001-2020 Mellanox Technologies, Ltd. All rights reserved.
+ * Copyright (c) 2001-2021 Mellanox Technologies, Ltd. All rights reserved.
  *
  * This software is available to you under a choice of one of two
  * licenses.  You may choose to be licensed under the terms of the GNU

--- a/src/utils/asm-x86.h
+++ b/src/utils/asm-x86.h
@@ -110,7 +110,7 @@ static inline int atomic_fetch_and_add(int x, volatile int *ptr)
  */
 static inline void gettimeoftsc(unsigned long long *p_tscval)
 {
-	register uint32_t upper_32, lower_32;
+	uint32_t upper_32, lower_32;
 
 	// ReaD Time Stamp Counter (RDTCS)
 	__asm__ __volatile__("rdtsc" : "=a" (lower_32), "=d" (upper_32));

--- a/src/utils/asm-x86.h
+++ b/src/utils/asm-x86.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001-2020 Mellanox Technologies, Ltd. All rights reserved.
+ * Copyright (c) 2001-2021 Mellanox Technologies, Ltd. All rights reserved.
  *
  * This software is available to you under a choice of one of two
  * licenses.  You may choose to be licensed under the terms of the GNU

--- a/src/utils/asm.h
+++ b/src/utils/asm.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001-2020 Mellanox Technologies, Ltd. All rights reserved.
+ * Copyright (c) 2001-2021 Mellanox Technologies, Ltd. All rights reserved.
  *
  * This software is available to you under a choice of one of two
  * licenses.  You may choose to be licensed under the terms of the GNU

--- a/src/utils/atomic.h
+++ b/src/utils/atomic.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001-2020 Mellanox Technologies, Ltd. All rights reserved.
+ * Copyright (c) 2001-2021 Mellanox Technologies, Ltd. All rights reserved.
  *
  * This software is available to you under a choice of one of two
  * licenses.  You may choose to be licensed under the terms of the GNU

--- a/src/utils/bullseye.h
+++ b/src/utils/bullseye.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001-2020 Mellanox Technologies, Ltd. All rights reserved.
+ * Copyright (c) 2001-2021 Mellanox Technologies, Ltd. All rights reserved.
  *
  * This software is available to you under a choice of one of two
  * licenses.  You may choose to be licensed under the terms of the GNU

--- a/src/utils/clock.h
+++ b/src/utils/clock.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001-2020 Mellanox Technologies, Ltd. All rights reserved.
+ * Copyright (c) 2001-2021 Mellanox Technologies, Ltd. All rights reserved.
  *
  * This software is available to you under a choice of one of two
  * licenses.  You may choose to be licensed under the terms of the GNU

--- a/src/utils/lock_wrapper.h
+++ b/src/utils/lock_wrapper.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001-2020 Mellanox Technologies, Ltd. All rights reserved.
+ * Copyright (c) 2001-2021 Mellanox Technologies, Ltd. All rights reserved.
  *
  * This software is available to you under a choice of one of two
  * licenses.  You may choose to be licensed under the terms of the GNU

--- a/src/utils/rdtsc.h
+++ b/src/utils/rdtsc.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001-2020 Mellanox Technologies, Ltd. All rights reserved.
+ * Copyright (c) 2001-2021 Mellanox Technologies, Ltd. All rights reserved.
  *
  * This software is available to you under a choice of one of two
  * licenses.  You may choose to be licensed under the terms of the GNU

--- a/src/utils/types.h
+++ b/src/utils/types.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001-2020 Mellanox Technologies, Ltd. All rights reserved.
+ * Copyright (c) 2001-2021 Mellanox Technologies, Ltd. All rights reserved.
  *
  * This software is available to you under a choice of one of two
  * licenses.  You may choose to be licensed under the terms of the GNU

--- a/src/vlogger/main.cpp
+++ b/src/vlogger/main.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001-2020 Mellanox Technologies, Ltd. All rights reserved.
+ * Copyright (c) 2001-2021 Mellanox Technologies, Ltd. All rights reserved.
  *
  * This software is available to you under a choice of one of two
  * licenses.  You may choose to be licensed under the terms of the GNU

--- a/src/vlogger/vlogger.cpp
+++ b/src/vlogger/vlogger.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001-2020 Mellanox Technologies, Ltd. All rights reserved.
+ * Copyright (c) 2001-2021 Mellanox Technologies, Ltd. All rights reserved.
  *
  * This software is available to you under a choice of one of two
  * licenses.  You may choose to be licensed under the terms of the GNU

--- a/src/vlogger/vlogger.h
+++ b/src/vlogger/vlogger.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001-2020 Mellanox Technologies, Ltd. All rights reserved.
+ * Copyright (c) 2001-2021 Mellanox Technologies, Ltd. All rights reserved.
  *
  * This software is available to you under a choice of one of two
  * licenses.  You may choose to be licensed under the terms of the GNU

--- a/src/vma/Makefile.am
+++ b/src/vma/Makefile.am
@@ -28,12 +28,9 @@ EXTRA_DIST = \
 	util/hash_map.inl \
 	dev/cq_mgr.inl \
 	dev/cq_mgr_mlx5.inl \
-	util/libvma.conf \
-	util/30-libvma-limits.conf
+	util/libvma.conf
 
 sysconf_DATA = util/libvma.conf
-othersysconfdir=$(sysconfdir)/security/limits.d
-othersysconf_DATA=util/30-libvma-limits.conf
 otherincludedir = $(includedir)/mellanox
 otherinclude_HEADERS = vma_extra.h
 

--- a/src/vma/config_scanner.c
+++ b/src/vma/config_scanner.c
@@ -756,7 +756,7 @@ int libvma_yy_flex_debug = 0;
 char *libvma_yytext;
 /* Line 1 of config_scanner.l */
 /*
- * Copyright (c) 2001-2020 Mellanox Technologies Ltd. All rights reserved.
+ * Copyright (c) 2001-2021 Mellanox Technologies Ltd. All rights reserved.
  *
  * This software is available to you under a choice of one of two
  * licenses.  You may choose to be licensed under the terms of the GNU

--- a/src/vma/dev/allocator.cpp
+++ b/src/vma/dev/allocator.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001-2020 Mellanox Technologies, Ltd. All rights reserved.
+ * Copyright (c) 2001-2021 Mellanox Technologies, Ltd. All rights reserved.
  *
  * This software is available to you under a choice of one of two
  * licenses.  You may choose to be licensed under the terms of the GNU

--- a/src/vma/dev/allocator.h
+++ b/src/vma/dev/allocator.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001-2020 Mellanox Technologies, Ltd. All rights reserved.
+ * Copyright (c) 2001-2021 Mellanox Technologies, Ltd. All rights reserved.
  *
  * This software is available to you under a choice of one of two
  * licenses.  You may choose to be licensed under the terms of the GNU

--- a/src/vma/dev/buffer_pool.cpp
+++ b/src/vma/dev/buffer_pool.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001-2020 Mellanox Technologies, Ltd. All rights reserved.
+ * Copyright (c) 2001-2021 Mellanox Technologies, Ltd. All rights reserved.
  *
  * This software is available to you under a choice of one of two
  * licenses.  You may choose to be licensed under the terms of the GNU

--- a/src/vma/dev/buffer_pool.h
+++ b/src/vma/dev/buffer_pool.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001-2020 Mellanox Technologies, Ltd. All rights reserved.
+ * Copyright (c) 2001-2021 Mellanox Technologies, Ltd. All rights reserved.
  *
  * This software is available to you under a choice of one of two
  * licenses.  You may choose to be licensed under the terms of the GNU

--- a/src/vma/dev/cq_mgr.cpp
+++ b/src/vma/dev/cq_mgr.cpp
@@ -580,17 +580,7 @@ void cq_mgr::reclaim_recv_buffer_helper(mem_buf_desc_t* buff)
 				temp->p_next_desc = NULL;
 				temp->p_prev_desc = NULL;
 				temp->reset_ref_count();
-				temp->rx.tcp.gro = 0;
-				temp->rx.is_vma_thr = false;
-				temp->rx.socketxtreme_polled = false;
-				temp->rx.flow_tag_id = 0;
-				temp->rx.tcp.p_ip_h = NULL;
-				temp->rx.tcp.p_tcp_h = NULL;
-				temp->rx.timestamps.sw.tv_nsec = 0;
-				temp->rx.timestamps.sw.tv_sec = 0;
-				temp->rx.timestamps.hw.tv_nsec = 0;
-				temp->rx.timestamps.hw.tv_sec = 0;
-				temp->rx.hw_raw_timestamp = 0;
+				memset(&temp->rx, 0, sizeof(temp->rx));
 				free_lwip_pbuf(&temp->lwip_pbuf);
 				m_rx_pool.push_back(temp);
 			}

--- a/src/vma/dev/cq_mgr.cpp
+++ b/src/vma/dev/cq_mgr.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001-2020 Mellanox Technologies, Ltd. All rights reserved.
+ * Copyright (c) 2001-2021 Mellanox Technologies, Ltd. All rights reserved.
  *
  * This software is available to you under a choice of one of two
  * licenses.  You may choose to be licensed under the terms of the GNU

--- a/src/vma/dev/cq_mgr.h
+++ b/src/vma/dev/cq_mgr.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001-2020 Mellanox Technologies, Ltd. All rights reserved.
+ * Copyright (c) 2001-2021 Mellanox Technologies, Ltd. All rights reserved.
  *
  * This software is available to you under a choice of one of two
  * licenses.  You may choose to be licensed under the terms of the GNU

--- a/src/vma/dev/cq_mgr.inl
+++ b/src/vma/dev/cq_mgr.inl
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001-2020 Mellanox Technologies, Ltd. All rights reserved.
+ * Copyright (c) 2001-2021 Mellanox Technologies, Ltd. All rights reserved.
  *
  * This software is available to you under a choice of one of two
  * licenses.  You may choose to be licensed under the terms of the GNU

--- a/src/vma/dev/cq_mgr_mlx5.cpp
+++ b/src/vma/dev/cq_mgr_mlx5.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001-2020 Mellanox Technologies, Ltd. All rights reserved.
+ * Copyright (c) 2001-2021 Mellanox Technologies, Ltd. All rights reserved.
  *
  * This software is available to you under a choice of one of two
  * licenses.  You may choose to be licensed under the terms of the GNU

--- a/src/vma/dev/cq_mgr_mlx5.h
+++ b/src/vma/dev/cq_mgr_mlx5.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001-2020 Mellanox Technologies, Ltd. All rights reserved.
+ * Copyright (c) 2001-2021 Mellanox Technologies, Ltd. All rights reserved.
  *
  * This software is available to you under a choice of one of two
  * licenses.  You may choose to be licensed under the terms of the GNU

--- a/src/vma/dev/cq_mgr_mlx5.inl
+++ b/src/vma/dev/cq_mgr_mlx5.inl
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001-2020 Mellanox Technologies, Ltd. All rights reserved.
+ * Copyright (c) 2001-2021 Mellanox Technologies, Ltd. All rights reserved.
  *
  * This software is available to you under a choice of one of two
  * licenses.  You may choose to be licensed under the terms of the GNU

--- a/src/vma/dev/cq_mgr_mp.cpp
+++ b/src/vma/dev/cq_mgr_mp.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001-2020 Mellanox Technologies, Ltd. All rights reserved.
+ * Copyright (c) 2001-2021 Mellanox Technologies, Ltd. All rights reserved.
  *
  * This software is available to you under a choice of one of two
  * licenses.  You may choose to be licensed under the terms of the GNU

--- a/src/vma/dev/cq_mgr_mp.h
+++ b/src/vma/dev/cq_mgr_mp.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001-2020 Mellanox Technologies, Ltd. All rights reserved.
+ * Copyright (c) 2001-2021 Mellanox Technologies, Ltd. All rights reserved.
  *
  * This software is available to you under a choice of one of two
  * licenses.  You may choose to be licensed under the terms of the GNU

--- a/src/vma/dev/dm_mgr.cpp
+++ b/src/vma/dev/dm_mgr.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001-2020 Mellanox Technologies, Ltd. All rights reserved.
+ * Copyright (c) 2001-2021 Mellanox Technologies, Ltd. All rights reserved.
  *
  * This software is available to you under a choice of one of two
  * licenses.  You may choose to be licensed under the terms of the GNU

--- a/src/vma/dev/dm_mgr.h
+++ b/src/vma/dev/dm_mgr.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001-2020 Mellanox Technologies, Ltd. All rights reserved.
+ * Copyright (c) 2001-2021 Mellanox Technologies, Ltd. All rights reserved.
  *
  * This software is available to you under a choice of one of two
  * licenses.  You may choose to be licensed under the terms of the GNU

--- a/src/vma/dev/gro_mgr.cpp
+++ b/src/vma/dev/gro_mgr.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001-2020 Mellanox Technologies, Ltd. All rights reserved.
+ * Copyright (c) 2001-2021 Mellanox Technologies, Ltd. All rights reserved.
  *
  * This software is available to you under a choice of one of two
  * licenses.  You may choose to be licensed under the terms of the GNU

--- a/src/vma/dev/gro_mgr.h
+++ b/src/vma/dev/gro_mgr.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001-2020 Mellanox Technologies, Ltd. All rights reserved.
+ * Copyright (c) 2001-2021 Mellanox Technologies, Ltd. All rights reserved.
  *
  * This software is available to you under a choice of one of two
  * licenses.  You may choose to be licensed under the terms of the GNU

--- a/src/vma/dev/ib_ctx_handler.cpp
+++ b/src/vma/dev/ib_ctx_handler.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001-2020 Mellanox Technologies, Ltd. All rights reserved.
+ * Copyright (c) 2001-2021 Mellanox Technologies, Ltd. All rights reserved.
  *
  * This software is available to you under a choice of one of two
  * licenses.  You may choose to be licensed under the terms of the GNU

--- a/src/vma/dev/ib_ctx_handler.h
+++ b/src/vma/dev/ib_ctx_handler.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001-2020 Mellanox Technologies, Ltd. All rights reserved.
+ * Copyright (c) 2001-2021 Mellanox Technologies, Ltd. All rights reserved.
  *
  * This software is available to you under a choice of one of two
  * licenses.  You may choose to be licensed under the terms of the GNU

--- a/src/vma/dev/ib_ctx_handler_collection.cpp
+++ b/src/vma/dev/ib_ctx_handler_collection.cpp
@@ -215,9 +215,6 @@ ib_ctx_handler* ib_ctx_handler_collection::get_ib_ctx(const char *ifa_name)
 			if (save_ptr) *save_ptr = '\0'; // Remove the tailing 'new line" char
 			strncpy(active_slave, slave_name, sizeof(active_slave) - 1);
 		}
-#if !defined(DEFINED_ROCE_LAG)
-		ifa_name = (const char *)active_slave;
-#endif /* DEFINED_ROCE_LAG */
 	}
 
 	for (ib_ctx_iter = m_ib_ctx_map.begin(); ib_ctx_iter != m_ib_ctx_map.end(); ib_ctx_iter++) {

--- a/src/vma/dev/ib_ctx_handler_collection.cpp
+++ b/src/vma/dev/ib_ctx_handler_collection.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001-2020 Mellanox Technologies, Ltd. All rights reserved.
+ * Copyright (c) 2001-2021 Mellanox Technologies, Ltd. All rights reserved.
  *
  * This software is available to you under a choice of one of two
  * licenses.  You may choose to be licensed under the terms of the GNU

--- a/src/vma/dev/ib_ctx_handler_collection.h
+++ b/src/vma/dev/ib_ctx_handler_collection.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001-2020 Mellanox Technologies, Ltd. All rights reserved.
+ * Copyright (c) 2001-2021 Mellanox Technologies, Ltd. All rights reserved.
  *
  * This software is available to you under a choice of one of two
  * licenses.  You may choose to be licensed under the terms of the GNU

--- a/src/vma/dev/net_device_entry.cpp
+++ b/src/vma/dev/net_device_entry.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001-2020 Mellanox Technologies, Ltd. All rights reserved.
+ * Copyright (c) 2001-2021 Mellanox Technologies, Ltd. All rights reserved.
  *
  * This software is available to you under a choice of one of two
  * licenses.  You may choose to be licensed under the terms of the GNU

--- a/src/vma/dev/net_device_entry.h
+++ b/src/vma/dev/net_device_entry.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001-2020 Mellanox Technologies, Ltd. All rights reserved.
+ * Copyright (c) 2001-2021 Mellanox Technologies, Ltd. All rights reserved.
  *
  * This software is available to you under a choice of one of two
  * licenses.  You may choose to be licensed under the terms of the GNU

--- a/src/vma/dev/net_device_table_mgr.cpp
+++ b/src/vma/dev/net_device_table_mgr.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001-2020 Mellanox Technologies, Ltd. All rights reserved.
+ * Copyright (c) 2001-2021 Mellanox Technologies, Ltd. All rights reserved.
  *
  * This software is available to you under a choice of one of two
  * licenses.  You may choose to be licensed under the terms of the GNU

--- a/src/vma/dev/net_device_table_mgr.h
+++ b/src/vma/dev/net_device_table_mgr.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001-2020 Mellanox Technologies, Ltd. All rights reserved.
+ * Copyright (c) 2001-2021 Mellanox Technologies, Ltd. All rights reserved.
  *
  * This software is available to you under a choice of one of two
  * licenses.  You may choose to be licensed under the terms of the GNU

--- a/src/vma/dev/net_device_val.cpp
+++ b/src/vma/dev/net_device_val.cpp
@@ -651,7 +651,6 @@ void net_device_val::set_slave_array()
 
 		m_slaves[i]->p_ib_ctx = g_p_ib_ctx_handler_collection->get_ib_ctx(base_ifname);
 		if (!m_slaves[i]->p_ib_ctx) {
-			nd_logerr("Can not find ib device by index=%d", m_slaves[i]->if_index);
 			continue;
 		}
 

--- a/src/vma/dev/net_device_val.cpp
+++ b/src/vma/dev/net_device_val.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001-2020 Mellanox Technologies, Ltd. All rights reserved.
+ * Copyright (c) 2001-2021 Mellanox Technologies, Ltd. All rights reserved.
  *
  * This software is available to you under a choice of one of two
  * licenses.  You may choose to be licensed under the terms of the GNU

--- a/src/vma/dev/net_device_val.h
+++ b/src/vma/dev/net_device_val.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001-2020 Mellanox Technologies, Ltd. All rights reserved.
+ * Copyright (c) 2001-2021 Mellanox Technologies, Ltd. All rights reserved.
  *
  * This software is available to you under a choice of one of two
  * licenses.  You may choose to be licensed under the terms of the GNU

--- a/src/vma/dev/qp_mgr.cpp
+++ b/src/vma/dev/qp_mgr.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001-2020 Mellanox Technologies, Ltd. All rights reserved.
+ * Copyright (c) 2001-2021 Mellanox Technologies, Ltd. All rights reserved.
  *
  * This software is available to you under a choice of one of two
  * licenses.  You may choose to be licensed under the terms of the GNU

--- a/src/vma/dev/qp_mgr.h
+++ b/src/vma/dev/qp_mgr.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001-2020 Mellanox Technologies, Ltd. All rights reserved.
+ * Copyright (c) 2001-2021 Mellanox Technologies, Ltd. All rights reserved.
  *
  * This software is available to you under a choice of one of two
  * licenses.  You may choose to be licensed under the terms of the GNU

--- a/src/vma/dev/qp_mgr_eth_direct.cpp
+++ b/src/vma/dev/qp_mgr_eth_direct.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001-2020 Mellanox Technologies, Ltd. All rights reserved.
+ * Copyright (c) 2001-2021 Mellanox Technologies, Ltd. All rights reserved.
  *
  * This software is available to you under a choice of one of two
  * licenses.  You may choose to be licensed under the terms of the GNU

--- a/src/vma/dev/qp_mgr_eth_direct.h
+++ b/src/vma/dev/qp_mgr_eth_direct.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001-2020 Mellanox Technologies, Ltd. All rights reserved.
+ * Copyright (c) 2001-2021 Mellanox Technologies, Ltd. All rights reserved.
  *
  * This software is available to you under a choice of one of two
  * licenses.  You may choose to be licensed under the terms of the GNU

--- a/src/vma/dev/qp_mgr_eth_mlx5.cpp
+++ b/src/vma/dev/qp_mgr_eth_mlx5.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001-2020 Mellanox Technologies, Ltd. All rights reserved.
+ * Copyright (c) 2001-2021 Mellanox Technologies, Ltd. All rights reserved.
  *
  * This software is available to you under a choice of one of two
  * licenses.  You may choose to be licensed under the terms of the GNU

--- a/src/vma/dev/qp_mgr_eth_mlx5.h
+++ b/src/vma/dev/qp_mgr_eth_mlx5.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001-2020 Mellanox Technologies, Ltd. All rights reserved.
+ * Copyright (c) 2001-2021 Mellanox Technologies, Ltd. All rights reserved.
  *
  * This software is available to you under a choice of one of two
  * licenses.  You may choose to be licensed under the terms of the GNU

--- a/src/vma/dev/qp_mgr_mp.cpp
+++ b/src/vma/dev/qp_mgr_mp.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001-2020 Mellanox Technologies, Ltd. All rights reserved.
+ * Copyright (c) 2001-2021 Mellanox Technologies, Ltd. All rights reserved.
  *
  * This software is available to you under a choice of one of two
  * licenses.  You may choose to be licensed under the terms of the GNU

--- a/src/vma/dev/qp_mgr_mp.h
+++ b/src/vma/dev/qp_mgr_mp.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001-2020 Mellanox Technologies, Ltd. All rights reserved.
+ * Copyright (c) 2001-2021 Mellanox Technologies, Ltd. All rights reserved.
  *
  * This software is available to you under a choice of one of two
  * licenses.  You may choose to be licensed under the terms of the GNU

--- a/src/vma/dev/rfs.cpp
+++ b/src/vma/dev/rfs.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001-2020 Mellanox Technologies, Ltd. All rights reserved.
+ * Copyright (c) 2001-2021 Mellanox Technologies, Ltd. All rights reserved.
  *
  * This software is available to you under a choice of one of two
  * licenses.  You may choose to be licensed under the terms of the GNU

--- a/src/vma/dev/rfs.h
+++ b/src/vma/dev/rfs.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001-2020 Mellanox Technologies, Ltd. All rights reserved.
+ * Copyright (c) 2001-2021 Mellanox Technologies, Ltd. All rights reserved.
  *
  * This software is available to you under a choice of one of two
  * licenses.  You may choose to be licensed under the terms of the GNU

--- a/src/vma/dev/rfs_mc.cpp
+++ b/src/vma/dev/rfs_mc.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001-2020 Mellanox Technologies, Ltd. All rights reserved.
+ * Copyright (c) 2001-2021 Mellanox Technologies, Ltd. All rights reserved.
  *
  * This software is available to you under a choice of one of two
  * licenses.  You may choose to be licensed under the terms of the GNU

--- a/src/vma/dev/rfs_mc.h
+++ b/src/vma/dev/rfs_mc.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001-2020 Mellanox Technologies, Ltd. All rights reserved.
+ * Copyright (c) 2001-2021 Mellanox Technologies, Ltd. All rights reserved.
  *
  * This software is available to you under a choice of one of two
  * licenses.  You may choose to be licensed under the terms of the GNU

--- a/src/vma/dev/rfs_uc.cpp
+++ b/src/vma/dev/rfs_uc.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001-2020 Mellanox Technologies, Ltd. All rights reserved.
+ * Copyright (c) 2001-2021 Mellanox Technologies, Ltd. All rights reserved.
  *
  * This software is available to you under a choice of one of two
  * licenses.  You may choose to be licensed under the terms of the GNU

--- a/src/vma/dev/rfs_uc.h
+++ b/src/vma/dev/rfs_uc.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001-2020 Mellanox Technologies, Ltd. All rights reserved.
+ * Copyright (c) 2001-2021 Mellanox Technologies, Ltd. All rights reserved.
  *
  * This software is available to you under a choice of one of two
  * licenses.  You may choose to be licensed under the terms of the GNU

--- a/src/vma/dev/rfs_uc_tcp_gro.cpp
+++ b/src/vma/dev/rfs_uc_tcp_gro.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001-2020 Mellanox Technologies, Ltd. All rights reserved.
+ * Copyright (c) 2001-2021 Mellanox Technologies, Ltd. All rights reserved.
  *
  * This software is available to you under a choice of one of two
  * licenses.  You may choose to be licensed under the terms of the GNU

--- a/src/vma/dev/rfs_uc_tcp_gro.h
+++ b/src/vma/dev/rfs_uc_tcp_gro.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001-2020 Mellanox Technologies, Ltd. All rights reserved.
+ * Copyright (c) 2001-2021 Mellanox Technologies, Ltd. All rights reserved.
  *
  * This software is available to you under a choice of one of two
  * licenses.  You may choose to be licensed under the terms of the GNU

--- a/src/vma/dev/ring.cpp
+++ b/src/vma/dev/ring.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001-2020 Mellanox Technologies, Ltd. All rights reserved.
+ * Copyright (c) 2001-2021 Mellanox Technologies, Ltd. All rights reserved.
  *
  * This software is available to you under a choice of one of two
  * licenses.  You may choose to be licensed under the terms of the GNU

--- a/src/vma/dev/ring.h
+++ b/src/vma/dev/ring.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001-2020 Mellanox Technologies, Ltd. All rights reserved.
+ * Copyright (c) 2001-2021 Mellanox Technologies, Ltd. All rights reserved.
  *
  * This software is available to you under a choice of one of two
  * licenses.  You may choose to be licensed under the terms of the GNU

--- a/src/vma/dev/ring.h
+++ b/src/vma/dev/ring.h
@@ -88,6 +88,7 @@ public:
 	// Get/Release memory buffer descriptor with a linked data memory buffer
 	virtual mem_buf_desc_t*	mem_buf_tx_get(ring_user_id_t id, bool b_block, int n_num_mem_bufs = 1) = 0;
 	virtual int		mem_buf_tx_release(mem_buf_desc_t* p_mem_buf_desc_list, bool b_accounting, bool trylock = false) = 0;
+	virtual void		mem_buf_rx_release(mem_buf_desc_t* p_mem_buf_desc) { buffer_pool::free_rx_lwip_pbuf_custom(&p_mem_buf_desc->lwip_pbuf.pbuf); };
 	virtual void		send_ring_buffer(ring_user_id_t id, vma_ibv_send_wr* p_send_wqe, vma_wr_tx_packet_attr attr) = 0;
 	virtual void		send_lwip_buffer(ring_user_id_t id, vma_ibv_send_wr* p_send_wqe, vma_wr_tx_packet_attr attr) = 0;
 

--- a/src/vma/dev/ring_allocation_logic.cpp
+++ b/src/vma/dev/ring_allocation_logic.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001-2020 Mellanox Technologies, Ltd. All rights reserved.
+ * Copyright (c) 2001-2021 Mellanox Technologies, Ltd. All rights reserved.
  *
  * This software is available to you under a choice of one of two
  * licenses.  You may choose to be licensed under the terms of the GNU

--- a/src/vma/dev/ring_allocation_logic.h
+++ b/src/vma/dev/ring_allocation_logic.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001-2020 Mellanox Technologies, Ltd. All rights reserved.
+ * Copyright (c) 2001-2021 Mellanox Technologies, Ltd. All rights reserved.
  *
  * This software is available to you under a choice of one of two
  * licenses.  You may choose to be licensed under the terms of the GNU

--- a/src/vma/dev/ring_bond.cpp
+++ b/src/vma/dev/ring_bond.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001-2020 Mellanox Technologies, Ltd. All rights reserved.
+ * Copyright (c) 2001-2021 Mellanox Technologies, Ltd. All rights reserved.
  *
  * This software is available to you under a choice of one of two
  * licenses.  You may choose to be licensed under the terms of the GNU

--- a/src/vma/dev/ring_bond.cpp
+++ b/src/vma/dev/ring_bond.cpp
@@ -376,6 +376,21 @@ int ring_bond::mem_buf_tx_release(mem_buf_desc_t* p_mem_buf_desc_list, bool b_ac
 	return ret;
 }
 
+void ring_bond::mem_buf_rx_release(mem_buf_desc_t* p_mem_buf_desc)
+{
+	uint32_t i;
+
+	for (i = 0; i < m_bond_rings.size(); i++) {
+		if (m_bond_rings[i] == p_mem_buf_desc->p_desc_owner) {
+			m_bond_rings[i]->mem_buf_rx_release(p_mem_buf_desc);
+			break;
+		}
+	}
+	if (i == m_bond_rings.size()) {
+		buffer_pool::free_rx_lwip_pbuf_custom(&p_mem_buf_desc->lwip_pbuf.pbuf);
+	}
+}
+
 void ring_bond::mem_buf_desc_return_single_to_owner_tx(mem_buf_desc_t* p_mem_buf_desc)
 {
 	p_mem_buf_desc->p_desc_owner->mem_buf_desc_return_single_to_owner_tx(p_mem_buf_desc);

--- a/src/vma/dev/ring_bond.h
+++ b/src/vma/dev/ring_bond.h
@@ -81,7 +81,7 @@ public:
         virtual uint32_t	get_max_send_sge(void);
         virtual uint32_t	get_max_payload_sz(void);
         virtual uint16_t	get_max_header_sz(void);
-	virtual uint32_t        get_tx_lkey(ring_user_id_t id) { return m_bond_rings[id]->get_tx_lkey(id); }
+	virtual uint32_t        get_tx_lkey(ring_user_id_t id) { return m_xmit_rings[id]->get_tx_lkey(id); }
         virtual bool		is_tso(void);
 #endif /* DEFINED_TSO */
 	int 			socketxtreme_poll(struct vma_completion_t *vma_completions, unsigned int ncompletions, int flags);

--- a/src/vma/dev/ring_bond.h
+++ b/src/vma/dev/ring_bond.h
@@ -59,6 +59,7 @@ public:
 	virtual void		adapt_cq_moderation();
 	virtual bool		reclaim_recv_buffers(descq_t *rx_reuse);
 	virtual bool		reclaim_recv_buffers(mem_buf_desc_t* rx_reuse_lst);
+	virtual void		mem_buf_rx_release(mem_buf_desc_t* p_mem_buf_desc);
 	virtual int		drain_and_proccess();
 	virtual int		wait_for_notification_and_process_element(int cq_channel_fd, uint64_t* p_cq_poll_sn, void* pv_fd_ready_array = NULL);
 	virtual int		get_num_resources() const { return m_bond_rings.size(); };

--- a/src/vma/dev/ring_bond.h
+++ b/src/vma/dev/ring_bond.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001-2020 Mellanox Technologies, Ltd. All rights reserved.
+ * Copyright (c) 2001-2021 Mellanox Technologies, Ltd. All rights reserved.
  *
  * This software is available to you under a choice of one of two
  * licenses.  You may choose to be licensed under the terms of the GNU

--- a/src/vma/dev/ring_eth_cb.cpp
+++ b/src/vma/dev/ring_eth_cb.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001-2020 Mellanox Technologies, Ltd. All rights reserved.
+ * Copyright (c) 2001-2021 Mellanox Technologies, Ltd. All rights reserved.
  *
  * This software is available to you under a choice of one of two
  * licenses.  You may choose to be licensed under the terms of the GNU

--- a/src/vma/dev/ring_eth_cb.h
+++ b/src/vma/dev/ring_eth_cb.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001-2020 Mellanox Technologies, Ltd. All rights reserved.
+ * Copyright (c) 2001-2021 Mellanox Technologies, Ltd. All rights reserved.
  *
  * This software is available to you under a choice of one of two
  * licenses.  You may choose to be licensed under the terms of the GNU

--- a/src/vma/dev/ring_eth_direct.cpp
+++ b/src/vma/dev/ring_eth_direct.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001-2020 Mellanox Technologies, Ltd. All rights reserved.
+ * Copyright (c) 2001-2021 Mellanox Technologies, Ltd. All rights reserved.
  *
  * This software is available to you under a choice of one of two
  * licenses.  You may choose to be licensed under the terms of the GNU

--- a/src/vma/dev/ring_eth_direct.h
+++ b/src/vma/dev/ring_eth_direct.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001-2020 Mellanox Technologies, Ltd. All rights reserved.
+ * Copyright (c) 2001-2021 Mellanox Technologies, Ltd. All rights reserved.
  *
  * This software is available to you under a choice of one of two
  * licenses.  You may choose to be licensed under the terms of the GNU

--- a/src/vma/dev/ring_profile.cpp
+++ b/src/vma/dev/ring_profile.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001-2020 Mellanox Technologies, Ltd. All rights reserved.
+ * Copyright (c) 2001-2021 Mellanox Technologies, Ltd. All rights reserved.
  *
  * This software is available to you under a choice of one of two
  * licenses.  You may choose to be licensed under the terms of the GNU

--- a/src/vma/dev/ring_profile.h
+++ b/src/vma/dev/ring_profile.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001-2020 Mellanox Technologies, Ltd. All rights reserved.
+ * Copyright (c) 2001-2021 Mellanox Technologies, Ltd. All rights reserved.
  *
  * This software is available to you under a choice of one of two
  * licenses.  You may choose to be licensed under the terms of the GNU

--- a/src/vma/dev/ring_simple.cpp
+++ b/src/vma/dev/ring_simple.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001-2020 Mellanox Technologies, Ltd. All rights reserved.
+ * Copyright (c) 2001-2021 Mellanox Technologies, Ltd. All rights reserved.
  *
  * This software is available to you under a choice of one of two
  * licenses.  You may choose to be licensed under the terms of the GNU

--- a/src/vma/dev/ring_simple.cpp
+++ b/src/vma/dev/ring_simple.cpp
@@ -629,6 +629,12 @@ int ring_simple::mem_buf_tx_release(mem_buf_desc_t* p_mem_buf_desc_list, bool b_
 	return accounting;
 }
 
+void ring_simple::mem_buf_rx_release(mem_buf_desc_t* p_mem_buf_desc)
+{
+	p_mem_buf_desc->p_next_desc = NULL;
+	reclaim_recv_buffers(p_mem_buf_desc);
+}
+
 /* note that this function is inline, so keep it above the functions using it */
 inline int ring_simple::send_buffer(vma_ibv_send_wr* p_send_wqe, vma_wr_tx_packet_attr attr)
 {

--- a/src/vma/dev/ring_simple.h
+++ b/src/vma/dev/ring_simple.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001-2020 Mellanox Technologies, Ltd. All rights reserved.
+ * Copyright (c) 2001-2021 Mellanox Technologies, Ltd. All rights reserved.
  *
  * This software is available to you under a choice of one of two
  * licenses.  You may choose to be licensed under the terms of the GNU

--- a/src/vma/dev/ring_simple.h
+++ b/src/vma/dev/ring_simple.h
@@ -69,6 +69,7 @@ public:
 	virtual bool		reclaim_recv_buffers(mem_buf_desc_t* rx_reuse_lst);
 	bool			reclaim_recv_buffers_no_lock(mem_buf_desc_t* rx_reuse_lst); // No locks
 	virtual int		reclaim_recv_single_buffer(mem_buf_desc_t* rx_reuse); // No locks
+	virtual void		mem_buf_rx_release(mem_buf_desc_t* p_mem_buf_desc);
 	virtual int 		socketxtreme_poll(struct vma_completion_t *vma_completions, unsigned int ncompletions, int flags);	
 	virtual int		drain_and_proccess();
 	virtual int		wait_for_notification_and_process_element(int cq_channel_fd, uint64_t* p_cq_poll_sn, void* pv_fd_ready_array = NULL);

--- a/src/vma/dev/ring_slave.cpp
+++ b/src/vma/dev/ring_slave.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001-2020 Mellanox Technologies, Ltd. All rights reserved.
+ * Copyright (c) 2001-2021 Mellanox Technologies, Ltd. All rights reserved.
  *
  * This software is available to you under a choice of one of two
  * licenses.  You may choose to be licensed under the terms of the GNU

--- a/src/vma/dev/ring_slave.h
+++ b/src/vma/dev/ring_slave.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001-2020 Mellanox Technologies, Ltd. All rights reserved.
+ * Copyright (c) 2001-2021 Mellanox Technologies, Ltd. All rights reserved.
  *
  * This software is available to you under a choice of one of two
  * licenses.  You may choose to be licensed under the terms of the GNU

--- a/src/vma/dev/ring_tap.cpp
+++ b/src/vma/dev/ring_tap.cpp
@@ -319,17 +319,7 @@ bool ring_tap::reclaim_recv_buffers(mem_buf_desc_t *buff)
 				temp->p_next_desc = NULL;
 				temp->p_prev_desc = NULL;
 				temp->reset_ref_count();
-				temp->rx.tcp.gro = 0;
-				temp->rx.is_vma_thr = false;
-				temp->rx.socketxtreme_polled = false;
-				temp->rx.flow_tag_id = 0;
-				temp->rx.tcp.p_ip_h = NULL;
-				temp->rx.tcp.p_tcp_h = NULL;
-				temp->rx.timestamps.sw.tv_nsec = 0;
-				temp->rx.timestamps.sw.tv_sec = 0;
-				temp->rx.timestamps.hw.tv_nsec = 0;
-				temp->rx.timestamps.hw.tv_sec = 0;
-				temp->rx.hw_raw_timestamp = 0;
+				memset(&temp->rx, 0, sizeof(temp->rx));
 				free_lwip_pbuf(&temp->lwip_pbuf);
 				m_rx_pool.push_back(temp);
 			}

--- a/src/vma/dev/ring_tap.cpp
+++ b/src/vma/dev/ring_tap.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001-2020 Mellanox Technologies, Ltd. All rights reserved.
+ * Copyright (c) 2001-2021 Mellanox Technologies, Ltd. All rights reserved.
  *
  * This software is available to you under a choice of one of two
  * licenses.  You may choose to be licensed under the terms of the GNU

--- a/src/vma/dev/ring_tap.h
+++ b/src/vma/dev/ring_tap.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001-2020 Mellanox Technologies, Ltd. All rights reserved.
+ * Copyright (c) 2001-2021 Mellanox Technologies, Ltd. All rights reserved.
  *
  * This software is available to you under a choice of one of two
  * licenses.  You may choose to be licensed under the terms of the GNU

--- a/src/vma/dev/time_converter.cpp
+++ b/src/vma/dev/time_converter.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001-2020 Mellanox Technologies, Ltd. All rights reserved.
+ * Copyright (c) 2001-2021 Mellanox Technologies, Ltd. All rights reserved.
  *
  * This software is available to you under a choice of one of two
  * licenses.  You may choose to be licensed under the terms of the GNU

--- a/src/vma/dev/time_converter.h
+++ b/src/vma/dev/time_converter.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001-2020 Mellanox Technologies, Ltd. All rights reserved.
+ * Copyright (c) 2001-2021 Mellanox Technologies, Ltd. All rights reserved.
  *
  * This software is available to you under a choice of one of two
  * licenses.  You may choose to be licensed under the terms of the GNU

--- a/src/vma/dev/time_converter_ib_ctx.cpp
+++ b/src/vma/dev/time_converter_ib_ctx.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001-2020 Mellanox Technologies, Ltd. All rights reserved.
+ * Copyright (c) 2001-2021 Mellanox Technologies, Ltd. All rights reserved.
  *
  * This software is available to you under a choice of one of two
  * licenses.  You may choose to be licensed under the terms of the GNU

--- a/src/vma/dev/time_converter_ib_ctx.h
+++ b/src/vma/dev/time_converter_ib_ctx.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001-2020 Mellanox Technologies, Ltd. All rights reserved.
+ * Copyright (c) 2001-2021 Mellanox Technologies, Ltd. All rights reserved.
  *
  * This software is available to you under a choice of one of two
  * licenses.  You may choose to be licensed under the terms of the GNU

--- a/src/vma/dev/time_converter_ptp.cpp
+++ b/src/vma/dev/time_converter_ptp.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001-2020 Mellanox Technologies, Ltd. All rights reserved.
+ * Copyright (c) 2001-2021 Mellanox Technologies, Ltd. All rights reserved.
  *
  * This software is available to you under a choice of one of two
  * licenses.  You may choose to be licensed under the terms of the GNU

--- a/src/vma/dev/time_converter_ptp.h
+++ b/src/vma/dev/time_converter_ptp.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001-2020 Mellanox Technologies, Ltd. All rights reserved.
+ * Copyright (c) 2001-2021 Mellanox Technologies, Ltd. All rights reserved.
  *
  * This software is available to you under a choice of one of two
  * licenses.  You may choose to be licensed under the terms of the GNU

--- a/src/vma/dev/wqe_send_handler.cpp
+++ b/src/vma/dev/wqe_send_handler.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001-2020 Mellanox Technologies, Ltd. All rights reserved.
+ * Copyright (c) 2001-2021 Mellanox Technologies, Ltd. All rights reserved.
  *
  * This software is available to you under a choice of one of two
  * licenses.  You may choose to be licensed under the terms of the GNU

--- a/src/vma/dev/wqe_send_handler.h
+++ b/src/vma/dev/wqe_send_handler.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001-2020 Mellanox Technologies, Ltd. All rights reserved.
+ * Copyright (c) 2001-2021 Mellanox Technologies, Ltd. All rights reserved.
  *
  * This software is available to you under a choice of one of two
  * licenses.  You may choose to be licensed under the terms of the GNU

--- a/src/vma/dev/wqe_send_ib_handler.cpp
+++ b/src/vma/dev/wqe_send_ib_handler.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001-2020 Mellanox Technologies, Ltd. All rights reserved.
+ * Copyright (c) 2001-2021 Mellanox Technologies, Ltd. All rights reserved.
  *
  * This software is available to you under a choice of one of two
  * licenses.  You may choose to be licensed under the terms of the GNU

--- a/src/vma/dev/wqe_send_ib_handler.h
+++ b/src/vma/dev/wqe_send_ib_handler.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001-2020 Mellanox Technologies, Ltd. All rights reserved.
+ * Copyright (c) 2001-2021 Mellanox Technologies, Ltd. All rights reserved.
  *
  * This software is available to you under a choice of one of two
  * licenses.  You may choose to be licensed under the terms of the GNU

--- a/src/vma/event/command.h
+++ b/src/vma/event/command.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001-2020 Mellanox Technologies, Ltd. All rights reserved.
+ * Copyright (c) 2001-2021 Mellanox Technologies, Ltd. All rights reserved.
  *
  * This software is available to you under a choice of one of two
  * licenses.  You may choose to be licensed under the terms of the GNU

--- a/src/vma/event/delta_timer.cpp
+++ b/src/vma/event/delta_timer.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001-2020 Mellanox Technologies, Ltd. All rights reserved.
+ * Copyright (c) 2001-2021 Mellanox Technologies, Ltd. All rights reserved.
  *
  * This software is available to you under a choice of one of two
  * licenses.  You may choose to be licensed under the terms of the GNU

--- a/src/vma/event/delta_timer.h
+++ b/src/vma/event/delta_timer.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001-2020 Mellanox Technologies, Ltd. All rights reserved.
+ * Copyright (c) 2001-2021 Mellanox Technologies, Ltd. All rights reserved.
  *
  * This software is available to you under a choice of one of two
  * licenses.  You may choose to be licensed under the terms of the GNU

--- a/src/vma/event/event.h
+++ b/src/vma/event/event.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001-2020 Mellanox Technologies, Ltd. All rights reserved.
+ * Copyright (c) 2001-2021 Mellanox Technologies, Ltd. All rights reserved.
  *
  * This software is available to you under a choice of one of two
  * licenses.  You may choose to be licensed under the terms of the GNU

--- a/src/vma/event/event_handler_ibverbs.h
+++ b/src/vma/event/event_handler_ibverbs.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001-2020 Mellanox Technologies, Ltd. All rights reserved.
+ * Copyright (c) 2001-2021 Mellanox Technologies, Ltd. All rights reserved.
  *
  * This software is available to you under a choice of one of two
  * licenses.  You may choose to be licensed under the terms of the GNU

--- a/src/vma/event/event_handler_manager.cpp
+++ b/src/vma/event/event_handler_manager.cpp
@@ -431,6 +431,8 @@ const char* event_handler_manager::reg_action_str(event_action_type_e reg_action
 //get new action of event (register / unregister), and post to the thread's pipe
 void event_handler_manager::post_new_reg_action(reg_action_t& reg_action)
 {
+	bool empty;
+
 	if (!m_b_continue_running)
 		return;
 
@@ -439,9 +441,11 @@ void event_handler_manager::post_new_reg_action(reg_action_t& reg_action)
 	evh_logfunc("add event action %s (%d)", reg_action_str(reg_action.type), reg_action.type);
 
 	m_reg_action_q_lock.lock();
+	empty = m_reg_action_q.empty();
 	m_reg_action_q.push_back(reg_action);
 	m_reg_action_q_lock.unlock();
-	do_wakeup();
+	if (empty)
+		do_wakeup();
 }
 
 void event_handler_manager::priv_register_timer_handler(timer_reg_info_t& info)

--- a/src/vma/event/event_handler_manager.cpp
+++ b/src/vma/event/event_handler_manager.cpp
@@ -431,8 +431,6 @@ const char* event_handler_manager::reg_action_str(event_action_type_e reg_action
 //get new action of event (register / unregister), and post to the thread's pipe
 void event_handler_manager::post_new_reg_action(reg_action_t& reg_action)
 {
-	bool empty;
-
 	if (!m_b_continue_running)
 		return;
 
@@ -441,11 +439,11 @@ void event_handler_manager::post_new_reg_action(reg_action_t& reg_action)
 	evh_logfunc("add event action %s (%d)", reg_action_str(reg_action.type), reg_action.type);
 
 	m_reg_action_q_lock.lock();
-	empty = m_reg_action_q.empty();
+	if (m_reg_action_q.empty()) {
+		do_wakeup();
+	}
 	m_reg_action_q.push_back(reg_action);
 	m_reg_action_q_lock.unlock();
-	if (empty)
-		do_wakeup();
 }
 
 void event_handler_manager::priv_register_timer_handler(timer_reg_info_t& info)

--- a/src/vma/event/event_handler_manager.cpp
+++ b/src/vma/event/event_handler_manager.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001-2020 Mellanox Technologies, Ltd. All rights reserved.
+ * Copyright (c) 2001-2021 Mellanox Technologies, Ltd. All rights reserved.
  *
  * This software is available to you under a choice of one of two
  * licenses.  You may choose to be licensed under the terms of the GNU

--- a/src/vma/event/event_handler_manager.h
+++ b/src/vma/event/event_handler_manager.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001-2020 Mellanox Technologies, Ltd. All rights reserved.
+ * Copyright (c) 2001-2021 Mellanox Technologies, Ltd. All rights reserved.
  *
  * This software is available to you under a choice of one of two
  * licenses.  You may choose to be licensed under the terms of the GNU

--- a/src/vma/event/event_handler_rdma_cm.h
+++ b/src/vma/event/event_handler_rdma_cm.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001-2020 Mellanox Technologies, Ltd. All rights reserved.
+ * Copyright (c) 2001-2021 Mellanox Technologies, Ltd. All rights reserved.
  *
  * This software is available to you under a choice of one of two
  * licenses.  You may choose to be licensed under the terms of the GNU

--- a/src/vma/event/netlink_event.cpp
+++ b/src/vma/event/netlink_event.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001-2020 Mellanox Technologies, Ltd. All rights reserved.
+ * Copyright (c) 2001-2021 Mellanox Technologies, Ltd. All rights reserved.
  *
  * This software is available to you under a choice of one of two
  * licenses.  You may choose to be licensed under the terms of the GNU

--- a/src/vma/event/netlink_event.h
+++ b/src/vma/event/netlink_event.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001-2020 Mellanox Technologies, Ltd. All rights reserved.
+ * Copyright (c) 2001-2021 Mellanox Technologies, Ltd. All rights reserved.
  *
  * This software is available to you under a choice of one of two
  * licenses.  You may choose to be licensed under the terms of the GNU

--- a/src/vma/event/timer_handler.h
+++ b/src/vma/event/timer_handler.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001-2020 Mellanox Technologies, Ltd. All rights reserved.
+ * Copyright (c) 2001-2021 Mellanox Technologies, Ltd. All rights reserved.
  *
  * This software is available to you under a choice of one of two
  * licenses.  You may choose to be licensed under the terms of the GNU

--- a/src/vma/event/timers_group.h
+++ b/src/vma/event/timers_group.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001-2020 Mellanox Technologies, Ltd. All rights reserved.
+ * Copyright (c) 2001-2021 Mellanox Technologies, Ltd. All rights reserved.
  *
  * This software is available to you under a choice of one of two
  * licenses.  You may choose to be licensed under the terms of the GNU

--- a/src/vma/event/vlogger_timer_handler.cpp
+++ b/src/vma/event/vlogger_timer_handler.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001-2020 Mellanox Technologies, Ltd. All rights reserved.
+ * Copyright (c) 2001-2021 Mellanox Technologies, Ltd. All rights reserved.
  *
  * This software is available to you under a choice of one of two
  * licenses.  You may choose to be licensed under the terms of the GNU

--- a/src/vma/event/vlogger_timer_handler.h
+++ b/src/vma/event/vlogger_timer_handler.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001-2020 Mellanox Technologies, Ltd. All rights reserved.
+ * Copyright (c) 2001-2021 Mellanox Technologies, Ltd. All rights reserved.
  *
  * This software is available to you under a choice of one of two
  * licenses.  You may choose to be licensed under the terms of the GNU

--- a/src/vma/ib/base/verbs_extra.cpp
+++ b/src/vma/ib/base/verbs_extra.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001-2020 Mellanox Technologies, Ltd. All rights reserved.
+ * Copyright (c) 2001-2021 Mellanox Technologies, Ltd. All rights reserved.
  *
  * This software is available to you under a choice of one of two
  * licenses.  You may choose to be licensed under the terms of the GNU

--- a/src/vma/ib/base/verbs_extra.h
+++ b/src/vma/ib/base/verbs_extra.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001-2020 Mellanox Technologies, Ltd. All rights reserved.
+ * Copyright (c) 2001-2021 Mellanox Technologies, Ltd. All rights reserved.
  *
  * This software is available to you under a choice of one of two
  * licenses.  You may choose to be licensed under the terms of the GNU

--- a/src/vma/ib/mlx5/ib_mlx5.cpp
+++ b/src/vma/ib/mlx5/ib_mlx5.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001-2020 Mellanox Technologies, Ltd. All rights reserved.
+ * Copyright (c) 2001-2021 Mellanox Technologies, Ltd. All rights reserved.
  *
  * This software is available to you under a choice of one of two
  * licenses.  You may choose to be licensed under the terms of the GNU

--- a/src/vma/ib/mlx5/ib_mlx5.h
+++ b/src/vma/ib/mlx5/ib_mlx5.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001-2020 Mellanox Technologies, Ltd. All rights reserved.
+ * Copyright (c) 2001-2021 Mellanox Technologies, Ltd. All rights reserved.
  *
  * This software is available to you under a choice of one of two
  * licenses.  You may choose to be licensed under the terms of the GNU

--- a/src/vma/ib/mlx5/ib_mlx5_dv.cpp
+++ b/src/vma/ib/mlx5/ib_mlx5_dv.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001-2020 Mellanox Technologies, Ltd. All rights reserved.
+ * Copyright (c) 2001-2021 Mellanox Technologies, Ltd. All rights reserved.
  *
  * This software is available to you under a choice of one of two
  * licenses.  You may choose to be licensed under the terms of the GNU

--- a/src/vma/ib/mlx5/ib_mlx5_dv.h
+++ b/src/vma/ib/mlx5/ib_mlx5_dv.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001-2020 Mellanox Technologies, Ltd. All rights reserved.
+ * Copyright (c) 2001-2021 Mellanox Technologies, Ltd. All rights reserved.
  *
  * This software is available to you under a choice of one of two
  * licenses.  You may choose to be licensed under the terms of the GNU

--- a/src/vma/ib/mlx5/ib_mlx5_hw.cpp
+++ b/src/vma/ib/mlx5/ib_mlx5_hw.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001-2020 Mellanox Technologies, Ltd. All rights reserved.
+ * Copyright (c) 2001-2021 Mellanox Technologies, Ltd. All rights reserved.
  *
  * This software is available to you under a choice of one of two
  * licenses.  You may choose to be licensed under the terms of the GNU

--- a/src/vma/ib/mlx5/ib_mlx5_hw.h
+++ b/src/vma/ib/mlx5/ib_mlx5_hw.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001-2020 Mellanox Technologies, Ltd. All rights reserved.
+ * Copyright (c) 2001-2021 Mellanox Technologies, Ltd. All rights reserved.
  *
  * This software is available to you under a choice of one of two
  * licenses.  You may choose to be licensed under the terms of the GNU

--- a/src/vma/infra/DemoCollMgr.cpp
+++ b/src/vma/infra/DemoCollMgr.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001-2020 Mellanox Technologies, Ltd. All rights reserved.
+ * Copyright (c) 2001-2021 Mellanox Technologies, Ltd. All rights reserved.
  *
  * This software is available to you under a choice of one of two
  * licenses.  You may choose to be licensed under the terms of the GNU

--- a/src/vma/infra/DemoCollMgr.h
+++ b/src/vma/infra/DemoCollMgr.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001-2020 Mellanox Technologies, Ltd. All rights reserved.
+ * Copyright (c) 2001-2021 Mellanox Technologies, Ltd. All rights reserved.
  *
  * This software is available to you under a choice of one of two
  * licenses.  You may choose to be licensed under the terms of the GNU

--- a/src/vma/infra/DemoObserver.cpp
+++ b/src/vma/infra/DemoObserver.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001-2020 Mellanox Technologies, Ltd. All rights reserved.
+ * Copyright (c) 2001-2021 Mellanox Technologies, Ltd. All rights reserved.
  *
  * This software is available to you under a choice of one of two
  * licenses.  You may choose to be licensed under the terms of the GNU

--- a/src/vma/infra/DemoObserver.h
+++ b/src/vma/infra/DemoObserver.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001-2020 Mellanox Technologies, Ltd. All rights reserved.
+ * Copyright (c) 2001-2021 Mellanox Technologies, Ltd. All rights reserved.
  *
  * This software is available to you under a choice of one of two
  * licenses.  You may choose to be licensed under the terms of the GNU

--- a/src/vma/infra/DemoSubject.cpp
+++ b/src/vma/infra/DemoSubject.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001-2020 Mellanox Technologies, Ltd. All rights reserved.
+ * Copyright (c) 2001-2021 Mellanox Technologies, Ltd. All rights reserved.
  *
  * This software is available to you under a choice of one of two
  * licenses.  You may choose to be licensed under the terms of the GNU

--- a/src/vma/infra/DemoSubject.h
+++ b/src/vma/infra/DemoSubject.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001-2020 Mellanox Technologies, Ltd. All rights reserved.
+ * Copyright (c) 2001-2021 Mellanox Technologies, Ltd. All rights reserved.
  *
  * This software is available to you under a choice of one of two
  * licenses.  You may choose to be licensed under the terms of the GNU

--- a/src/vma/infra/cache_subject_observer.h
+++ b/src/vma/infra/cache_subject_observer.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001-2020 Mellanox Technologies, Ltd. All rights reserved.
+ * Copyright (c) 2001-2021 Mellanox Technologies, Ltd. All rights reserved.
  *
  * This software is available to you under a choice of one of two
  * licenses.  You may choose to be licensed under the terms of the GNU

--- a/src/vma/infra/main.cpp
+++ b/src/vma/infra/main.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001-2020 Mellanox Technologies, Ltd. All rights reserved.
+ * Copyright (c) 2001-2021 Mellanox Technologies, Ltd. All rights reserved.
  *
  * This software is available to you under a choice of one of two
  * licenses.  You may choose to be licensed under the terms of the GNU

--- a/src/vma/infra/sender.h
+++ b/src/vma/infra/sender.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001-2020 Mellanox Technologies, Ltd. All rights reserved.
+ * Copyright (c) 2001-2021 Mellanox Technologies, Ltd. All rights reserved.
  *
  * This software is available to you under a choice of one of two
  * licenses.  You may choose to be licensed under the terms of the GNU

--- a/src/vma/infra/sender_info_dst.cpp
+++ b/src/vma/infra/sender_info_dst.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001-2020 Mellanox Technologies, Ltd. All rights reserved.
+ * Copyright (c) 2001-2021 Mellanox Technologies, Ltd. All rights reserved.
  *
  * This software is available to you under a choice of one of two
  * licenses.  You may choose to be licensed under the terms of the GNU

--- a/src/vma/infra/sender_info_dst.h
+++ b/src/vma/infra/sender_info_dst.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001-2020 Mellanox Technologies, Ltd. All rights reserved.
+ * Copyright (c) 2001-2021 Mellanox Technologies, Ltd. All rights reserved.
  *
  * This software is available to you under a choice of one of two
  * licenses.  You may choose to be licensed under the terms of the GNU

--- a/src/vma/infra/subject_observer.cpp
+++ b/src/vma/infra/subject_observer.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001-2020 Mellanox Technologies, Ltd. All rights reserved.
+ * Copyright (c) 2001-2021 Mellanox Technologies, Ltd. All rights reserved.
  *
  * This software is available to you under a choice of one of two
  * licenses.  You may choose to be licensed under the terms of the GNU

--- a/src/vma/infra/subject_observer.h
+++ b/src/vma/infra/subject_observer.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001-2020 Mellanox Technologies, Ltd. All rights reserved.
+ * Copyright (c) 2001-2021 Mellanox Technologies, Ltd. All rights reserved.
  *
  * This software is available to you under a choice of one of two
  * licenses.  You may choose to be licensed under the terms of the GNU

--- a/src/vma/iomux/epfd_info.cpp
+++ b/src/vma/iomux/epfd_info.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001-2020 Mellanox Technologies, Ltd. All rights reserved.
+ * Copyright (c) 2001-2021 Mellanox Technologies, Ltd. All rights reserved.
  *
  * This software is available to you under a choice of one of two
  * licenses.  You may choose to be licensed under the terms of the GNU

--- a/src/vma/iomux/epfd_info.h
+++ b/src/vma/iomux/epfd_info.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001-2020 Mellanox Technologies, Ltd. All rights reserved.
+ * Copyright (c) 2001-2021 Mellanox Technologies, Ltd. All rights reserved.
  *
  * This software is available to you under a choice of one of two
  * licenses.  You may choose to be licensed under the terms of the GNU

--- a/src/vma/iomux/epoll_wait_call.cpp
+++ b/src/vma/iomux/epoll_wait_call.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001-2020 Mellanox Technologies, Ltd. All rights reserved.
+ * Copyright (c) 2001-2021 Mellanox Technologies, Ltd. All rights reserved.
  *
  * This software is available to you under a choice of one of two
  * licenses.  You may choose to be licensed under the terms of the GNU

--- a/src/vma/iomux/epoll_wait_call.h
+++ b/src/vma/iomux/epoll_wait_call.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001-2020 Mellanox Technologies, Ltd. All rights reserved.
+ * Copyright (c) 2001-2021 Mellanox Technologies, Ltd. All rights reserved.
  *
  * This software is available to you under a choice of one of two
  * licenses.  You may choose to be licensed under the terms of the GNU

--- a/src/vma/iomux/io_mux_call.cpp
+++ b/src/vma/iomux/io_mux_call.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001-2020 Mellanox Technologies, Ltd. All rights reserved.
+ * Copyright (c) 2001-2021 Mellanox Technologies, Ltd. All rights reserved.
  *
  * This software is available to you under a choice of one of two
  * licenses.  You may choose to be licensed under the terms of the GNU

--- a/src/vma/iomux/io_mux_call.h
+++ b/src/vma/iomux/io_mux_call.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001-2020 Mellanox Technologies, Ltd. All rights reserved.
+ * Copyright (c) 2001-2021 Mellanox Technologies, Ltd. All rights reserved.
  *
  * This software is available to you under a choice of one of two
  * licenses.  You may choose to be licensed under the terms of the GNU

--- a/src/vma/iomux/poll_call.cpp
+++ b/src/vma/iomux/poll_call.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001-2020 Mellanox Technologies, Ltd. All rights reserved.
+ * Copyright (c) 2001-2021 Mellanox Technologies, Ltd. All rights reserved.
  *
  * This software is available to you under a choice of one of two
  * licenses.  You may choose to be licensed under the terms of the GNU

--- a/src/vma/iomux/poll_call.h
+++ b/src/vma/iomux/poll_call.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001-2020 Mellanox Technologies, Ltd. All rights reserved.
+ * Copyright (c) 2001-2021 Mellanox Technologies, Ltd. All rights reserved.
  *
  * This software is available to you under a choice of one of two
  * licenses.  You may choose to be licensed under the terms of the GNU

--- a/src/vma/iomux/select_call.cpp
+++ b/src/vma/iomux/select_call.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001-2020 Mellanox Technologies, Ltd. All rights reserved.
+ * Copyright (c) 2001-2021 Mellanox Technologies, Ltd. All rights reserved.
  *
  * This software is available to you under a choice of one of two
  * licenses.  You may choose to be licensed under the terms of the GNU

--- a/src/vma/iomux/select_call.h
+++ b/src/vma/iomux/select_call.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001-2020 Mellanox Technologies, Ltd. All rights reserved.
+ * Copyright (c) 2001-2021 Mellanox Technologies, Ltd. All rights reserved.
  *
  * This software is available to you under a choice of one of two
  * licenses.  You may choose to be licensed under the terms of the GNU

--- a/src/vma/libvma.c
+++ b/src/vma/libvma.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001-2020 Mellanox Technologies, Ltd. All rights reserved.
+ * Copyright (c) 2001-2021 Mellanox Technologies, Ltd. All rights reserved.
  *
  * This software is available to you under a choice of one of two
  * licenses.  You may choose to be licensed under the terms of the GNU

--- a/src/vma/lwip/cc.c
+++ b/src/vma/lwip/cc.c
@@ -49,7 +49,7 @@
  */
 
 /*
- * Copyright (c) 2001-2020 Mellanox Technologies, Ltd. All rights reserved.
+ * Copyright (c) 2001-2021 Mellanox Technologies, Ltd. All rights reserved.
  *
  * This software is available to you under a choice of one of two
  * licenses.  You may choose to be licensed under the terms of the GNU

--- a/src/vma/lwip/cc.h
+++ b/src/vma/lwip/cc.h
@@ -49,7 +49,7 @@
  */
 
 /*
- * Copyright (c) 2001-2020 Mellanox Technologies, Ltd. All rights reserved.
+ * Copyright (c) 2001-2021 Mellanox Technologies, Ltd. All rights reserved.
  *
  * This software is available to you under a choice of one of two
  * licenses.  You may choose to be licensed under the terms of the GNU

--- a/src/vma/lwip/cc_cubic.c
+++ b/src/vma/lwip/cc_cubic.c
@@ -49,7 +49,7 @@
  */
 
 /*
- * Copyright (c) 2001-2020 Mellanox Technologies, Ltd. All rights reserved.
+ * Copyright (c) 2001-2021 Mellanox Technologies, Ltd. All rights reserved.
  *
  * This software is available to you under a choice of one of two
  * licenses.  You may choose to be licensed under the terms of the GNU

--- a/src/vma/lwip/cc_cubic.h
+++ b/src/vma/lwip/cc_cubic.h
@@ -49,7 +49,7 @@
  */
 
 /*
- * Copyright (c) 2001-2020 Mellanox Technologies, Ltd. All rights reserved.
+ * Copyright (c) 2001-2021 Mellanox Technologies, Ltd. All rights reserved.
  *
  * This software is available to you under a choice of one of two
  * licenses.  You may choose to be licensed under the terms of the GNU

--- a/src/vma/lwip/cc_lwip.c
+++ b/src/vma/lwip/cc_lwip.c
@@ -49,7 +49,7 @@
  */
 
 /*
- * Copyright (c) 2001-2020 Mellanox Technologies, Ltd. All rights reserved.
+ * Copyright (c) 2001-2021 Mellanox Technologies, Ltd. All rights reserved.
  *
  * This software is available to you under a choice of one of two
  * licenses.  You may choose to be licensed under the terms of the GNU

--- a/src/vma/lwip/cc_none.c
+++ b/src/vma/lwip/cc_none.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001-2020 Mellanox Technologies, Ltd. All rights reserved.
+ * Copyright (c) 2001-2021 Mellanox Technologies, Ltd. All rights reserved.
  *
  * This software is available to you under a choice of one of two
  * licenses.  You may choose to be licensed under the terms of the GNU

--- a/src/vma/main.cpp
+++ b/src/vma/main.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001-2020 Mellanox Technologies, Ltd. All rights reserved.
+ * Copyright (c) 2001-2021 Mellanox Technologies, Ltd. All rights reserved.
  *
  * This software is available to you under a choice of one of two
  * licenses.  You may choose to be licensed under the terms of the GNU

--- a/src/vma/main.h
+++ b/src/vma/main.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001-2020 Mellanox Technologies, Ltd. All rights reserved.
+ * Copyright (c) 2001-2021 Mellanox Technologies, Ltd. All rights reserved.
  *
  * This software is available to you under a choice of one of two
  * licenses.  You may choose to be licensed under the terms of the GNU

--- a/src/vma/netlink/link_info.cpp
+++ b/src/vma/netlink/link_info.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001-2020 Mellanox Technologies, Ltd. All rights reserved.
+ * Copyright (c) 2001-2021 Mellanox Technologies, Ltd. All rights reserved.
  *
  * This software is available to you under a choice of one of two
  * licenses.  You may choose to be licensed under the terms of the GNU

--- a/src/vma/netlink/link_info.h
+++ b/src/vma/netlink/link_info.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001-2020 Mellanox Technologies, Ltd. All rights reserved.
+ * Copyright (c) 2001-2021 Mellanox Technologies, Ltd. All rights reserved.
  *
  * This software is available to you under a choice of one of two
  * licenses.  You may choose to be licensed under the terms of the GNU

--- a/src/vma/netlink/neigh_info.cpp
+++ b/src/vma/netlink/neigh_info.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001-2020 Mellanox Technologies, Ltd. All rights reserved.
+ * Copyright (c) 2001-2021 Mellanox Technologies, Ltd. All rights reserved.
  *
  * This software is available to you under a choice of one of two
  * licenses.  You may choose to be licensed under the terms of the GNU

--- a/src/vma/netlink/neigh_info.h
+++ b/src/vma/netlink/neigh_info.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001-2020 Mellanox Technologies, Ltd. All rights reserved.
+ * Copyright (c) 2001-2021 Mellanox Technologies, Ltd. All rights reserved.
  *
  * This software is available to you under a choice of one of two
  * licenses.  You may choose to be licensed under the terms of the GNU

--- a/src/vma/netlink/netlink_compatibility.cpp
+++ b/src/vma/netlink/netlink_compatibility.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001-2020 Mellanox Technologies, Ltd. All rights reserved.
+ * Copyright (c) 2001-2021 Mellanox Technologies, Ltd. All rights reserved.
  *
  * This software is available to you under a choice of one of two
  * licenses.  You may choose to be licensed under the terms of the GNU

--- a/src/vma/netlink/netlink_compatibility.h
+++ b/src/vma/netlink/netlink_compatibility.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001-2020 Mellanox Technologies, Ltd. All rights reserved.
+ * Copyright (c) 2001-2021 Mellanox Technologies, Ltd. All rights reserved.
  *
  * This software is available to you under a choice of one of two
  * licenses.  You may choose to be licensed under the terms of the GNU

--- a/src/vma/netlink/netlink_wrapper.cpp
+++ b/src/vma/netlink/netlink_wrapper.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001-2020 Mellanox Technologies, Ltd. All rights reserved.
+ * Copyright (c) 2001-2021 Mellanox Technologies, Ltd. All rights reserved.
  *
  * This software is available to you under a choice of one of two
  * licenses.  You may choose to be licensed under the terms of the GNU

--- a/src/vma/netlink/netlink_wrapper.h
+++ b/src/vma/netlink/netlink_wrapper.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001-2020 Mellanox Technologies, Ltd. All rights reserved.
+ * Copyright (c) 2001-2021 Mellanox Technologies, Ltd. All rights reserved.
  *
  * This software is available to you under a choice of one of two
  * licenses.  You may choose to be licensed under the terms of the GNU

--- a/src/vma/netlink/route_info.cpp
+++ b/src/vma/netlink/route_info.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001-2020 Mellanox Technologies, Ltd. All rights reserved.
+ * Copyright (c) 2001-2021 Mellanox Technologies, Ltd. All rights reserved.
  *
  * This software is available to you under a choice of one of two
  * licenses.  You may choose to be licensed under the terms of the GNU

--- a/src/vma/netlink/route_info.h
+++ b/src/vma/netlink/route_info.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001-2020 Mellanox Technologies, Ltd. All rights reserved.
+ * Copyright (c) 2001-2021 Mellanox Technologies, Ltd. All rights reserved.
  *
  * This software is available to you under a choice of one of two
  * licenses.  You may choose to be licensed under the terms of the GNU

--- a/src/vma/netlink/test_main.cpp
+++ b/src/vma/netlink/test_main.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001-2020 Mellanox Technologies, Ltd. All rights reserved.
+ * Copyright (c) 2001-2021 Mellanox Technologies, Ltd. All rights reserved.
  *
  * This software is available to you under a choice of one of two
  * licenses.  You may choose to be licensed under the terms of the GNU

--- a/src/vma/proto/L2_address.cpp
+++ b/src/vma/proto/L2_address.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001-2020 Mellanox Technologies, Ltd. All rights reserved.
+ * Copyright (c) 2001-2021 Mellanox Technologies, Ltd. All rights reserved.
  *
  * This software is available to you under a choice of one of two
  * licenses.  You may choose to be licensed under the terms of the GNU

--- a/src/vma/proto/L2_address.h
+++ b/src/vma/proto/L2_address.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001-2020 Mellanox Technologies, Ltd. All rights reserved.
+ * Copyright (c) 2001-2021 Mellanox Technologies, Ltd. All rights reserved.
  *
  * This software is available to you under a choice of one of two
  * licenses.  You may choose to be licensed under the terms of the GNU

--- a/src/vma/proto/arp.cpp
+++ b/src/vma/proto/arp.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001-2020 Mellanox Technologies, Ltd. All rights reserved.
+ * Copyright (c) 2001-2021 Mellanox Technologies, Ltd. All rights reserved.
  *
  * This software is available to you under a choice of one of two
  * licenses.  You may choose to be licensed under the terms of the GNU

--- a/src/vma/proto/arp.h
+++ b/src/vma/proto/arp.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001-2020 Mellanox Technologies, Ltd. All rights reserved.
+ * Copyright (c) 2001-2021 Mellanox Technologies, Ltd. All rights reserved.
  *
  * This software is available to you under a choice of one of two
  * licenses.  You may choose to be licensed under the terms of the GNU

--- a/src/vma/proto/dst_entry.cpp
+++ b/src/vma/proto/dst_entry.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001-2020 Mellanox Technologies, Ltd. All rights reserved.
+ * Copyright (c) 2001-2021 Mellanox Technologies, Ltd. All rights reserved.
  *
  * This software is available to you under a choice of one of two
  * licenses.  You may choose to be licensed under the terms of the GNU

--- a/src/vma/proto/dst_entry.h
+++ b/src/vma/proto/dst_entry.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001-2020 Mellanox Technologies, Ltd. All rights reserved.
+ * Copyright (c) 2001-2021 Mellanox Technologies, Ltd. All rights reserved.
  *
  * This software is available to you under a choice of one of two
  * licenses.  You may choose to be licensed under the terms of the GNU

--- a/src/vma/proto/dst_entry_tcp.cpp
+++ b/src/vma/proto/dst_entry_tcp.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001-2020 Mellanox Technologies, Ltd. All rights reserved.
+ * Copyright (c) 2001-2021 Mellanox Technologies, Ltd. All rights reserved.
  *
  * This software is available to you under a choice of one of two
  * licenses.  You may choose to be licensed under the terms of the GNU

--- a/src/vma/proto/dst_entry_tcp.h
+++ b/src/vma/proto/dst_entry_tcp.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001-2020 Mellanox Technologies, Ltd. All rights reserved.
+ * Copyright (c) 2001-2021 Mellanox Technologies, Ltd. All rights reserved.
  *
  * This software is available to you under a choice of one of two
  * licenses.  You may choose to be licensed under the terms of the GNU

--- a/src/vma/proto/dst_entry_udp.cpp
+++ b/src/vma/proto/dst_entry_udp.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001-2020 Mellanox Technologies, Ltd. All rights reserved.
+ * Copyright (c) 2001-2021 Mellanox Technologies, Ltd. All rights reserved.
  *
  * This software is available to you under a choice of one of two
  * licenses.  You may choose to be licensed under the terms of the GNU

--- a/src/vma/proto/dst_entry_udp.h
+++ b/src/vma/proto/dst_entry_udp.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001-2020 Mellanox Technologies, Ltd. All rights reserved.
+ * Copyright (c) 2001-2021 Mellanox Technologies, Ltd. All rights reserved.
  *
  * This software is available to you under a choice of one of two
  * licenses.  You may choose to be licensed under the terms of the GNU

--- a/src/vma/proto/dst_entry_udp_mc.cpp
+++ b/src/vma/proto/dst_entry_udp_mc.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001-2020 Mellanox Technologies, Ltd. All rights reserved.
+ * Copyright (c) 2001-2021 Mellanox Technologies, Ltd. All rights reserved.
  *
  * This software is available to you under a choice of one of two
  * licenses.  You may choose to be licensed under the terms of the GNU

--- a/src/vma/proto/dst_entry_udp_mc.h
+++ b/src/vma/proto/dst_entry_udp_mc.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001-2020 Mellanox Technologies, Ltd. All rights reserved.
+ * Copyright (c) 2001-2021 Mellanox Technologies, Ltd. All rights reserved.
  *
  * This software is available to you under a choice of one of two
  * licenses.  You may choose to be licensed under the terms of the GNU

--- a/src/vma/proto/flow_tuple.cpp
+++ b/src/vma/proto/flow_tuple.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001-2020 Mellanox Technologies, Ltd. All rights reserved.
+ * Copyright (c) 2001-2021 Mellanox Technologies, Ltd. All rights reserved.
  *
  * This software is available to you under a choice of one of two
  * licenses.  You may choose to be licensed under the terms of the GNU

--- a/src/vma/proto/flow_tuple.h
+++ b/src/vma/proto/flow_tuple.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001-2020 Mellanox Technologies, Ltd. All rights reserved.
+ * Copyright (c) 2001-2021 Mellanox Technologies, Ltd. All rights reserved.
  *
  * This software is available to you under a choice of one of two
  * licenses.  You may choose to be licensed under the terms of the GNU

--- a/src/vma/proto/header.cpp
+++ b/src/vma/proto/header.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001-2020 Mellanox Technologies, Ltd. All rights reserved.
+ * Copyright (c) 2001-2021 Mellanox Technologies, Ltd. All rights reserved.
  *
  * This software is available to you under a choice of one of two
  * licenses.  You may choose to be licensed under the terms of the GNU

--- a/src/vma/proto/header.h
+++ b/src/vma/proto/header.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001-2020 Mellanox Technologies, Ltd. All rights reserved.
+ * Copyright (c) 2001-2021 Mellanox Technologies, Ltd. All rights reserved.
  *
  * This software is available to you under a choice of one of two
  * licenses.  You may choose to be licensed under the terms of the GNU

--- a/src/vma/proto/igmp_handler.cpp
+++ b/src/vma/proto/igmp_handler.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001-2020 Mellanox Technologies, Ltd. All rights reserved.
+ * Copyright (c) 2001-2021 Mellanox Technologies, Ltd. All rights reserved.
  *
  * This software is available to you under a choice of one of two
  * licenses.  You may choose to be licensed under the terms of the GNU

--- a/src/vma/proto/igmp_handler.h
+++ b/src/vma/proto/igmp_handler.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001-2020 Mellanox Technologies, Ltd. All rights reserved.
+ * Copyright (c) 2001-2021 Mellanox Technologies, Ltd. All rights reserved.
  *
  * This software is available to you under a choice of one of two
  * licenses.  You may choose to be licensed under the terms of the GNU

--- a/src/vma/proto/igmp_mgr.cpp
+++ b/src/vma/proto/igmp_mgr.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001-2020 Mellanox Technologies, Ltd. All rights reserved.
+ * Copyright (c) 2001-2021 Mellanox Technologies, Ltd. All rights reserved.
  *
  * This software is available to you under a choice of one of two
  * licenses.  You may choose to be licensed under the terms of the GNU

--- a/src/vma/proto/igmp_mgr.h
+++ b/src/vma/proto/igmp_mgr.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001-2020 Mellanox Technologies, Ltd. All rights reserved.
+ * Copyright (c) 2001-2021 Mellanox Technologies, Ltd. All rights reserved.
  *
  * This software is available to you under a choice of one of two
  * licenses.  You may choose to be licensed under the terms of the GNU

--- a/src/vma/proto/ip_address.h
+++ b/src/vma/proto/ip_address.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001-2020 Mellanox Technologies, Ltd. All rights reserved.
+ * Copyright (c) 2001-2021 Mellanox Technologies, Ltd. All rights reserved.
  *
  * This software is available to you under a choice of one of two
  * licenses.  You may choose to be licensed under the terms of the GNU

--- a/src/vma/proto/ip_frag.cpp
+++ b/src/vma/proto/ip_frag.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001-2020 Mellanox Technologies, Ltd. All rights reserved.
+ * Copyright (c) 2001-2021 Mellanox Technologies, Ltd. All rights reserved.
  *
  * This software is available to you under a choice of one of two
  * licenses.  You may choose to be licensed under the terms of the GNU

--- a/src/vma/proto/ip_frag.h
+++ b/src/vma/proto/ip_frag.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001-2020 Mellanox Technologies, Ltd. All rights reserved.
+ * Copyright (c) 2001-2021 Mellanox Technologies, Ltd. All rights reserved.
  *
  * This software is available to you under a choice of one of two
  * licenses.  You may choose to be licensed under the terms of the GNU

--- a/src/vma/proto/mem_buf_desc.h
+++ b/src/vma/proto/mem_buf_desc.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001-2020 Mellanox Technologies, Ltd. All rights reserved.
+ * Copyright (c) 2001-2021 Mellanox Technologies, Ltd. All rights reserved.
  *
  * This software is available to you under a choice of one of two
  * licenses.  You may choose to be licensed under the terms of the GNU

--- a/src/vma/proto/neighbour.cpp
+++ b/src/vma/proto/neighbour.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001-2020 Mellanox Technologies, Ltd. All rights reserved.
+ * Copyright (c) 2001-2021 Mellanox Technologies, Ltd. All rights reserved.
  *
  * This software is available to you under a choice of one of two
  * licenses.  You may choose to be licensed under the terms of the GNU

--- a/src/vma/proto/neighbour.h
+++ b/src/vma/proto/neighbour.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001-2020 Mellanox Technologies, Ltd. All rights reserved.
+ * Copyright (c) 2001-2021 Mellanox Technologies, Ltd. All rights reserved.
  *
  * This software is available to you under a choice of one of two
  * licenses.  You may choose to be licensed under the terms of the GNU

--- a/src/vma/proto/neighbour_observer.h
+++ b/src/vma/proto/neighbour_observer.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001-2020 Mellanox Technologies, Ltd. All rights reserved.
+ * Copyright (c) 2001-2021 Mellanox Technologies, Ltd. All rights reserved.
  *
  * This software is available to you under a choice of one of two
  * licenses.  You may choose to be licensed under the terms of the GNU

--- a/src/vma/proto/neighbour_table_mgr.cpp
+++ b/src/vma/proto/neighbour_table_mgr.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001-2020 Mellanox Technologies, Ltd. All rights reserved.
+ * Copyright (c) 2001-2021 Mellanox Technologies, Ltd. All rights reserved.
  *
  * This software is available to you under a choice of one of two
  * licenses.  You may choose to be licensed under the terms of the GNU

--- a/src/vma/proto/neighbour_table_mgr.h
+++ b/src/vma/proto/neighbour_table_mgr.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001-2020 Mellanox Technologies, Ltd. All rights reserved.
+ * Copyright (c) 2001-2021 Mellanox Technologies, Ltd. All rights reserved.
  *
  * This software is available to you under a choice of one of two
  * licenses.  You may choose to be licensed under the terms of the GNU

--- a/src/vma/proto/netlink_socket_mgr.h
+++ b/src/vma/proto/netlink_socket_mgr.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001-2020 Mellanox Technologies, Ltd. All rights reserved.
+ * Copyright (c) 2001-2021 Mellanox Technologies, Ltd. All rights reserved.
  *
  * This software is available to you under a choice of one of two
  * licenses.  You may choose to be licensed under the terms of the GNU

--- a/src/vma/proto/peer_key.h
+++ b/src/vma/proto/peer_key.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001-2020 Mellanox Technologies, Ltd. All rights reserved.
+ * Copyright (c) 2001-2021 Mellanox Technologies, Ltd. All rights reserved.
  *
  * This software is available to you under a choice of one of two
  * licenses.  You may choose to be licensed under the terms of the GNU

--- a/src/vma/proto/route_entry.cpp
+++ b/src/vma/proto/route_entry.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001-2020 Mellanox Technologies, Ltd. All rights reserved.
+ * Copyright (c) 2001-2021 Mellanox Technologies, Ltd. All rights reserved.
  *
  * This software is available to you under a choice of one of two
  * licenses.  You may choose to be licensed under the terms of the GNU

--- a/src/vma/proto/route_entry.h
+++ b/src/vma/proto/route_entry.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001-2020 Mellanox Technologies, Ltd. All rights reserved.
+ * Copyright (c) 2001-2021 Mellanox Technologies, Ltd. All rights reserved.
  *
  * This software is available to you under a choice of one of two
  * licenses.  You may choose to be licensed under the terms of the GNU

--- a/src/vma/proto/route_rule_table_key.h
+++ b/src/vma/proto/route_rule_table_key.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001-2020 Mellanox Technologies, Ltd. All rights reserved.
+ * Copyright (c) 2001-2021 Mellanox Technologies, Ltd. All rights reserved.
  *
  * This software is available to you under a choice of one of two
  * licenses.  You may choose to be licensed under the terms of the GNU

--- a/src/vma/proto/route_table_mgr.cpp
+++ b/src/vma/proto/route_table_mgr.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001-2020 Mellanox Technologies, Ltd. All rights reserved.
+ * Copyright (c) 2001-2021 Mellanox Technologies, Ltd. All rights reserved.
  *
  * This software is available to you under a choice of one of two
  * licenses.  You may choose to be licensed under the terms of the GNU

--- a/src/vma/proto/route_table_mgr.h
+++ b/src/vma/proto/route_table_mgr.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001-2020 Mellanox Technologies, Ltd. All rights reserved.
+ * Copyright (c) 2001-2021 Mellanox Technologies, Ltd. All rights reserved.
  *
  * This software is available to you under a choice of one of two
  * licenses.  You may choose to be licensed under the terms of the GNU

--- a/src/vma/proto/route_val.cpp
+++ b/src/vma/proto/route_val.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001-2020 Mellanox Technologies, Ltd. All rights reserved.
+ * Copyright (c) 2001-2021 Mellanox Technologies, Ltd. All rights reserved.
  *
  * This software is available to you under a choice of one of two
  * licenses.  You may choose to be licensed under the terms of the GNU

--- a/src/vma/proto/route_val.h
+++ b/src/vma/proto/route_val.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001-2020 Mellanox Technologies, Ltd. All rights reserved.
+ * Copyright (c) 2001-2021 Mellanox Technologies, Ltd. All rights reserved.
  *
  * This software is available to you under a choice of one of two
  * licenses.  You may choose to be licensed under the terms of the GNU

--- a/src/vma/proto/rule_entry.cpp
+++ b/src/vma/proto/rule_entry.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001-2020 Mellanox Technologies, Ltd. All rights reserved.
+ * Copyright (c) 2001-2021 Mellanox Technologies, Ltd. All rights reserved.
  *
  * This software is available to you under a choice of one of two
  * licenses.  You may choose to be licensed under the terms of the GNU

--- a/src/vma/proto/rule_entry.h
+++ b/src/vma/proto/rule_entry.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001-2020 Mellanox Technologies, Ltd. All rights reserved.
+ * Copyright (c) 2001-2021 Mellanox Technologies, Ltd. All rights reserved.
  *
  * This software is available to you under a choice of one of two
  * licenses.  You may choose to be licensed under the terms of the GNU

--- a/src/vma/proto/rule_table_mgr.cpp
+++ b/src/vma/proto/rule_table_mgr.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001-2020 Mellanox Technologies, Ltd. All rights reserved.
+ * Copyright (c) 2001-2021 Mellanox Technologies, Ltd. All rights reserved.
  *
  * This software is available to you under a choice of one of two
  * licenses.  You may choose to be licensed under the terms of the GNU

--- a/src/vma/proto/rule_table_mgr.h
+++ b/src/vma/proto/rule_table_mgr.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001-2020 Mellanox Technologies, Ltd. All rights reserved.
+ * Copyright (c) 2001-2021 Mellanox Technologies, Ltd. All rights reserved.
  *
  * This software is available to you under a choice of one of two
  * licenses.  You may choose to be licensed under the terms of the GNU

--- a/src/vma/proto/rule_val.cpp
+++ b/src/vma/proto/rule_val.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001-2020 Mellanox Technologies, Ltd. All rights reserved.
+ * Copyright (c) 2001-2021 Mellanox Technologies, Ltd. All rights reserved.
  *
  * This software is available to you under a choice of one of two
  * licenses.  You may choose to be licensed under the terms of the GNU

--- a/src/vma/proto/rule_val.h
+++ b/src/vma/proto/rule_val.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001-2020 Mellanox Technologies, Ltd. All rights reserved.
+ * Copyright (c) 2001-2021 Mellanox Technologies, Ltd. All rights reserved.
  *
  * This software is available to you under a choice of one of two
  * licenses.  You may choose to be licensed under the terms of the GNU

--- a/src/vma/proto/vma_lwip.cpp
+++ b/src/vma/proto/vma_lwip.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001-2020 Mellanox Technologies, Ltd. All rights reserved.
+ * Copyright (c) 2001-2021 Mellanox Technologies, Ltd. All rights reserved.
  *
  * This software is available to you under a choice of one of two
  * licenses.  You may choose to be licensed under the terms of the GNU

--- a/src/vma/proto/vma_lwip.h
+++ b/src/vma/proto/vma_lwip.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001-2020 Mellanox Technologies, Ltd. All rights reserved.
+ * Copyright (c) 2001-2021 Mellanox Technologies, Ltd. All rights reserved.
  *
  * This software is available to you under a choice of one of two
  * licenses.  You may choose to be licensed under the terms of the GNU

--- a/src/vma/sock/cleanable_obj.h
+++ b/src/vma/sock/cleanable_obj.h
@@ -44,7 +44,14 @@ public:
 
 	virtual ~cleanable_obj(){};
 
-	virtual void clean_obj(){ set_cleaned(); delete this; };
+	/* This function should be used just for objects that
+	 * was allocated via new() (not by new[], nor by placement new, nor a local object on the stack,
+	 * nor a namespace-scope / global, nor a member of another object; but by plain ordinary new)
+	 */
+	virtual void clean_obj(){
+		set_cleaned();
+		delete this;
+	};
 
 	bool is_cleaned(){ return m_b_cleaned; };
 

--- a/src/vma/sock/cleanable_obj.h
+++ b/src/vma/sock/cleanable_obj.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001-2020 Mellanox Technologies, Ltd. All rights reserved.
+ * Copyright (c) 2001-2021 Mellanox Technologies, Ltd. All rights reserved.
  *
  * This software is available to you under a choice of one of two
  * licenses.  You may choose to be licensed under the terms of the GNU

--- a/src/vma/sock/fd_collection.cpp
+++ b/src/vma/sock/fd_collection.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001-2020 Mellanox Technologies, Ltd. All rights reserved.
+ * Copyright (c) 2001-2021 Mellanox Technologies, Ltd. All rights reserved.
  *
  * This software is available to you under a choice of one of two
  * licenses.  You may choose to be licensed under the terms of the GNU

--- a/src/vma/sock/fd_collection.h
+++ b/src/vma/sock/fd_collection.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001-2020 Mellanox Technologies, Ltd. All rights reserved.
+ * Copyright (c) 2001-2021 Mellanox Technologies, Ltd. All rights reserved.
  *
  * This software is available to you under a choice of one of two
  * licenses.  You may choose to be licensed under the terms of the GNU

--- a/src/vma/sock/pipeinfo.cpp
+++ b/src/vma/sock/pipeinfo.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001-2020 Mellanox Technologies, Ltd. All rights reserved.
+ * Copyright (c) 2001-2021 Mellanox Technologies, Ltd. All rights reserved.
  *
  * This software is available to you under a choice of one of two
  * licenses.  You may choose to be licensed under the terms of the GNU

--- a/src/vma/sock/pipeinfo.h
+++ b/src/vma/sock/pipeinfo.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001-2020 Mellanox Technologies, Ltd. All rights reserved.
+ * Copyright (c) 2001-2021 Mellanox Technologies, Ltd. All rights reserved.
  *
  * This software is available to you under a choice of one of two
  * licenses.  You may choose to be licensed under the terms of the GNU

--- a/src/vma/sock/pkt_rcvr_sink.h
+++ b/src/vma/sock/pkt_rcvr_sink.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001-2020 Mellanox Technologies, Ltd. All rights reserved.
+ * Copyright (c) 2001-2021 Mellanox Technologies, Ltd. All rights reserved.
  *
  * This software is available to you under a choice of one of two
  * licenses.  You may choose to be licensed under the terms of the GNU

--- a/src/vma/sock/pkt_sndr_source.h
+++ b/src/vma/sock/pkt_sndr_source.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001-2020 Mellanox Technologies, Ltd. All rights reserved.
+ * Copyright (c) 2001-2021 Mellanox Technologies, Ltd. All rights reserved.
  *
  * This software is available to you under a choice of one of two
  * licenses.  You may choose to be licensed under the terms of the GNU

--- a/src/vma/sock/sock-redirect.cpp
+++ b/src/vma/sock/sock-redirect.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001-2020 Mellanox Technologies, Ltd. All rights reserved.
+ * Copyright (c) 2001-2021 Mellanox Technologies, Ltd. All rights reserved.
  *
  * This software is available to you under a choice of one of two
  * licenses.  You may choose to be licensed under the terms of the GNU

--- a/src/vma/sock/sock-redirect.h
+++ b/src/vma/sock/sock-redirect.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001-2020 Mellanox Technologies, Ltd. All rights reserved.
+ * Copyright (c) 2001-2021 Mellanox Technologies, Ltd. All rights reserved.
  *
  * This software is available to you under a choice of one of two
  * licenses.  You may choose to be licensed under the terms of the GNU

--- a/src/vma/sock/socket_fd_api.cpp
+++ b/src/vma/sock/socket_fd_api.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001-2020 Mellanox Technologies, Ltd. All rights reserved.
+ * Copyright (c) 2001-2021 Mellanox Technologies, Ltd. All rights reserved.
  *
  * This software is available to you under a choice of one of two
  * licenses.  You may choose to be licensed under the terms of the GNU

--- a/src/vma/sock/socket_fd_api.h
+++ b/src/vma/sock/socket_fd_api.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001-2020 Mellanox Technologies, Ltd. All rights reserved.
+ * Copyright (c) 2001-2021 Mellanox Technologies, Ltd. All rights reserved.
  *
  * This software is available to you under a choice of one of two
  * licenses.  You may choose to be licensed under the terms of the GNU

--- a/src/vma/sock/sockinfo.cpp
+++ b/src/vma/sock/sockinfo.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001-2020 Mellanox Technologies, Ltd. All rights reserved.
+ * Copyright (c) 2001-2021 Mellanox Technologies, Ltd. All rights reserved.
  *
  * This software is available to you under a choice of one of two
  * licenses.  You may choose to be licensed under the terms of the GNU

--- a/src/vma/sock/sockinfo.h
+++ b/src/vma/sock/sockinfo.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001-2020 Mellanox Technologies, Ltd. All rights reserved.
+ * Copyright (c) 2001-2021 Mellanox Technologies, Ltd. All rights reserved.
  *
  * This software is available to you under a choice of one of two
  * licenses.  You may choose to be licensed under the terms of the GNU

--- a/src/vma/sock/sockinfo_tcp.cpp
+++ b/src/vma/sock/sockinfo_tcp.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001-2020 Mellanox Technologies, Ltd. All rights reserved.
+ * Copyright (c) 2001-2021 Mellanox Technologies, Ltd. All rights reserved.
  *
  * This software is available to you under a choice of one of two
  * licenses.  You may choose to be licensed under the terms of the GNU

--- a/src/vma/sock/sockinfo_tcp.h
+++ b/src/vma/sock/sockinfo_tcp.h
@@ -182,6 +182,7 @@ public:
 
 	static struct pbuf * tcp_tx_pbuf_alloc(void* p_conn);
 	static void tcp_tx_pbuf_free(void* p_conn, struct pbuf *p_buff);
+	static void tcp_rx_pbuf_free(struct pbuf *p_buff);
 	static struct tcp_seg * tcp_seg_alloc(void* p_conn);
 	static void tcp_seg_free(void* p_conn, struct tcp_seg * seg);
 

--- a/src/vma/sock/sockinfo_tcp.h
+++ b/src/vma/sock/sockinfo_tcp.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001-2020 Mellanox Technologies, Ltd. All rights reserved.
+ * Copyright (c) 2001-2021 Mellanox Technologies, Ltd. All rights reserved.
  *
  * This software is available to you under a choice of one of two
  * licenses.  You may choose to be licensed under the terms of the GNU

--- a/src/vma/sock/sockinfo_udp.cpp
+++ b/src/vma/sock/sockinfo_udp.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001-2020 Mellanox Technologies, Ltd. All rights reserved.
+ * Copyright (c) 2001-2021 Mellanox Technologies, Ltd. All rights reserved.
  *
  * This software is available to you under a choice of one of two
  * licenses.  You may choose to be licensed under the terms of the GNU

--- a/src/vma/sock/sockinfo_udp.h
+++ b/src/vma/sock/sockinfo_udp.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001-2020 Mellanox Technologies, Ltd. All rights reserved.
+ * Copyright (c) 2001-2021 Mellanox Technologies, Ltd. All rights reserved.
  *
  * This software is available to you under a choice of one of two
  * licenses.  You may choose to be licensed under the terms of the GNU

--- a/src/vma/util/30-libvma-limits.conf
+++ b/src/vma/util/30-libvma-limits.conf
@@ -1,6 +1,0 @@
-# Default limits that are needed for proper work of libvma
-# Read more about this topic in the VMA's User Manual
-
-*             -   memlock        unlimited
-*          soft   memlock        unlimited
-*          hard   memlock        unlimited

--- a/src/vma/util/agent.cpp
+++ b/src/vma/util/agent.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001-2020 Mellanox Technologies, Ltd. All rights reserved.
+ * Copyright (c) 2001-2021 Mellanox Technologies, Ltd. All rights reserved.
  *
  * This software is available to you under a choice of one of two
  * licenses.  You may choose to be licensed under the terms of the GNU

--- a/src/vma/util/agent.h
+++ b/src/vma/util/agent.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001-2020 Mellanox Technologies, Ltd. All rights reserved.
+ * Copyright (c) 2001-2021 Mellanox Technologies, Ltd. All rights reserved.
  *
  * This software is available to you under a choice of one of two
  * licenses.  You may choose to be licensed under the terms of the GNU

--- a/src/vma/util/agent_def.h
+++ b/src/vma/util/agent_def.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001-2020 Mellanox Technologies, Ltd. All rights reserved.
+ * Copyright (c) 2001-2021 Mellanox Technologies, Ltd. All rights reserved.
  *
  * This software is available to you under a choice of one of two
  * licenses.  You may choose to be licensed under the terms of the GNU

--- a/src/vma/util/chunk_list.h
+++ b/src/vma/util/chunk_list.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001-2020 Mellanox Technologies, Ltd. All rights reserved.
+ * Copyright (c) 2001-2021 Mellanox Technologies, Ltd. All rights reserved.
  *
  * This software is available to you under a choice of one of two
  * licenses.  You may choose to be licensed under the terms of the GNU

--- a/src/vma/util/config_parser.y
+++ b/src/vma/util/config_parser.y
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001-2020 Mellanox Technologies Ltd. All rights reserved.
+ * Copyright (c) 2001-2021 Mellanox Technologies Ltd. All rights reserved.
  *
  * This software is available to you under a choice of one of two
  * licenses.  You may choose to be licensed under the terms of the GNU

--- a/src/vma/util/config_scanner.l
+++ b/src/vma/util/config_scanner.l
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001-2020 Mellanox Technologies Ltd. All rights reserved.
+ * Copyright (c) 2001-2021 Mellanox Technologies Ltd. All rights reserved.
  *
  * This software is available to you under a choice of one of two
  * licenses.  You may choose to be licensed under the terms of the GNU

--- a/src/vma/util/data_updater.cpp
+++ b/src/vma/util/data_updater.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001-2020 Mellanox Technologies, Ltd. All rights reserved.
+ * Copyright (c) 2001-2021 Mellanox Technologies, Ltd. All rights reserved.
  *
  * This software is available to you under a choice of one of two
  * licenses.  You may choose to be licensed under the terms of the GNU

--- a/src/vma/util/data_updater.h
+++ b/src/vma/util/data_updater.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001-2020 Mellanox Technologies, Ltd. All rights reserved.
+ * Copyright (c) 2001-2021 Mellanox Technologies, Ltd. All rights reserved.
  *
  * This software is available to you under a choice of one of two
  * licenses.  You may choose to be licensed under the terms of the GNU

--- a/src/vma/util/hash_map.h
+++ b/src/vma/util/hash_map.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001-2020 Mellanox Technologies, Ltd. All rights reserved.
+ * Copyright (c) 2001-2021 Mellanox Technologies, Ltd. All rights reserved.
  *
  * This software is available to you under a choice of one of two
  * licenses.  You may choose to be licensed under the terms of the GNU

--- a/src/vma/util/hash_map.inl
+++ b/src/vma/util/hash_map.inl
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001-2020 Mellanox Technologies, Ltd. All rights reserved.
+ * Copyright (c) 2001-2021 Mellanox Technologies, Ltd. All rights reserved.
  *
  * This software is available to you under a choice of one of two
  * licenses.  You may choose to be licensed under the terms of the GNU

--- a/src/vma/util/if.h
+++ b/src/vma/util/if.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001-2020 Mellanox Technologies, Ltd. All rights reserved.
+ * Copyright (c) 2001-2021 Mellanox Technologies, Ltd. All rights reserved.
  *
  * This software is available to you under a choice of one of two
  * licenses.  You may choose to be licensed under the terms of the GNU

--- a/src/vma/util/instrumentation.cpp
+++ b/src/vma/util/instrumentation.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001-2020 Mellanox Technologies, Ltd. All rights reserved.
+ * Copyright (c) 2001-2021 Mellanox Technologies, Ltd. All rights reserved.
  *
  * This software is available to you under a choice of one of two
  * licenses.  You may choose to be licensed under the terms of the GNU

--- a/src/vma/util/instrumentation.h
+++ b/src/vma/util/instrumentation.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001-2020 Mellanox Technologies, Ltd. All rights reserved.
+ * Copyright (c) 2001-2021 Mellanox Technologies, Ltd. All rights reserved.
  *
  * This software is available to you under a choice of one of two
  * licenses.  You may choose to be licensed under the terms of the GNU

--- a/src/vma/util/libvma.h
+++ b/src/vma/util/libvma.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001-2020 Mellanox Technologies, Ltd. All rights reserved.
+ * Copyright (c) 2001-2021 Mellanox Technologies, Ltd. All rights reserved.
  *
  * This software is available to you under a choice of one of two
  * licenses.  You may choose to be licensed under the terms of the GNU

--- a/src/vma/util/match.cpp
+++ b/src/vma/util/match.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001-2020 Mellanox Technologies, Ltd. All rights reserved.
+ * Copyright (c) 2001-2021 Mellanox Technologies, Ltd. All rights reserved.
  *
  * This software is available to you under a choice of one of two
  * licenses.  You may choose to be licensed under the terms of the GNU

--- a/src/vma/util/sg_array.h
+++ b/src/vma/util/sg_array.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001-2020 Mellanox Technologies, Ltd. All rights reserved.
+ * Copyright (c) 2001-2021 Mellanox Technologies, Ltd. All rights reserved.
  *
  * This software is available to you under a choice of one of two
  * licenses.  You may choose to be licensed under the terms of the GNU

--- a/src/vma/util/sock_addr.h
+++ b/src/vma/util/sock_addr.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001-2020 Mellanox Technologies, Ltd. All rights reserved.
+ * Copyright (c) 2001-2021 Mellanox Technologies, Ltd. All rights reserved.
  *
  * This software is available to you under a choice of one of two
  * licenses.  You may choose to be licensed under the terms of the GNU

--- a/src/vma/util/sys_vars.cpp
+++ b/src/vma/util/sys_vars.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001-2020 Mellanox Technologies, Ltd. All rights reserved.
+ * Copyright (c) 2001-2021 Mellanox Technologies, Ltd. All rights reserved.
  *
  * This software is available to you under a choice of one of two
  * licenses.  You may choose to be licensed under the terms of the GNU

--- a/src/vma/util/sys_vars.h
+++ b/src/vma/util/sys_vars.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001-2020 Mellanox Technologies, Ltd. All rights reserved.
+ * Copyright (c) 2001-2021 Mellanox Technologies, Ltd. All rights reserved.
  *
  * This software is available to you under a choice of one of two
  * licenses.  You may choose to be licensed under the terms of the GNU

--- a/src/vma/util/sysctl_reader.h
+++ b/src/vma/util/sysctl_reader.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001-2020 Mellanox Technologies, Ltd. All rights reserved.
+ * Copyright (c) 2001-2021 Mellanox Technologies, Ltd. All rights reserved.
  *
  * This software is available to you under a choice of one of two
  * licenses.  You may choose to be licensed under the terms of the GNU

--- a/src/vma/util/to_str.h
+++ b/src/vma/util/to_str.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001-2020 Mellanox Technologies, Ltd. All rights reserved.
+ * Copyright (c) 2001-2021 Mellanox Technologies, Ltd. All rights reserved.
  *
  * This software is available to you under a choice of one of two
  * licenses.  You may choose to be licensed under the terms of the GNU

--- a/src/vma/util/utils.cpp
+++ b/src/vma/util/utils.cpp
@@ -822,9 +822,7 @@ bool check_bond_device_exist(const char* ifname)
 		goto out;
 	}
 	link_type = rtnl_link_get_type(link);
-	if (link_type &&
-		(strcmp(link_type, "bond") != 0) &&
-		(strcmp(link_type, "team") != 0)) {
+	if (link_type && (strcmp(link_type, "bond") != 0)) {
 		link_type = NULL;
 	}
 out:

--- a/src/vma/util/utils.cpp
+++ b/src/vma/util/utils.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001-2020 Mellanox Technologies, Ltd. All rights reserved.
+ * Copyright (c) 2001-2021 Mellanox Technologies, Ltd. All rights reserved.
  *
  * This software is available to you under a choice of one of two
  * licenses.  You may choose to be licensed under the terms of the GNU

--- a/src/vma/util/utils.cpp
+++ b/src/vma/util/utils.cpp
@@ -235,7 +235,7 @@ unsigned short compute_ip_checksum(const unsigned short *buf, unsigned int nshor
  * */
 unsigned short compute_tcp_checksum(const struct iphdr *p_iphdr, const uint16_t *p_ip_payload)
 {
-    register unsigned long sum = 0;
+    unsigned long sum = 0;
     uint16_t tcpLen = ntohs(p_iphdr->tot_len) - (p_iphdr->ihl<<2); // shift left 2 will multiply by 4 for converting to octets
 
     //add the pseudo header
@@ -277,7 +277,7 @@ unsigned short compute_tcp_checksum(const struct iphdr *p_iphdr, const uint16_t 
  */
 unsigned short compute_udp_checksum_rx(const struct iphdr *p_iphdr, const struct udphdr *udphdrp, mem_buf_desc_t* p_rx_wc_buf_desc)
 {
-    register unsigned long sum = 0;
+    unsigned long sum = 0;
     unsigned short udp_len = htons(udphdrp->len);
     const uint16_t *p_ip_payload = (const uint16_t *) udphdrp;
     mem_buf_desc_t *p_ip_frag = p_rx_wc_buf_desc;

--- a/src/vma/util/utils.h
+++ b/src/vma/util/utils.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001-2020 Mellanox Technologies, Ltd. All rights reserved.
+ * Copyright (c) 2001-2021 Mellanox Technologies, Ltd. All rights reserved.
  *
  * This software is available to you under a choice of one of two
  * licenses.  You may choose to be licensed under the terms of the GNU

--- a/src/vma/util/valgrind.h
+++ b/src/vma/util/valgrind.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001-2020 Mellanox Technologies, Ltd. All rights reserved.
+ * Copyright (c) 2001-2021 Mellanox Technologies, Ltd. All rights reserved.
  *
  * This software is available to you under a choice of one of two
  * licenses.  You may choose to be licensed under the terms of the GNU

--- a/src/vma/util/vma_list.h
+++ b/src/vma/util/vma_list.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001-2020 Mellanox Technologies, Ltd. All rights reserved.
+ * Copyright (c) 2001-2021 Mellanox Technologies, Ltd. All rights reserved.
  *
  * This software is available to you under a choice of one of two
  * licenses.  You may choose to be licensed under the terms of the GNU

--- a/src/vma/util/vma_stats.h
+++ b/src/vma/util/vma_stats.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001-2020 Mellanox Technologies, Ltd. All rights reserved.
+ * Copyright (c) 2001-2021 Mellanox Technologies, Ltd. All rights reserved.
  *
  * This software is available to you under a choice of one of two
  * licenses.  You may choose to be licensed under the terms of the GNU

--- a/src/vma/util/vtypes.h
+++ b/src/vma/util/vtypes.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001-2020 Mellanox Technologies, Ltd. All rights reserved.
+ * Copyright (c) 2001-2021 Mellanox Technologies, Ltd. All rights reserved.
  *
  * This software is available to you under a choice of one of two
  * licenses.  You may choose to be licensed under the terms of the GNU

--- a/src/vma/util/wakeup.cpp
+++ b/src/vma/util/wakeup.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001-2020 Mellanox Technologies, Ltd. All rights reserved.
+ * Copyright (c) 2001-2021 Mellanox Technologies, Ltd. All rights reserved.
  *
  * This software is available to you under a choice of one of two
  * licenses.  You may choose to be licensed under the terms of the GNU

--- a/src/vma/util/wakeup.h
+++ b/src/vma/util/wakeup.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001-2020 Mellanox Technologies, Ltd. All rights reserved.
+ * Copyright (c) 2001-2021 Mellanox Technologies, Ltd. All rights reserved.
  *
  * This software is available to you under a choice of one of two
  * licenses.  You may choose to be licensed under the terms of the GNU

--- a/src/vma/util/wakeup_pipe.cpp
+++ b/src/vma/util/wakeup_pipe.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001-2020 Mellanox Technologies, Ltd. All rights reserved.
+ * Copyright (c) 2001-2021 Mellanox Technologies, Ltd. All rights reserved.
  *
  * This software is available to you under a choice of one of two
  * licenses.  You may choose to be licensed under the terms of the GNU

--- a/src/vma/util/wakeup_pipe.h
+++ b/src/vma/util/wakeup_pipe.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001-2020 Mellanox Technologies, Ltd. All rights reserved.
+ * Copyright (c) 2001-2021 Mellanox Technologies, Ltd. All rights reserved.
  *
  * This software is available to you under a choice of one of two
  * licenses.  You may choose to be licensed under the terms of the GNU

--- a/src/vma/vma_extra.h
+++ b/src/vma/vma_extra.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001-2020 Mellanox Technologies, Ltd. All rights reserved.
+ * Copyright (c) 2001-2021 Mellanox Technologies, Ltd. All rights reserved.
  *
  * This software is available to you under a choice of one of two
  * licenses.  You may choose to be licensed under the terms of the GNU

--- a/tests/api-support-check.py
+++ b/tests/api-support-check.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 #
 #@copyright:
-#        Copyright (c) 2001-2020 Mellanox Technologies, Ltd. All rights reserved.
+#        Copyright (c) 2001-2021 Mellanox Technologies, Ltd. All rights reserved.
 #
 #        This software is available to you under a choice of one of two
 #        licenses.  You may choose to be licensed under the terms of the GNU

--- a/tests/async-echo-client/async-echo-client.py
+++ b/tests/async-echo-client/async-echo-client.py
@@ -2,7 +2,7 @@
 #
 #
 #@copyright:
-#        Copyright (c) 2001-2020 Mellanox Technologies, Ltd. All rights reserved.
+#        Copyright (c) 2001-2021 Mellanox Technologies, Ltd. All rights reserved.
 #
 #        This software is available to you under a choice of one of two
 #        licenses.  You may choose to be licensed under the terms of the GNU

--- a/tests/async-echo-client/syncronized-echo-client.py
+++ b/tests/async-echo-client/syncronized-echo-client.py
@@ -2,7 +2,7 @@
 #
 #
 #@copyright:
-#        Copyright (c) 2001-2020 Mellanox Technologies, Ltd. All rights reserved.
+#        Copyright (c) 2001-2021 Mellanox Technologies, Ltd. All rights reserved.
 #
 #        This software is available to you under a choice of one of two
 #        licenses.  You may choose to be licensed under the terms of the GNU

--- a/tests/bindtodevice/client.py
+++ b/tests/bindtodevice/client.py
@@ -2,7 +2,7 @@
 #
 #
 #@copyright:
-#        Copyright (c) 2001-2020 Mellanox Technologies, Ltd. All rights reserved.
+#        Copyright (c) 2001-2021 Mellanox Technologies, Ltd. All rights reserved.
 #
 #        This software is available to you under a choice of one of two
 #        licenses.  You may choose to be licensed under the terms of the GNU

--- a/tests/connect-disconnect/client.py
+++ b/tests/connect-disconnect/client.py
@@ -2,7 +2,7 @@
 #
 #
 #@copyright:
-#        Copyright (c) 2001-2020 Mellanox Technologies, Ltd. All rights reserved.
+#        Copyright (c) 2001-2021 Mellanox Technologies, Ltd. All rights reserved.
 #
 #        This software is available to you under a choice of one of two
 #        licenses.  You may choose to be licensed under the terms of the GNU

--- a/tests/gtest/common/base.cc
+++ b/tests/gtest/common/base.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001-2020 Mellanox Technologies, Ltd. All rights reserved.
+ * Copyright (c) 2001-2021 Mellanox Technologies, Ltd. All rights reserved.
  *
  * This software is available to you under a choice of one of two
  * licenses.  You may choose to be licensed under the terms of the GNU

--- a/tests/gtest/common/base.h
+++ b/tests/gtest/common/base.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001-2020 Mellanox Technologies, Ltd. All rights reserved.
+ * Copyright (c) 2001-2021 Mellanox Technologies, Ltd. All rights reserved.
  *
  * This software is available to you under a choice of one of two
  * licenses.  You may choose to be licensed under the terms of the GNU

--- a/tests/gtest/common/cmn.h
+++ b/tests/gtest/common/cmn.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001-2020 Mellanox Technologies, Ltd. All rights reserved.
+ * Copyright (c) 2001-2021 Mellanox Technologies, Ltd. All rights reserved.
  *
  * This software is available to you under a choice of one of two
  * licenses.  You may choose to be licensed under the terms of the GNU

--- a/tests/gtest/common/def.h
+++ b/tests/gtest/common/def.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001-2020 Mellanox Technologies, Ltd. All rights reserved.
+ * Copyright (c) 2001-2021 Mellanox Technologies, Ltd. All rights reserved.
  *
  * This software is available to you under a choice of one of two
  * licenses.  You may choose to be licensed under the terms of the GNU

--- a/tests/gtest/common/log.h
+++ b/tests/gtest/common/log.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001-2020 Mellanox Technologies, Ltd. All rights reserved.
+ * Copyright (c) 2001-2021 Mellanox Technologies, Ltd. All rights reserved.
  *
  * This software is available to you under a choice of one of two
  * licenses.  You may choose to be licensed under the terms of the GNU

--- a/tests/gtest/common/sys.cc
+++ b/tests/gtest/common/sys.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001-2020 Mellanox Technologies, Ltd. All rights reserved.
+ * Copyright (c) 2001-2021 Mellanox Technologies, Ltd. All rights reserved.
  *
  * This software is available to you under a choice of one of two
  * licenses.  You may choose to be licensed under the terms of the GNU

--- a/tests/gtest/common/sys.h
+++ b/tests/gtest/common/sys.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001-2020 Mellanox Technologies, Ltd. All rights reserved.
+ * Copyright (c) 2001-2021 Mellanox Technologies, Ltd. All rights reserved.
  *
  * This software is available to you under a choice of one of two
  * licenses.  You may choose to be licensed under the terms of the GNU

--- a/tests/gtest/main.cc
+++ b/tests/gtest/main.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001-2020 Mellanox Technologies, Ltd. All rights reserved.
+ * Copyright (c) 2001-2021 Mellanox Technologies, Ltd. All rights reserved.
  *
  * This software is available to you under a choice of one of two
  * licenses.  You may choose to be licensed under the terms of the GNU

--- a/tests/gtest/mix/mix_base.cc
+++ b/tests/gtest/mix/mix_base.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001-2020 Mellanox Technologies, Ltd. All rights reserved.
+ * Copyright (c) 2001-2021 Mellanox Technologies, Ltd. All rights reserved.
  *
  * This software is available to you under a choice of one of two
  * licenses.  You may choose to be licensed under the terms of the GNU

--- a/tests/gtest/mix/mix_base.h
+++ b/tests/gtest/mix/mix_base.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001-2020 Mellanox Technologies, Ltd. All rights reserved.
+ * Copyright (c) 2001-2021 Mellanox Technologies, Ltd. All rights reserved.
  *
  * This software is available to you under a choice of one of two
  * licenses.  You may choose to be licensed under the terms of the GNU

--- a/tests/gtest/mix/mix_list.cc
+++ b/tests/gtest/mix/mix_list.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001-2020 Mellanox Technologies, Ltd. All rights reserved.
+ * Copyright (c) 2001-2021 Mellanox Technologies, Ltd. All rights reserved.
  *
  * This software is available to you under a choice of one of two
  * licenses.  You may choose to be licensed under the terms of the GNU

--- a/tests/gtest/mix/sg_array.cc
+++ b/tests/gtest/mix/sg_array.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001-2020 Mellanox Technologies, Ltd. All rights reserved.
+ * Copyright (c) 2001-2021 Mellanox Technologies, Ltd. All rights reserved.
  *
  * This software is available to you under a choice of one of two
  * licenses.  You may choose to be licensed under the terms of the GNU

--- a/tests/gtest/sock/sock_base.cc
+++ b/tests/gtest/sock/sock_base.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001-2020 Mellanox Technologies, Ltd. All rights reserved.
+ * Copyright (c) 2001-2021 Mellanox Technologies, Ltd. All rights reserved.
  *
  * This software is available to you under a choice of one of two
  * licenses.  You may choose to be licensed under the terms of the GNU

--- a/tests/gtest/sock/sock_base.h
+++ b/tests/gtest/sock/sock_base.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001-2020 Mellanox Technologies, Ltd. All rights reserved.
+ * Copyright (c) 2001-2021 Mellanox Technologies, Ltd. All rights reserved.
  *
  * This software is available to you under a choice of one of two
  * licenses.  You may choose to be licensed under the terms of the GNU

--- a/tests/gtest/sock/sock_socket.cc
+++ b/tests/gtest/sock/sock_socket.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001-2020 Mellanox Technologies, Ltd. All rights reserved.
+ * Copyright (c) 2001-2021 Mellanox Technologies, Ltd. All rights reserved.
  *
  * This software is available to you under a choice of one of two
  * licenses.  You may choose to be licensed under the terms of the GNU

--- a/tests/gtest/tcp/tcp_base.cc
+++ b/tests/gtest/tcp/tcp_base.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001-2020 Mellanox Technologies, Ltd. All rights reserved.
+ * Copyright (c) 2001-2021 Mellanox Technologies, Ltd. All rights reserved.
  *
  * This software is available to you under a choice of one of two
  * licenses.  You may choose to be licensed under the terms of the GNU

--- a/tests/gtest/tcp/tcp_base.h
+++ b/tests/gtest/tcp/tcp_base.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001-2020 Mellanox Technologies, Ltd. All rights reserved.
+ * Copyright (c) 2001-2021 Mellanox Technologies, Ltd. All rights reserved.
  *
  * This software is available to you under a choice of one of two
  * licenses.  You may choose to be licensed under the terms of the GNU

--- a/tests/gtest/tcp/tcp_bind.cc
+++ b/tests/gtest/tcp/tcp_bind.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001-2020 Mellanox Technologies, Ltd. All rights reserved.
+ * Copyright (c) 2001-2021 Mellanox Technologies, Ltd. All rights reserved.
  *
  * This software is available to you under a choice of one of two
  * licenses.  You may choose to be licensed under the terms of the GNU

--- a/tests/gtest/tcp/tcp_connect.cc
+++ b/tests/gtest/tcp/tcp_connect.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001-2020 Mellanox Technologies, Ltd. All rights reserved.
+ * Copyright (c) 2001-2021 Mellanox Technologies, Ltd. All rights reserved.
  *
  * This software is available to you under a choice of one of two
  * licenses.  You may choose to be licensed under the terms of the GNU

--- a/tests/gtest/tcp/tcp_connect_nb.cc
+++ b/tests/gtest/tcp/tcp_connect_nb.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001-2020 Mellanox Technologies, Ltd. All rights reserved.
+ * Copyright (c) 2001-2021 Mellanox Technologies, Ltd. All rights reserved.
  *
  * This software is available to you under a choice of one of two
  * licenses.  You may choose to be licensed under the terms of the GNU

--- a/tests/gtest/tcp/tcp_event.cc
+++ b/tests/gtest/tcp/tcp_event.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001-2020 Mellanox Technologies, Ltd. All rights reserved.
+ * Copyright (c) 2001-2021 Mellanox Technologies, Ltd. All rights reserved.
  *
  * This software is available to you under a choice of one of two
  * licenses.  You may choose to be licensed under the terms of the GNU

--- a/tests/gtest/tcp/tcp_send.cc
+++ b/tests/gtest/tcp/tcp_send.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001-2020 Mellanox Technologies, Ltd. All rights reserved.
+ * Copyright (c) 2001-2021 Mellanox Technologies, Ltd. All rights reserved.
  *
  * This software is available to you under a choice of one of two
  * licenses.  You may choose to be licensed under the terms of the GNU

--- a/tests/gtest/tcp/tcp_sendto.cc
+++ b/tests/gtest/tcp/tcp_sendto.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001-2020 Mellanox Technologies, Ltd. All rights reserved.
+ * Copyright (c) 2001-2021 Mellanox Technologies, Ltd. All rights reserved.
  *
  * This software is available to you under a choice of one of two
  * licenses.  You may choose to be licensed under the terms of the GNU

--- a/tests/gtest/tcp/tcp_socket.cc
+++ b/tests/gtest/tcp/tcp_socket.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001-2020 Mellanox Technologies, Ltd. All rights reserved.
+ * Copyright (c) 2001-2021 Mellanox Technologies, Ltd. All rights reserved.
  *
  * This software is available to you under a choice of one of two
  * licenses.  You may choose to be licensed under the terms of the GNU

--- a/tests/gtest/udp/udp_base.cc
+++ b/tests/gtest/udp/udp_base.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001-2020 Mellanox Technologies, Ltd. All rights reserved.
+ * Copyright (c) 2001-2021 Mellanox Technologies, Ltd. All rights reserved.
  *
  * This software is available to you under a choice of one of two
  * licenses.  You may choose to be licensed under the terms of the GNU

--- a/tests/gtest/udp/udp_base.h
+++ b/tests/gtest/udp/udp_base.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001-2020 Mellanox Technologies, Ltd. All rights reserved.
+ * Copyright (c) 2001-2021 Mellanox Technologies, Ltd. All rights reserved.
  *
  * This software is available to you under a choice of one of two
  * licenses.  You may choose to be licensed under the terms of the GNU

--- a/tests/gtest/udp/udp_bind.cc
+++ b/tests/gtest/udp/udp_bind.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001-2020 Mellanox Technologies, Ltd. All rights reserved.
+ * Copyright (c) 2001-2021 Mellanox Technologies, Ltd. All rights reserved.
  *
  * This software is available to you under a choice of one of two
  * licenses.  You may choose to be licensed under the terms of the GNU

--- a/tests/gtest/udp/udp_connect.cc
+++ b/tests/gtest/udp/udp_connect.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001-2020 Mellanox Technologies, Ltd. All rights reserved.
+ * Copyright (c) 2001-2021 Mellanox Technologies, Ltd. All rights reserved.
  *
  * This software is available to you under a choice of one of two
  * licenses.  You may choose to be licensed under the terms of the GNU

--- a/tests/gtest/udp/udp_send.cc
+++ b/tests/gtest/udp/udp_send.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001-2020 Mellanox Technologies, Ltd. All rights reserved.
+ * Copyright (c) 2001-2021 Mellanox Technologies, Ltd. All rights reserved.
  *
  * This software is available to you under a choice of one of two
  * licenses.  You may choose to be licensed under the terms of the GNU

--- a/tests/gtest/udp/udp_sendto.cc
+++ b/tests/gtest/udp/udp_sendto.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001-2020 Mellanox Technologies, Ltd. All rights reserved.
+ * Copyright (c) 2001-2021 Mellanox Technologies, Ltd. All rights reserved.
  *
  * This software is available to you under a choice of one of two
  * licenses.  You may choose to be licensed under the terms of the GNU

--- a/tests/gtest/vma/vma_base.cc
+++ b/tests/gtest/vma/vma_base.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001-2020 Mellanox Technologies, Ltd. All rights reserved.
+ * Copyright (c) 2001-2021 Mellanox Technologies, Ltd. All rights reserved.
  *
  * This software is available to you under a choice of one of two
  * licenses.  You may choose to be licensed under the terms of the GNU

--- a/tests/gtest/vma/vma_base.h
+++ b/tests/gtest/vma/vma_base.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001-2020 Mellanox Technologies, Ltd. All rights reserved.
+ * Copyright (c) 2001-2021 Mellanox Technologies, Ltd. All rights reserved.
  *
  * This software is available to you under a choice of one of two
  * licenses.  You may choose to be licensed under the terms of the GNU

--- a/tests/gtest/vma/vma_poll.cc
+++ b/tests/gtest/vma/vma_poll.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001-2020 Mellanox Technologies, Ltd. All rights reserved.
+ * Copyright (c) 2001-2021 Mellanox Technologies, Ltd. All rights reserved.
  *
  * This software is available to you under a choice of one of two
  * licenses.  You may choose to be licensed under the terms of the GNU

--- a/tests/gtest/vma/vma_ring.cc
+++ b/tests/gtest/vma/vma_ring.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001-2020 Mellanox Technologies, Ltd. All rights reserved.
+ * Copyright (c) 2001-2021 Mellanox Technologies, Ltd. All rights reserved.
  *
  * This software is available to you under a choice of one of two
  * licenses.  You may choose to be licensed under the terms of the GNU

--- a/tests/gtest/vma/vma_sockopt.cc
+++ b/tests/gtest/vma/vma_sockopt.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001-2020 Mellanox Technologies, Ltd. All rights reserved.
+ * Copyright (c) 2001-2021 Mellanox Technologies, Ltd. All rights reserved.
  *
  * This software is available to you under a choice of one of two
  * licenses.  You may choose to be licensed under the terms of the GNU

--- a/tests/gtest/vmad/vmad_base.cc
+++ b/tests/gtest/vmad/vmad_base.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001-2020 Mellanox Technologies, Ltd. All rights reserved.
+ * Copyright (c) 2001-2021 Mellanox Technologies, Ltd. All rights reserved.
  *
  * This software is available to you under a choice of one of two
  * licenses.  You may choose to be licensed under the terms of the GNU

--- a/tests/gtest/vmad/vmad_base.h
+++ b/tests/gtest/vmad/vmad_base.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001-2020 Mellanox Technologies, Ltd. All rights reserved.
+ * Copyright (c) 2001-2021 Mellanox Technologies, Ltd. All rights reserved.
  *
  * This software is available to you under a choice of one of two
  * licenses.  You may choose to be licensed under the terms of the GNU

--- a/tests/gtest/vmad/vmad_bitmap.cc
+++ b/tests/gtest/vmad/vmad_bitmap.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001-2020 Mellanox Technologies, Ltd. All rights reserved.
+ * Copyright (c) 2001-2021 Mellanox Technologies, Ltd. All rights reserved.
  *
  * This software is available to you under a choice of one of two
  * licenses.  You may choose to be licensed under the terms of the GNU

--- a/tests/gtest/vmad/vmad_flow.cc
+++ b/tests/gtest/vmad/vmad_flow.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001-2020 Mellanox Technologies, Ltd. All rights reserved.
+ * Copyright (c) 2001-2021 Mellanox Technologies, Ltd. All rights reserved.
  *
  * This software is available to you under a choice of one of two
  * licenses.  You may choose to be licensed under the terms of the GNU

--- a/tests/gtest/vmad/vmad_hash.cc
+++ b/tests/gtest/vmad/vmad_hash.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001-2020 Mellanox Technologies, Ltd. All rights reserved.
+ * Copyright (c) 2001-2021 Mellanox Technologies, Ltd. All rights reserved.
  *
  * This software is available to you under a choice of one of two
  * licenses.  You may choose to be licensed under the terms of the GNU

--- a/tests/gtest/vmad/vmad_init.cc
+++ b/tests/gtest/vmad/vmad_init.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001-2020 Mellanox Technologies, Ltd. All rights reserved.
+ * Copyright (c) 2001-2021 Mellanox Technologies, Ltd. All rights reserved.
  *
  * This software is available to you under a choice of one of two
  * licenses.  You may choose to be licensed under the terms of the GNU

--- a/tests/gtest/vmad/vmad_state.cc
+++ b/tests/gtest/vmad/vmad_state.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001-2020 Mellanox Technologies, Ltd. All rights reserved.
+ * Copyright (c) 2001-2021 Mellanox Technologies, Ltd. All rights reserved.
  *
  * This software is available to you under a choice of one of two
  * licenses.  You may choose to be licensed under the terms of the GNU

--- a/tests/latency_test/tcp_lat.cpp
+++ b/tests/latency_test/tcp_lat.cpp
@@ -326,7 +326,7 @@ void run_select_server()
 	}
 
 	/* listen on any port */
-        memset(&addr, sizeof(addr), 0);
+        memset(&addr, 0, sizeof(addr));
         addr.sin_family = PF_INET;
         addr.sin_addr.s_addr = INADDR_ANY;
 	addr.sin_port = htons(tcp_lat_port);
@@ -421,7 +421,7 @@ static void run_tcp_server()
 	}
 
 	/* listen on any port */
-        memset(&addr, sizeof(addr), 0);
+        memset(&addr, 0, sizeof(addr));
         addr.sin_family = PF_INET;
         addr.sin_addr.s_addr = INADDR_ANY;
 	addr.sin_port = htons(tcp_lat_port);

--- a/tests/latency_test/tcp_lat.cpp
+++ b/tests/latency_test/tcp_lat.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001-2020 Mellanox Technologies, Ltd. All rights reserved.
+ * Copyright (c) 2001-2021 Mellanox Technologies, Ltd. All rights reserved.
  *
  * This software is available to you under a choice of one of two
  * licenses.  You may choose to be licensed under the terms of the GNU

--- a/tests/latency_test/udp_lat.c
+++ b/tests/latency_test/udp_lat.c
@@ -2425,7 +2425,8 @@ int main(int argc, char *argv[])
 	   if (user_params.mthread_server) {
 	           server_select_per_thread();
 	           break;
-	   }	   
+	   }
+	   /* fall through */
 	case MODE_BRIDGE:		
 		server_handler(fd_min, fd_max, fd_num); 
 		break;

--- a/tests/latency_test/udp_lat.c
+++ b/tests/latency_test/udp_lat.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001-2020 Mellanox Technologies, Ltd. All rights reserved.
+ * Copyright (c) 2001-2021 Mellanox Technologies, Ltd. All rights reserved.
  *
  * This software is available to you under a choice of one of two
  * licenses.  You may choose to be licensed under the terms of the GNU

--- a/tests/low_pps_tcp_send_test/exchange.cpp
+++ b/tests/low_pps_tcp_send_test/exchange.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001-2020 Mellanox Technologies, Ltd. All rights reserved.
+ * Copyright (c) 2001-2021 Mellanox Technologies, Ltd. All rights reserved.
  *
  * This software is available to you under a choice of one of two
  * licenses.  You may choose to be licensed under the terms of the GNU

--- a/tests/low_pps_tcp_send_test/trader.cpp
+++ b/tests/low_pps_tcp_send_test/trader.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001-2020 Mellanox Technologies, Ltd. All rights reserved.
+ * Copyright (c) 2001-2021 Mellanox Technologies, Ltd. All rights reserved.
  *
  * This software is available to you under a choice of one of two
  * licenses.  You may choose to be licensed under the terms of the GNU

--- a/tests/mc_loop_test/mc_loop_test.c
+++ b/tests/mc_loop_test/mc_loop_test.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001-2020 Mellanox Technologies, Ltd. All rights reserved.
+ * Copyright (c) 2001-2021 Mellanox Technologies, Ltd. All rights reserved.
  *
  * This software is available to you under a choice of one of two
  * licenses.  You may choose to be licensed under the terms of the GNU

--- a/tests/pps_test/pps_test.c
+++ b/tests/pps_test/pps_test.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001-2020 Mellanox Technologies, Ltd. All rights reserved.
+ * Copyright (c) 2001-2021 Mellanox Technologies, Ltd. All rights reserved.
  *
  * This software is available to you under a choice of one of two
  * licenses.  You may choose to be licensed under the terms of the GNU

--- a/tests/resource_release_checker/server_socket_receive_and_recreate_loop.py
+++ b/tests/resource_release_checker/server_socket_receive_and_recreate_loop.py
@@ -2,7 +2,7 @@
 #
 #
 #@copyright:
-#        Copyright (c) 2001-2020 Mellanox Technologies, Ltd. All rights reserved.
+#        Copyright (c) 2001-2021 Mellanox Technologies, Ltd. All rights reserved.
 #
 #        This software is available to you under a choice of one of two
 #        licenses.  You may choose to be licensed under the terms of the GNU

--- a/tests/resource_release_checker/server_socket_recreate_loop.py
+++ b/tests/resource_release_checker/server_socket_recreate_loop.py
@@ -2,7 +2,7 @@
 #
 #
 #@copyright:
-#        Copyright (c) 2001-2020 Mellanox Technologies, Ltd. All rights reserved.
+#        Copyright (c) 2001-2021 Mellanox Technologies, Ltd. All rights reserved.
 #
 #        This software is available to you under a choice of one of two
 #        licenses.  You may choose to be licensed under the terms of the GNU

--- a/tests/server_test/client.cc
+++ b/tests/server_test/client.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001-2020 Mellanox Technologies, Ltd. All rights reserved.
+ * Copyright (c) 2001-2021 Mellanox Technologies, Ltd. All rights reserved.
  *
  * This software is available to you under a choice of one of two
  * licenses.  You may choose to be licensed under the terms of the GNU

--- a/tests/server_test/client.h
+++ b/tests/server_test/client.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001-2020 Mellanox Technologies, Ltd. All rights reserved.
+ * Copyright (c) 2001-2021 Mellanox Technologies, Ltd. All rights reserved.
  *
  * This software is available to you under a choice of one of two
  * licenses.  You may choose to be licensed under the terms of the GNU

--- a/tests/server_test/main.cc
+++ b/tests/server_test/main.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001-2020 Mellanox Technologies, Ltd. All rights reserved.
+ * Copyright (c) 2001-2021 Mellanox Technologies, Ltd. All rights reserved.
  *
  * This software is available to you under a choice of one of two
  * licenses.  You may choose to be licensed under the terms of the GNU

--- a/tests/server_test/options.cc
+++ b/tests/server_test/options.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001-2020 Mellanox Technologies, Ltd. All rights reserved.
+ * Copyright (c) 2001-2021 Mellanox Technologies, Ltd. All rights reserved.
  *
  * This software is available to you under a choice of one of two
  * licenses.  You may choose to be licensed under the terms of the GNU

--- a/tests/server_test/options.h
+++ b/tests/server_test/options.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001-2020 Mellanox Technologies, Ltd. All rights reserved.
+ * Copyright (c) 2001-2021 Mellanox Technologies, Ltd. All rights reserved.
  *
  * This software is available to you under a choice of one of two
  * licenses.  You may choose to be licensed under the terms of the GNU

--- a/tests/server_test/server.cc
+++ b/tests/server_test/server.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001-2020 Mellanox Technologies, Ltd. All rights reserved.
+ * Copyright (c) 2001-2021 Mellanox Technologies, Ltd. All rights reserved.
  *
  * This software is available to you under a choice of one of two
  * licenses.  You may choose to be licensed under the terms of the GNU

--- a/tests/server_test/server.h
+++ b/tests/server_test/server.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001-2020 Mellanox Technologies, Ltd. All rights reserved.
+ * Copyright (c) 2001-2021 Mellanox Technologies, Ltd. All rights reserved.
  *
  * This software is available to you under a choice of one of two
  * licenses.  You may choose to be licensed under the terms of the GNU

--- a/tests/server_test/vtime.cc
+++ b/tests/server_test/vtime.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001-2020 Mellanox Technologies, Ltd. All rights reserved.
+ * Copyright (c) 2001-2021 Mellanox Technologies, Ltd. All rights reserved.
  *
  * This software is available to you under a choice of one of two
  * licenses.  You may choose to be licensed under the terms of the GNU

--- a/tests/server_test/vtime.h
+++ b/tests/server_test/vtime.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001-2020 Mellanox Technologies, Ltd. All rights reserved.
+ * Copyright (c) 2001-2021 Mellanox Technologies, Ltd. All rights reserved.
  *
  * This software is available to you under a choice of one of two
  * licenses.  You may choose to be licensed under the terms of the GNU

--- a/tests/tcp_window_size_exerciser/tcp_wnd_test.h
+++ b/tests/tcp_window_size_exerciser/tcp_wnd_test.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001-2020 Mellanox Technologies, Ltd. All rights reserved.
+ * Copyright (c) 2001-2021 Mellanox Technologies, Ltd. All rights reserved.
  *
  * This software is available to you under a choice of one of two
  * licenses.  You may choose to be licensed under the terms of the GNU

--- a/tests/tcp_window_size_exerciser/tcp_wnd_test_client.c
+++ b/tests/tcp_window_size_exerciser/tcp_wnd_test_client.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001-2020 Mellanox Technologies, Ltd. All rights reserved.
+ * Copyright (c) 2001-2021 Mellanox Technologies, Ltd. All rights reserved.
  *
  * This software is available to you under a choice of one of two
  * licenses.  You may choose to be licensed under the terms of the GNU

--- a/tests/tcp_window_size_exerciser/tcp_wnd_test_server.c
+++ b/tests/tcp_window_size_exerciser/tcp_wnd_test_server.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001-2020 Mellanox Technologies, Ltd. All rights reserved.
+ * Copyright (c) 2001-2021 Mellanox Technologies, Ltd. All rights reserved.
  *
  * This software is available to you under a choice of one of two
  * licenses.  You may choose to be licensed under the terms of the GNU

--- a/tests/throughput_test/bandwidth_test.c
+++ b/tests/throughput_test/bandwidth_test.c
@@ -645,7 +645,7 @@ int main(int argc, char *argv[]) {
 			}
 			break;
 		case 'r':
-			strncpy(send_rate, optarg, MAX_PATH_LENGTH);
+			strncpy(send_rate, optarg, MAX_PATH_LENGTH - 1);
 			user_params.sendRate=get_send_rate(send_rate);
 			
 			if (user_params.sendRateDetails == (char)KBYTE)

--- a/tests/throughput_test/bandwidth_test.c
+++ b/tests/throughput_test/bandwidth_test.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001-2020 Mellanox Technologies, Ltd. All rights reserved.
+ * Copyright (c) 2001-2021 Mellanox Technologies, Ltd. All rights reserved.
  *
  * This software is available to you under a choice of one of two
  * licenses.  You may choose to be licensed under the terms of the GNU

--- a/tests/timetest/timetest.cpp
+++ b/tests/timetest/timetest.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001-2020 Mellanox Technologies, Ltd. All rights reserved.
+ * Copyright (c) 2001-2021 Mellanox Technologies, Ltd. All rights reserved.
  *
  * This software is available to you under a choice of one of two
  * licenses.  You may choose to be licensed under the terms of the GNU

--- a/tests/vma_perf_envelope/vma_multiplexers_test.sh
+++ b/tests/vma_perf_envelope/vma_multiplexers_test.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# Copyright (c) 2001-2020 Mellanox Technologies, Ltd. All rights reserved.
+# Copyright (c) 2001-2021 Mellanox Technologies, Ltd. All rights reserved.
 #
 # This software is available to you under a choice of one of two
 # licenses.  You may choose to be licensed under the terms of the GNU

--- a/tests/vma_perf_envelope/vma_perf_envelope.sh
+++ b/tests/vma_perf_envelope/vma_perf_envelope.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# Copyright (c) 2001-2020 Mellanox Technologies, Ltd. All rights reserved.
+# Copyright (c) 2001-2021 Mellanox Technologies, Ltd. All rights reserved.
 #
 # This software is available to you under a choice of one of two
 # licenses.  You may choose to be licensed under the terms of the GNU

--- a/tools/daemon/bitmap.h
+++ b/tools/daemon/bitmap.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001-2020 Mellanox Technologies, Ltd. All rights reserved.
+ * Copyright (c) 2001-2021 Mellanox Technologies, Ltd. All rights reserved.
  *
  * This software is available to you under a choice of one of two
  * licenses.  You may choose to be licensed under the terms of the GNU

--- a/tools/daemon/daemon.c
+++ b/tools/daemon/daemon.c
@@ -66,11 +66,6 @@ int main(int argc, char *argv[])
 	/* Setup syslog logging */
 	openlog(MODULE_NAME, LOG_PID, LOG_LOCAL5);
 
-	/* already a daemon */
-	if (getppid() == 1) {
-		return 0;
-	}
-
 	/* command line parsing... */
 	config_def();
 	log_info("Starting\n");

--- a/tools/daemon/daemon.c
+++ b/tools/daemon/daemon.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001-2020 Mellanox Technologies, Ltd. All rights reserved.
+ * Copyright (c) 2001-2021 Mellanox Technologies, Ltd. All rights reserved.
  *
  * This software is available to you under a choice of one of two
  * licenses.  You may choose to be licensed under the terms of the GNU

--- a/tools/daemon/daemon.h
+++ b/tools/daemon/daemon.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001-2020 Mellanox Technologies, Ltd. All rights reserved.
+ * Copyright (c) 2001-2021 Mellanox Technologies, Ltd. All rights reserved.
  *
  * This software is available to you under a choice of one of two
  * licenses.  You may choose to be licensed under the terms of the GNU

--- a/tools/daemon/flow.c
+++ b/tools/daemon/flow.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001-2020 Mellanox Technologies, Ltd. All rights reserved.
+ * Copyright (c) 2001-2021 Mellanox Technologies, Ltd. All rights reserved.
  *
  * This software is available to you under a choice of one of two
  * licenses.  You may choose to be licensed under the terms of the GNU

--- a/tools/daemon/hash.c
+++ b/tools/daemon/hash.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001-2020 Mellanox Technologies, Ltd. All rights reserved.
+ * Copyright (c) 2001-2021 Mellanox Technologies, Ltd. All rights reserved.
  *
  * This software is available to you under a choice of one of two
  * licenses.  You may choose to be licensed under the terms of the GNU

--- a/tools/daemon/hash.h
+++ b/tools/daemon/hash.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001-2020 Mellanox Technologies, Ltd. All rights reserved.
+ * Copyright (c) 2001-2021 Mellanox Technologies, Ltd. All rights reserved.
  *
  * This software is available to you under a choice of one of two
  * licenses.  You may choose to be licensed under the terms of the GNU

--- a/tools/daemon/loop.c
+++ b/tools/daemon/loop.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001-2020 Mellanox Technologies, Ltd. All rights reserved.
+ * Copyright (c) 2001-2021 Mellanox Technologies, Ltd. All rights reserved.
  *
  * This software is available to you under a choice of one of two
  * licenses.  You may choose to be licensed under the terms of the GNU

--- a/tools/daemon/message.c
+++ b/tools/daemon/message.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001-2020 Mellanox Technologies, Ltd. All rights reserved.
+ * Copyright (c) 2001-2021 Mellanox Technologies, Ltd. All rights reserved.
  *
  * This software is available to you under a choice of one of two
  * licenses.  You may choose to be licensed under the terms of the GNU

--- a/tools/daemon/nl.c
+++ b/tools/daemon/nl.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001-2020 Mellanox Technologies, Ltd. All rights reserved.
+ * Copyright (c) 2001-2021 Mellanox Technologies, Ltd. All rights reserved.
  *
  * This software is available to you under a choice of one of two
  * licenses.  You may choose to be licensed under the terms of the GNU

--- a/tools/daemon/nl.h
+++ b/tools/daemon/nl.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001-2020 Mellanox Technologies, Ltd. All rights reserved.
+ * Copyright (c) 2001-2021 Mellanox Technologies, Ltd. All rights reserved.
  *
  * This software is available to you under a choice of one of two
  * licenses.  You may choose to be licensed under the terms of the GNU

--- a/tools/daemon/notify.c
+++ b/tools/daemon/notify.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001-2020 Mellanox Technologies, Ltd. All rights reserved.
+ * Copyright (c) 2001-2021 Mellanox Technologies, Ltd. All rights reserved.
  *
  * This software is available to you under a choice of one of two
  * licenses.  You may choose to be licensed under the terms of the GNU

--- a/tools/daemon/store.c
+++ b/tools/daemon/store.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001-2020 Mellanox Technologies, Ltd. All rights reserved.
+ * Copyright (c) 2001-2021 Mellanox Technologies, Ltd. All rights reserved.
  *
  * This software is available to you under a choice of one of two
  * licenses.  You may choose to be licensed under the terms of the GNU

--- a/tools/daemon/tc.c
+++ b/tools/daemon/tc.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001-2020 Mellanox Technologies, Ltd. All rights reserved.
+ * Copyright (c) 2001-2021 Mellanox Technologies, Ltd. All rights reserved.
  *
  * This software is available to you under a choice of one of two
  * licenses.  You may choose to be licensed under the terms of the GNU

--- a/tools/daemon/tc.h
+++ b/tools/daemon/tc.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001-2020 Mellanox Technologies, Ltd. All rights reserved.
+ * Copyright (c) 2001-2021 Mellanox Technologies, Ltd. All rights reserved.
  *
  * This software is available to you under a choice of one of two
  * licenses.  You may choose to be licensed under the terms of the GNU

--- a/tools/media/netmap-vma/netmap_vma.cpp
+++ b/tools/media/netmap-vma/netmap_vma.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001-2020 Mellanox Technologies, Ltd. All rights reserved.
+ * Copyright (c) 2001-2021 Mellanox Technologies, Ltd. All rights reserved.
  *
  * This software is available to you under a choice of one of two
  * licenses.  You may choose to be licensed under the terms of the GNU

--- a/tools/media/netmap-vma/netmap_vma.h
+++ b/tools/media/netmap-vma/netmap_vma.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001-2020 Mellanox Technologies, Ltd. All rights reserved.
+ * Copyright (c) 2001-2021 Mellanox Technologies, Ltd. All rights reserved.
  *
  * This software is available to you under a choice of one of two
  * licenses.  You may choose to be licensed under the terms of the GNU


### PR DESCRIPTION
Global buffer_pool lock leads to a lock contention in multi-threaded applications. We can mitigate it by using ring per core and returning pbufs to respective cq_mgr cache.