### PR TITLE
issue: 2789483 VMA_UDP_3T_RULES flag is not taken into account correctly for UDP UC

### DIFF
--- a/src/vma/dev/ring_slave.cpp
+++ b/src/vma/dev/ring_slave.cpp
@@ -207,9 +207,9 @@ bool ring_slave::attach_flow(flow_tuple& flow_spec_5t, pkt_rcvr_sink *sink)
 		p_rfs = m_flow_udp_uc_map.get(rfs_key, NULL);
 		if (p_rfs == NULL) {
 			// No rfs object exists so a new one must be created and inserted in the flow map
-			if (safe_mce_sys().tcp_3t_rules) {
-				flow_tuple tcp_3t_only(flow_spec_5t.get_dst_ip(), flow_spec_5t.get_dst_port(), 0, 0, flow_spec_5t.get_protocol());
-				dst_port_filter = new rfs_rule_filter(m_udp_uc_dst_port_attach_map, rule_key.key, tcp_3t_only);
+			if (safe_mce_sys().udp_3t_rules) {
+				flow_tuple udp_3t_only(flow_spec_5t.get_dst_ip(), flow_spec_5t.get_dst_port(), 0, 0, flow_spec_5t.get_protocol());
+				dst_port_filter = new rfs_rule_filter(m_udp_uc_dst_port_attach_map, rule_key.key, udp_3t_only);
 			}
 			try {
 				p_tmp_rfs = new (std::nothrow)rfs_uc(&flow_spec_5t, this, dst_port_filter, flow_tag_id);


### PR DESCRIPTION
Signed-off-by: Alexander Grissik <agrissik@nvidia.com>

## Description
Fixing UDP UC 3T/5T rules configuration

##### What
Fixing usage of tcp_3t config instead of udp_3t config. 

##### Why ?
For UDP UC 'connected' socket the 3T/5T rules may be switched.

## Change type
What kind of change does this PR introduce?
- [X] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Tests
- [ ] Other

## Check list
- [X] Code follows the style de facto guidelines of this project
- [X] Comments have been inserted in hard to understand places
- [ ] Documentation has been updated (if necessary)
- [ ] Test has been added (if possible)

