### PR TITLE
issue: 3092554 Use VMA_HANDLE_SIGINTR for signal() API

### DIFF
--- a/src/vma/sock/sock-redirect.cpp
+++ b/src/vma/sock/sock-redirect.cpp
@@ -2873,15 +2873,17 @@ extern "C"
 EXPORT_SYMBOL
 sighandler_t signal(int signum, sighandler_t handler)
 {
-	srdr_logdbg_entry("signum=%d, handler=%p", signum, handler);
-
 	if (!orig_os_api.signal) get_orig_funcs();
 
-	if (handler && handler != SIG_ERR && handler != SIG_DFL && handler != SIG_IGN) {
-		// Only SIGINT is supported for now
-		if (signum == SIGINT) {
-			g_sighandler = handler;
-			return orig_os_api.signal(SIGINT, &handle_signal);
+	if (safe_mce_sys().handle_sigintr) {
+		srdr_logdbg_entry("signum=%d, handler=%p", signum, handler);
+
+		if (handler && handler != SIG_ERR && handler != SIG_DFL && handler != SIG_IGN) {
+			// Only SIGINT is supported for now
+			if (signum == SIGINT) {
+				g_sighandler = handler;
+				return orig_os_api.signal(SIGINT, &handle_signal);
+			}
 		}
 	}
 


### PR DESCRIPTION
Signed-off-by: Alexander Grissik <agrissik@nvidia.com>

## Description
The signal() API does not take into consideration the VMA_HANDLE_SIGINTR env flag.

##### What
Make signal() to consider VMA_HANDLE_SIGINTR.

##### Why ?
Currently, there is no way to disable VMA SIGINT overtake.

## Change type
What kind of change does this PR introduce?
- [ ] Bugfix
- [X] Feature
- [ ] Code style update
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Tests
- [ ] Other

## Check list
- [ ] Code follows the style de facto guidelines of this project
- [ ] Comments have been inserted in hard to understand places
- [ ] Documentation has been updated (if necessary)
- [ ] Test has been added (if possible)

