### PR TITLE
issue: 2394023 Fix active-backup failover_mac=1 RX

### DIFF
--- a/src/vma/dev/net_device_val.h
+++ b/src/vma/dev/net_device_val.h
@@ -260,6 +260,7 @@ public:
 	L2_address*		get_l2_address() { return m_p_L2_addr; };
 	L2_address* 		get_br_address() { return m_p_br_addr; };
 	inline bond_type  get_is_bond() { return m_bond; }
+	inline int		get_fail_over_mac() { return m_bond_fail_over_mac; }
 	inline bond_xmit_hash_policy get_bond_xmit_hash_policy() { return m_bond_xmit_hash_policy; }
 	bool 			update_active_slaves();
 	void 			update_netvsc_slaves(int if_index, int if_flags);

--- a/src/vma/dev/ring_bond.cpp
+++ b/src/vma/dev/ring_bond.cpp
@@ -837,6 +837,17 @@ int ring_bond::socketxtreme_poll(struct vma_completion_t *, unsigned int, int)
 void ring_bond::check_roce_lag_mode(const slave_data_vector_t& slaves)
 {
 #if defined(DEFINED_ROCE_LAG)
+	if (m_type == net_device_val::ACTIVE_BACKUP) {
+		net_device_val *p_ndev = g_p_net_device_table_mgr->get_net_device_val(m_parent->get_if_index());
+		if (p_ndev->get_fail_over_mac() > 0) {
+			/*
+			 * Skip active-backup mode with failover_mac=1
+			 * because we have to create rules for all MAC
+			 * addresses.
+			 */
+			return;
+		}
+	}
 	m_b_roce_lag = slaves.size() > 1;
 	for (uint32_t i = 1; i < slaves.size(); i++) {
 		if (slaves[i]->p_ib_ctx != slaves[0]->p_ib_ctx) {


### PR DESCRIPTION
In RoCE LAG failover_mac=1 mode we create a single rule which
doesn't include MAC address of the second interface. As workaround,
skip RoCE LAG mode check for active-backup failover_mac=1 and
perform attach flow operation for all slave rings.

Signed-off-by: Dmytro Podgornyi <dmytrop@mellanox.com>