### PR TITLE
issue: 3092555 Fixing pcb resources leak for failed blocking connect

### DIFF
--- a/src/vma/sock/sockinfo_tcp.cpp
+++ b/src/vma/sock/sockinfo_tcp.cpp
@@ -2272,7 +2272,7 @@ int sockinfo_tcp::connect(const sockaddr *__to, socklen_t __tolen)
 			m_conn_state = TCP_CONN_FAILED;
 		}
 
-		set_tcp_state(&m_pcb, CLOSED);
+		tcp_close(&m_pcb);
 
 		destructor_helper();
 		unlock_tcp_con();


### PR DESCRIPTION
Signed-off-by: Alexander Grissik <agrissik@nvidia.com>

## Description
PCB resource leak for failing connect blocking socket.

##### What
Setting pcb state manually to CLOSED, prevents it to be cleared correctly in subsequent tcp_close which should clear pcb resources.

##### Why ?
Resource leak.

##### How ?
Use tcp_close instead of manually setting tcp_sate

## Change type
What kind of change does this PR introduce?
- [X] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Tests
- [ ] Other

## Check list
- [X] Code follows the style de facto guidelines of this project
- [ ] Comments have been inserted in hard to understand places
- [ ] Documentation has been updated (if necessary)
- [ ] Test has been added (if possible)

