### PR TITLE
issue: 2446197 Skip team interface when check bonding

### DIFF
--- a/src/vma/util/utils.cpp
+++ b/src/vma/util/utils.cpp
@@ -822,9 +822,7 @@ bool check_bond_device_exist(const char* ifname)
 		goto out;
 	}
 	link_type = rtnl_link_get_type(link);
-	if (link_type &&
-		(strcmp(link_type, "bond") != 0) &&
-		(strcmp(link_type, "team") != 0)) {
+	if (link_type && (strcmp(link_type, "bond") != 0)) {
 		link_type = NULL;
 	}
 out:


### PR DESCRIPTION
Both team and bonding Master interface has IFF_MASTER flag bit set.

However, linux sys files, such as BONDING_MODE_PARAM_FILE,  are used
to check bonding interface. The linux 'team' kernel module does not
create those files as 'bonding' module.

In other words, 'bonding' interface verify does not work for 'team'
interface, so skip 'team' interface when check 'bonding'.

Otherwise, we will have significant performance issues for UDP traffic
over 'team' interface.

Fixes: ee0a1b983a6f ("issue: 2233904 Check bonding device using netlink")

Signed-off-by: Honggang Li <honli@redhat.com>