### PR TITLE
issue: 3092555 Fix connect timeout return value

### DIFF
--- a/src/vma/sock/sockinfo_tcp.cpp
+++ b/src/vma/sock/sockinfo_tcp.cpp
@@ -3169,12 +3169,12 @@ int sockinfo_tcp::wait_for_conn_ready_blocking()
 
 	}
 	if (m_conn_state != TCP_CONN_CONNECTED) {
-		m_conn_state = TCP_CONN_FAILED;
 		if (m_conn_state == TCP_CONN_TIMEOUT) {
 			errno = ETIMEDOUT;
 		} else {
 			errno = ECONNREFUSED;
 		}
+		m_conn_state = TCP_CONN_FAILED;
 		si_tcp_logdbg("bad connect -> timeout or none listening");
 		return -1;
 	}


### PR DESCRIPTION
## Description
Fix #992. `m_conn_state` value is overwritten before it's used in a condition.

##### What
Fix #992.

##### Why ?
Bugfix

## Change type
What kind of change does this PR introduce?
- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Tests
- [ ] Other

## Check list
- [ ] Code follows the style de facto guidelines of this project
- [ ] Comments have been inserted in hard to understand places
- [ ] Documentation has been updated (if necessary)
- [ ] Test has been added (if possible)

