### PR TITLE
issue: 3045735 Fix no traffic during disabled sriov (azure)

### DIFF
--- a/src/vma/dev/ring_bond.cpp
+++ b/src/vma/dev/ring_bond.cpp
@@ -738,11 +738,15 @@ void ring_bond::popup_recv_rings()
 	 * Consider using ring related slave with lag_tx_port_affinity = 1
 	 * even if slave is not active.
 	 * - For NETVSC device all rings (vf and tap) should be ready for receive.
+	 * when SRIOV is off slaves.size() can be zero.
 	 */
 	for (uint32_t i = 0; i < m_bond_rings.size(); i++) {
-		for (uint32_t j = 0; j < slaves.size() ; j ++) {
-			if ((slaves[j]->if_index != m_bond_rings[i]->get_if_index()) &&
-				((p_ndev->get_is_bond() != net_device_val::NETVSC))) {
+		if (p_ndev->get_is_bond() == net_device_val::NETVSC) {
+			m_recv_rings.push_back(m_bond_rings[i]);
+			continue;
+		}
+		for (uint32_t j = 0; j < slaves.size(); j ++) {
+			if (slaves[j]->if_index != m_bond_rings[i]->get_if_index()) {
 				continue;
 			}
 			if (slaves[j]->lag_tx_port_affinity < 2) {

--- a/src/vma/dev/ring_tap.cpp
+++ b/src/vma/dev/ring_tap.cpp
@@ -360,8 +360,11 @@ void ring_tap::send_lwip_buffer(ring_user_id_t id, vma_ibv_send_wr* p_send_wqe, 
 	compute_tx_checksum((mem_buf_desc_t*)(p_send_wqe->wr_id), attr & VMA_TX_PACKET_L3_CSUM, attr & VMA_TX_PACKET_L4_CSUM);
 
 	auto_unlocker lock(m_lock_ring_tx);
+#ifdef DEFINED_TSO
+#else
 	mem_buf_desc_t* p_mem_buf_desc = (mem_buf_desc_t*)(p_send_wqe->wr_id);
 	p_mem_buf_desc->lwip_pbuf.pbuf.ref++;
+#endif /* DEFINED_TSO */
 	int ret = send_buffer(p_send_wqe, attr);
 	send_status_handler(ret, p_send_wqe);
 }


### PR DESCRIPTION
Signed-off-by: Igor Ivanov <igori@nvidia.com>

## Description
Issue happens when during switching sriov to off on established
connection.


##### What
Details: m_recv_rings is not updated because of slaves array
becames zero.

##### Why ?
RM: 3045735

## Change type
What kind of change does this PR introduce?
- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Tests
- [ ] Other

## Check list
- [x] Code follows the style de facto guidelines of this project
- [ ] Comments have been inserted in hard to understand places
- [ ] Documentation has been updated (if necessary)
- [ ] Test has been added (if possible)

