### PR TITLE
issue: 3092555 Cont for PR992: Blocking socket connect race

### DIFF
--- a/tests/gtest/tcp/tcp_connect.cc
+++ b/tests/gtest/tcp/tcp_connect.cc
@@ -290,9 +290,14 @@ TEST_F(tcp_connect, ti_5_multi_connect)
         rc = -1;
         fd = tcp_base::sock_create();
         if (fd > 0) {
-            rc = connect(fd, reinterpret_cast<const sockaddr *>(&server_addr), sizeof(server_addr));
-            if (rc != 0) {
-                log_trace("Final connected errno: %d\n", errno);
+            rc = setsockopt(fd, SOL_SOCKET, SO_RCVTIMEO, &tv, sizeof(tv));
+            EXPECT_EQ(0, rc);
+            if (rc == 0) {
+                rc = connect(fd, reinterpret_cast<const sockaddr *>(&server_addr),
+                             sizeof(server_addr));
+                if (rc != 0) {
+                    log_trace("Final connected errno: %d\n", errno);
+                }
             }
             close(fd);
         }


### PR DESCRIPTION
Signed-off-by: Alexander Grissik <agrissik@nvidia.com>

## Description
Fixing issue of no SYN rexmit due to previous timer change.
Refactoring the solution.

##### What
Continuation for PR 992.

##### Why ?
Fixing no SYN rexmits + refactoring.

## Change type
What kind of change does this PR introduce?
- [X] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Tests
- [ ] Other

## Check list
- [X] Code follows the style de facto guidelines of this project
- [X] Comments have been inserted in hard to understand places
- [ ] Documentation has been updated (if necessary)
- [ ] Test has been added (if possible)

