### PR TITLE
issue: 2945718 Fix gcc12 compilation issue

### DIFF
--- a/config/m4/dpcp.m4
+++ b/config/m4/dpcp.m4
@@ -43,7 +43,7 @@ AS_IF([test "x$with_dpcp" == xno],
         vma_cv_dpcp_LDFLAGS="-L$with_dpcp/lib64 -Wl,--rpath,$with_dpcp/lib64"
     fi
 
-    CPPFLAGS="$vma_cv_dpcp_CPPFLAGS $CPPFLAGS"
+    CPPFLAGS="-std=c++11 $vma_cv_dpcp_CPPFLAGS $CPPFLAGS"
     CXXFLAGS="-std=c++11 $CXXFLAGS"
     LDFLAGS="$vma_cv_dpcp_LDFLAGS $LDFLAGS"
     LIBS="$vma_cv_dpcp_LIBS $LIBS"

--- a/src/vma/util/vma_list.h
+++ b/src/vma/util/vma_list.h
@@ -88,9 +88,14 @@ public :
 
 template<typename T, size_t offset(void)>
 /* coverity[missing_move_assignment] */
-class list_iterator_t : public std::iterator<std::random_access_iterator_tag, T, std::ptrdiff_t, T*, T&>
+class list_iterator_t
 {
 public:
+	using iterator_category = std::random_access_iterator_tag;
+	using value_type = T;
+	using difference_type = std::ptrdiff_t;
+	using pointer = T*;
+	using reference = T&;
 
 	list_iterator_t(T* ptr = NULL) : m_ptr(ptr) {}
 


### PR DESCRIPTION
C++17 has deprecated a few components that had been in C++ since its beginning,
and std::iterator is one of them.

Signed-off-by: Igor Ivanov <igori@nvidia.com>

## Description
Fix gcc12 compilation issue on Fedora36.

##### What
Change `std::iterator` usage

##### Why ?
RM#2945718

## Change type
What kind of change does this PR introduce?
- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Tests
- [ ] Other

## Check list
- [ ] Code follows the style de facto guidelines of this project
- [ ] Comments have been inserted in hard to understand places
- [ ] Documentation has been updated (if necessary)
- [ ] Test has been added (if possible)

