### PR TITLE
issue: 2366027 Fix big-endian support for TIMESTAMP option

### DIFF
--- a/src/vma/lwip/def.h
+++ b/src/vma/lwip/def.h
@@ -119,6 +119,19 @@ u32_t lwip_ntohl(u32_t x);
 
 #endif /* BYTE_ORDER == BIG_ENDIAN */
 
+static inline u32_t read32_be(const void *addr)
+{
+	const u8_t *p = (const u8_t *)addr;
+	u32_t ret = 0;
+
+	ret |= (u32_t)p[3];
+	ret |= (u32_t)p[2] << 8U;
+	ret |= (u32_t)p[1] << 16U;
+	ret |= (u32_t)p[0] << 24U;
+
+	return ret;
+}
+
 #ifdef __cplusplus
 }
 #endif

--- a/src/vma/lwip/tcp_in.c
+++ b/src/vma/lwip/tcp_in.c
@@ -1670,15 +1670,14 @@ tcp_parseopt(struct tcp_pcb *pcb, tcp_in_data* in_data)
           return;
         }
         /* TCP timestamp option with valid length */
-        tsval = (opts[c+2]) | (opts[c+3] << 8) | 
-          (opts[c+4] << 16) | (opts[c+5] << 24);
+        tsval = read32_be(&opts[c + 2]);
         if (in_data->flags & TCP_SYN) {
           if (pcb->enable_ts_opt) {
-            pcb->ts_recent = ntohl(tsval);
+            pcb->ts_recent = tsval;
             pcb->flags |= TF_TIMESTAMP;
           }
         } else if (TCP_SEQ_BETWEEN(pcb->ts_lastacksent, in_data->seqno, in_data->seqno+in_data->tcplen)) {
-          pcb->ts_recent = ntohl(tsval);
+          pcb->ts_recent = tsval;
         }
         /* Advance to next option */
         c += 0x0A;


### PR DESCRIPTION
TIMESTAMP value is read byte by byte like a little-endian system does
this. This approach won't work on a big-endian system.

Since TIMESTAMP values are always in the network byte order (big-endian)
we can convert it to host byte order without ntohl(). In this way we can
avoid unaligned 32-bit read operation.