### PR TITLE
issue: 2822230 Suppress unwanted error when cq fd is removed

### DIFF
--- a/src/vma/dev/net_device_val.cpp
+++ b/src/vma/dev/net_device_val.cpp
@@ -1045,8 +1045,9 @@ int net_device_val::release_ring(resource_allocation_key *key)
 			for (size_t i = 0; i < num_ring_rx_fds; i++) {
 				int cq_ch_fd = ring_rx_fds_array[i];
 				BULLSEYE_EXCLUDE_BLOCK_START
-				if (unlikely(orig_os_api.epoll_ctl(g_p_net_device_table_mgr->global_ring_epfd_get(),
-						EPOLL_CTL_DEL, cq_ch_fd, NULL))) {
+				if (unlikely((orig_os_api.epoll_ctl(g_p_net_device_table_mgr->global_ring_epfd_get(),
+						EPOLL_CTL_DEL, cq_ch_fd, NULL)) &&
+						(!(errno == ENOENT || errno == EBADF)))) {
 					nd_logerr("Failed to delete RING notification fd to global_table_mgr_epfd (errno=%d %s)", errno, strerror(errno));
 				}
 				BULLSEYE_EXCLUDE_BLOCK_END

--- a/src/vma/sock/sockinfo.cpp
+++ b/src/vma/sock/sockinfo.cpp
@@ -1250,7 +1250,8 @@ void sockinfo::rx_del_ring_cb(flow_tuple_with_local_if &flow_key, ring* p_ring)
 			for (size_t i = 0; i < num_ring_rx_fds; i++) {
 				int cq_ch_fd = ring_rx_fds_array[i];
 				BULLSEYE_EXCLUDE_BLOCK_START
-				if (unlikely( orig_os_api.epoll_ctl(m_rx_epfd, EPOLL_CTL_DEL, cq_ch_fd, NULL))) {
+				if (unlikely((orig_os_api.epoll_ctl(m_rx_epfd, EPOLL_CTL_DEL, cq_ch_fd, NULL)) &&
+							 (!(errno == ENOENT || errno == EBADF)))) {
 					si_logerr("failed to delete cq channel fd from internal epfd (errno=%d %s)", errno, strerror(errno));
 				}
 				BULLSEYE_EXCLUDE_BLOCK_END


### PR DESCRIPTION
## Description
This change can be considered as an addition to previous
commit as (b4b9d7a)
issue: 559317 Continue processing CQ for ready FD after failure on one of them

##### What
Suppress not needed error

##### Why ?
RM: #2822230

## Change type
What kind of change does this PR introduce?
- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Tests
- [ ] Other

## Check list
- [x] Code follows the style de facto guidelines of this project
- [ ] Comments have been inserted in hard to understand places
- [ ] Documentation has been updated (if necessary)
- [ ] Test has been added (if possible)

