### PR TITLE
issue: 3092555 Fixing blocking socket connect timer race

### DIFF
--- a/src/vma/sock/sockinfo_tcp.h
+++ b/src/vma/sock/sockinfo_tcp.h
@@ -283,7 +283,9 @@ private:
 	lock_spin_recursive m_tcp_con_lock;
 	bool m_timer_pending;
 
-	bool report_connected; //used for reporting 'connected' on second non-blocking call to connect.
+	// used for reporting 'connected' on second non-blocking call to connect or
+	// second call to failed connect blocking socket.
+	bool report_connected;
 
 	int m_error_status;
 
@@ -338,7 +340,7 @@ private:
 	// clone socket in accept call
 	sockinfo_tcp *accept_clone();
 	// connect() helper & callback func
-	int wait_for_conn_ready();
+	int wait_for_conn_ready_blocking();
 	static err_t connect_lwip_cb(void *arg, struct tcp_pcb *tpcb, err_t err);
 	//tx
 	unsigned tx_wait(int & err, bool is_blocking);

--- a/tests/gtest/common/base.cc
+++ b/tests/gtest/common/base.cc
@@ -163,12 +163,12 @@ int test_base::wait_fork(int pid)
 	}
 }
 
-void test_base::barrier_fork(int pid)
+void test_base::barrier_fork(int pid, bool sync_parent)
 {
 	ssize_t ret;
 
 	m_break_signal = 0;
-	if (0 == pid) {
+	if ((0 == pid && !sync_parent) || (0 != pid && sync_parent)) {
 		prctl(PR_SET_PDEATHSIG, SIGTERM);
 		do {
 			ret = read(m_efd, &m_efd_signal, sizeof(m_efd_signal));

--- a/tests/gtest/common/base.h
+++ b/tests/gtest/common/base.h
@@ -52,7 +52,7 @@ protected:
 	virtual void cleanup();
 	virtual void init();
 	bool barrier();
-	void barrier_fork(int);
+	void barrier_fork(int pid, bool sync_parent = false);
 	bool child_fork_exit() {
 		return m_break_signal;
 	}

--- a/tests/gtest/common/sys.cc
+++ b/tests/gtest/common/sys.cc
@@ -96,7 +96,7 @@ int sys_get_addr(char *dst, struct sockaddr_in *addr)
 
 	rc = getaddrinfo(dst, NULL, NULL, &res);
 	if (rc) {
-		log_error("getaddrinfo failed - invalid hostname or IP address\n");
+		log_error("getaddrinfo failed - invalid hostname or IP address %s\n", dst);
 		return rc;
 	}
 

--- a/tests/gtest/tcp/tcp_base.cc
+++ b/tests/gtest/tcp/tcp_base.cc
@@ -46,11 +46,11 @@ void tcp_base::TearDown()
 {
 }
 
-int tcp_base::sock_create(void)
+int tcp_base::sock_create(bool reuse_addr)
 {
 	int rc;
 	int fd;
-	int opt_val = 0;
+	int opt_val = (reuse_addr ? 1 : 0);
 
 	fd = socket(PF_INET, SOCK_STREAM, IPPROTO_IP);
 	if (fd < 0) {

--- a/tests/gtest/tcp/tcp_base.h
+++ b/tests/gtest/tcp/tcp_base.h
@@ -39,7 +39,7 @@
  */
 class tcp_base : virtual public testing::Test, virtual public test_base {
 public:
-    static int sock_create(void);
+    static int sock_create(bool reuse_addr = false);
     static int sock_create_nb(void);
 
 protected:

--- a/tests/gtest/tcp/tcp_connect.cc
+++ b/tests/gtest/tcp/tcp_connect.cc
@@ -34,7 +34,8 @@
 #include "common/log.h"
 #include "common/sys.h"
 #include "common/base.h"
-
+#include <list>
+#include <algorithm>
 #include "tcp_base.h"
 
 class tcp_connect : public tcp_base {};
@@ -132,4 +133,174 @@ TEST_F(tcp_connect, DISABLED_ti_3) {
 	}
 
 	close(fd);
+}
+
+/**
+ * @test tcp_connect.ti_4_rto_racing
+ * @brief
+ *    Loop of blocking connect() to unreachable ip
+ * @details
+ */
+TEST_F(tcp_connect, ti_4_rto_racing)
+{
+    int pid = fork();
+
+    if (0 == pid) { /* I am the child */
+        int lfd = tcp_base::sock_create(true);
+        ASSERT_LE(0, lfd);
+
+        int rc = bind(lfd, (struct sockaddr *)&server_addr, sizeof(server_addr));
+        ASSERT_EQ(0, rc);
+
+        rc = listen(lfd, 1024);
+        ASSERT_EQ(0, rc);
+
+        barrier_fork(pid, true);
+
+        int fd = accept(lfd, nullptr, nullptr);
+        ASSERT_LE(0, fd);
+
+        close(fd);
+        close(lfd);
+
+        // This exit is very important, otherwise the fork
+        // keeps running and may duplicate other tests.
+        exit(testing::Test::HasFailure());
+    } else { /* I am the parent */
+        auto connect_fn = [](const sockaddr_in &server_addr_in, std::list<int> &fns,
+                             int rts) -> int {
+            int fd = tcp_base::sock_create();
+            EXPECT_LE(0, fd);
+            if (fd <= 0) {
+                return fd;
+            }
+
+            struct timeval tv;
+            tv.tv_sec = 1;
+            tv.tv_usec = 0;
+            int rc = setsockopt(fd, SOL_SOCKET, SO_RCVTIMEO, &tv, sizeof(tv));
+            EXPECT_EQ(0, rc);
+            if (rc != 0) {
+                close(fd);
+                return -1;
+            }
+
+            log_trace("Connecting...\n");
+            while (--rts >= 0) {
+                log_trace("Connecting... %d\n", rts);
+                rc = connect(fd, reinterpret_cast<const sockaddr *>(&server_addr_in),
+                             sizeof(server_addr_in));
+
+                if (0 == rc) {
+                    fns.push_back(fd);
+                    log_trace("Connected %zu sockets.\n", fns.size());
+                    return fd;
+                }
+
+                sleep(3);
+            }
+
+            close(fd);
+            return -1;
+        };
+
+        std::list<int> fns;
+
+        barrier_fork(pid, true);
+
+        int retries = 2;
+        while (connect_fn(server_addr, fns, 2) > 0 || --retries > 0)
+            ;
+
+        ASSERT_EQ(0, wait_fork(pid));
+
+        std::for_each(std::begin(fns), std::end(fns), [](int fd) { EXPECT_EQ(0, close(fd)); });
+    }
+}
+
+/**
+ * @test tcp_connect.ti_5_multi_connect
+ * @brief
+ *    Multiple connect on the same socket
+ * @details
+ */
+TEST_F(tcp_connect, ti_5_multi_connect)
+{
+    int fd = tcp_base::sock_create();
+    ASSERT_LE(0, fd);
+
+    struct timeval tv;
+    tv.tv_sec = 1;
+    tv.tv_usec = 0;
+    int rc = setsockopt(fd, SOL_SOCKET, SO_RCVTIMEO, &tv, sizeof(tv));
+    EXPECT_EQ(0, rc);
+    if (rc != 0) {
+        close(fd);
+    }
+
+    // Failing connect
+    rc = connect(fd, reinterpret_cast<const sockaddr *>(&server_addr), sizeof(server_addr));
+    ASSERT_NE(0, rc);
+
+    int pid = fork();
+
+    if (0 == pid) { /* I am the child */
+        rc = -1;
+        int lfd = tcp_base::sock_create(true);
+        if (lfd > 0) {
+            rc = bind(lfd, (struct sockaddr *)&server_addr, sizeof(server_addr));
+            if (rc != 0) {
+                log_trace("Bind errno: %d\n", errno);
+            } else {
+                rc = listen(lfd, 1024);
+                if (rc == 0) {
+                    barrier_fork(pid, true);
+                    fd = accept(lfd, nullptr, nullptr);
+                    if (fd > 0) {
+                        close(fd);
+                    }
+                } else {
+                    log_trace("Listen errno: %d\n", errno);
+                }
+            }
+
+            close(lfd);
+        }
+
+        if (rc != 0) {
+            barrier_fork(pid, true);
+        }
+
+        // This exit is very important, otherwise the fork
+        // keeps running and may duplicate other tests.
+        exit(testing::Test::HasFailure());
+    } else { /* I am the parent */
+        barrier_fork(pid, true);
+
+        rc = connect(fd, reinterpret_cast<const sockaddr *>(&server_addr), sizeof(server_addr));
+        EXPECT_TRUE(0 == rc || errno == ECONNABORTED);
+        if (rc != 0) {
+            log_trace("Connected errno: %d\n", errno);
+        }
+
+        rc = close(fd);
+        EXPECT_EQ(0, rc);
+
+        // Get the child process out of the accept.
+        rc = -1;
+        fd = tcp_base::sock_create();
+        if (fd > 0) {
+            rc = connect(fd, reinterpret_cast<const sockaddr *>(&server_addr), sizeof(server_addr));
+            if (rc != 0) {
+                log_trace("Final connected errno: %d\n", errno);
+            }
+            close(fd);
+        }
+
+        if (0 != rc) {
+            kill(pid, SIGKILL);
+        }
+
+        wait_fork(pid);
+    }
 }


### PR DESCRIPTION
Signed-off-by: Alexander Grissik <agrissik@nvidia.com>

## Description
When a blocking connect() returns with an error, it may already start a timer. So in case the internal threads tries to rto the SYN a segmentation fault occurs. 

##### What
Timer should not be started for failed blocking connect()
Reproductive gtests added.

##### Why ?
Fixing segmentation fault.

##### How ?
Start timer only for non-blocking socket connect() or successful connect() of a blocking socket.

## Change type
What kind of change does this PR introduce?
- [X] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Tests
- [ ] Other

## Check list
- [ ] Code follows the style de facto guidelines of this project
- [ ] Comments have been inserted in hard to understand places
- [ ] Documentation has been updated (if necessary)
- [ ] Test has been added (if possible)

