### PR TITLE
issue: 2398382 Fix issues for gcc-11

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -144,8 +144,12 @@ AC_MSG_CHECKING([for compiler])
 case $CC in
     gcc*|g++*)
         AC_MSG_RESULT([gcc])
-        CFLAGS="$CFLAGS -Wall -Wextra -Werror -Wundef -ffunction-sections -fdata-sections -Wsequence-point -pipe -Winit-self -Wmissing-include-dirs"
-        CXXFLAGS="$CXXFLAGS -Wshadow -Wall -Wextra -Werror -Wundef -ffunction-sections -fdata-sections -Wsequence-point -pipe -Winit-self -Wmissing-include-dirs"
+        CFLAGS="$CFLAGS -Wall -Wextra -Werror -Wundef \
+                -ffunction-sections -fdata-sections -Wsequence-point -pipe -Winit-self -Wmissing-include-dirs \
+                -Wno-free-nonheap-object "
+        CXXFLAGS="$CXXFLAGS -Wshadow -Wall -Wextra -Werror -Wundef \
+                -ffunction-sections -fdata-sections -Wsequence-point -pipe -Winit-self -Wmissing-include-dirs \
+                -Wno-free-nonheap-object "
         ;;
     icc*|icpc*)
         AC_MSG_RESULT([icc])

--- a/src/utils/asm-x86.h
+++ b/src/utils/asm-x86.h
@@ -110,7 +110,7 @@ static inline int atomic_fetch_and_add(int x, volatile int *ptr)
  */
 static inline void gettimeoftsc(unsigned long long *p_tscval)
 {
-	register uint32_t upper_32, lower_32;
+	uint32_t upper_32, lower_32;
 
 	// ReaD Time Stamp Counter (RDTCS)
 	__asm__ __volatile__("rdtsc" : "=a" (lower_32), "=d" (upper_32));

--- a/src/vma/dev/net_device_val.cpp
+++ b/src/vma/dev/net_device_val.cpp
@@ -962,7 +962,7 @@ void net_device_val::update_netvsc_slaves(int if_index, int if_flags)
 
 std::string net_device_val::to_str()
 {
-	return std::string("Net Device: " + m_name);
+	return std::string("Net Device: ") + m_name;
 }
 
 ring* net_device_val::reserve_ring(resource_allocation_key *key)
@@ -1414,7 +1414,7 @@ void net_device_val_eth::create_br_address(const char* ifname)
 }
 std::string net_device_val_eth::to_str()
 {
-	return std::string("ETH: " + net_device_val::to_str());
+	return std::string("ETH: ") + net_device_val::to_str();
 }
 
 net_device_val_ib::~net_device_val_ib()
@@ -1512,7 +1512,7 @@ void net_device_val_ib::create_br_address(const char* ifname)
 
 std::string net_device_val_ib::to_str()
 {
-	return std::string("IB: " + net_device_val::to_str());
+	return std::string("IB: ") + net_device_val::to_str();
 }
 
 

--- a/src/vma/sock/cleanable_obj.h
+++ b/src/vma/sock/cleanable_obj.h
@@ -44,7 +44,14 @@ public:
 
 	virtual ~cleanable_obj(){};
 
-	virtual void clean_obj(){ set_cleaned(); delete this; };
+	/* This function should be used just for objects that
+	 * was allocated via new() (not by new[], nor by placement new, nor a local object on the stack,
+	 * nor a namespace-scope / global, nor a member of another object; but by plain ordinary new)
+	 */
+	virtual void clean_obj(){
+		set_cleaned();
+		delete this;
+	};
 
 	bool is_cleaned(){ return m_b_cleaned; };
 

--- a/src/vma/util/utils.cpp
+++ b/src/vma/util/utils.cpp
@@ -235,7 +235,7 @@ unsigned short compute_ip_checksum(const unsigned short *buf, unsigned int nshor
  * */
 unsigned short compute_tcp_checksum(const struct iphdr *p_iphdr, const uint16_t *p_ip_payload)
 {
-    register unsigned long sum = 0;
+    unsigned long sum = 0;
     uint16_t tcpLen = ntohs(p_iphdr->tot_len) - (p_iphdr->ihl<<2); // shift left 2 will multiply by 4 for converting to octets
 
     //add the pseudo header
@@ -277,7 +277,7 @@ unsigned short compute_tcp_checksum(const struct iphdr *p_iphdr, const uint16_t 
  */
 unsigned short compute_udp_checksum_rx(const struct iphdr *p_iphdr, const struct udphdr *udphdrp, mem_buf_desc_t* p_rx_wc_buf_desc)
 {
-    register unsigned long sum = 0;
+    unsigned long sum = 0;
     unsigned short udp_len = htons(udphdrp->len);
     const uint16_t *p_ip_payload = (const uint16_t *) udphdrp;
     mem_buf_desc_t *p_ip_frag = p_rx_wc_buf_desc;


### PR DESCRIPTION
1. The register storage class specifier is deprecated in C++11
2. Disable -Wno-free-nonheap-object diagnostic that looks as
   incorrect for gcc-11

Signed-off-by: Igor Ivanov <igor.ivanov.va@gmail.com>