### PR TITLE
Fix segment fault issue

### DIFF
--- a/src/vma/dev/rfs_uc.cpp
+++ b/src/vma/dev/rfs_uc.cpp
@@ -143,8 +143,9 @@ bool rfs_uc::prepare_flow_spec()
 			   attach_flow_data_eth->ibv_flow_attr.attr.num_of_specs,
 			   m_flow_tag_id);
 	}
-        rfs_logfunc("transport type: %d, num_of_specs: %d flow_tag_id: %d", type,
-			   attach_flow_data_eth->ibv_flow_attr.attr.num_of_specs,
+        rfs_logfunc("transport type: %s, num_of_specs: %d flow_tag_id: %d",
+			   priv_vma_transport_type_str(type),
+			   p_attach_flow_data->ibv_flow_attr.num_of_specs,
 			   m_flow_tag_id);
 
 	m_attach_flow_data_vector.push_back(p_attach_flow_data);


### PR DESCRIPTION
When run libvma over IPoIB device, access the `attach_flow_data_eth`
will trigger segment issue, as it is NULL.

Signed-off-by: Honggang LI <honggangli@163.com>

## Description
```bash
$ ./configure --enable-opt-log=none
$ VMA_TRACELEVEL=6 LD_PRELOAD=./src/vma/.libs/libvma.so ~/udp/server.exe 7777
......
 Pid: 214208 Tid: 214213 VMA FINER: ndtm[0x18a6e20]:525:global_ring_drain_and_procces() ret_total=0
 Pid: 214208 Tid: 214213 VMA FINER: ndtm[0x18a6e20]:532:global_ring_adapt_cq_moderation() 
 Pid: 214208 Tid: 214213 VMA FINER: ndv[0x18a7ef0]:1201:ring_adapt_cq_moderation() 
 Pid: 214208 Tid: 214213 VMA FINER: evh:937:thread_loop() calling orig_os_api.epoll with 10 msec timeout
 Pid: 214208 Tid: 214208 VMA DEBUG: ring_slave[0x1982be0]:179:attach_flow() flow: dst:192.168.6.67:7777, src:0.0.0.0:0, proto:UDP, if:192.168.6.67, with sink (0x1982060), flow tag id 0 m_flow_tag_enabled: 0
Segmentation fault (core dumped)
```

```
#0  0x00007f52ff322884 in rfs_uc::prepare_flow_spec (this=0x19bc9f0) at dev/rfs_uc.cpp:146
#1  0x00007f52ff322cf3 in rfs_uc::rfs_uc (this=0x19bc9f0, flow_spec_5t=<optimized out>, p_ring=0x1982be0, rule_filter=0x19bc950, flow_tag_id=0) at ../../src/vma/dev/ring_slave.h:143
#2  0x00007f52ff38f5b1 in ring_slave::attach_flow (this=0x1982be0, flow_spec_5t=..., sink=0x1982100) at dev/ring_slave.cpp:215
#3  0x00007f52ff475603 in sockinfo::attach_receiver (this=0x1982060, flow_key=...) at sock/sockinfo.cpp:659
#4  0x00007f52ff475cfd in sockinfo::attach_as_uc_receiver (this=this@entry=0x1982060, role=role@entry=ROLE_UDP_RECEIVER, skip_rules=skip_rules@entry=false) at sock/sockinfo.cpp:1422
#5  0x00007f52ff492c8c in sockinfo_udp::on_sockname_change (this=0x1982060, __name=<optimized out>, __namelen=<optimized out>) at sock/sockinfo_udp.cpp:647
#6  0x00007f52ff4937cb in sockinfo_udp::bind (this=0x1982060, __addr=<optimized out>, __addrlen=<optimized out>) at sock/sockinfo_udp.cpp:463
#7  0x00007f52ff4d38c0 in bind (__fd=21, __addr=0x1898080, __addrlen=16) at sock/sock-redirect.cpp:983
#8  0x0000000000400ad7 in main (argc=2, argv=0x7ffe34fef578) at server.c:49

```


## Change type
What kind of change does this PR introduce?
- [ X] Bugfix
