### PR TITLE
issue: 3173318 Fixing the handling of null elements in iov tx vector.

### DIFF
--- a/src/vma/proto/dst_entry_udp.h
+++ b/src/vma/proto/dst_entry_udp.h
@@ -69,6 +69,7 @@ private:
 
 	inline ssize_t fast_send_not_fragmented(const iovec* p_iov, const ssize_t sz_iov, vma_wr_tx_packet_attr attr, size_t sz_udp_payload, ssize_t sz_data_payload);
 	ssize_t fast_send_fragmented(const iovec* p_iov, const ssize_t sz_iov, vma_wr_tx_packet_attr attr, size_t sz_udp_payload, ssize_t sz_data_payload);
+	ssize_t check_payload_size(const iovec* p_iov, ssize_t sz_iov);
 
 	const uint32_t m_n_sysvar_tx_bufs_batch_udp;
 	const bool m_b_sysvar_tx_nonblocked_eagains;

--- a/src/vma/sock/sockinfo_tcp.cpp
+++ b/src/vma/sock/sockinfo_tcp.cpp
@@ -757,11 +757,9 @@ ssize_t sockinfo_tcp::tx(vma_tx_call_attr_t &tx_arg)
 	 * inconsistencies in setting errno values
 	 */
 	if (unlikely((m_sock_offload != TCP_SOCK_LWIP) ||
-			(NULL == p_iov) ||
-			(0 >= sz_iov) ||
-			(NULL == p_iov[0].iov_base))) {
+			unlikely(NULL == p_iov) || unlikely(0 >= sz_iov))) {
 		goto tx_packet_to_os;
-		}
+	}
 
 #ifdef VMA_TIME_MEASURE
 	TAKE_T_TX_START;
@@ -770,7 +768,6 @@ ssize_t sockinfo_tcp::tx(vma_tx_call_attr_t &tx_arg)
 retry_is_ready:
 
 	if (unlikely(!is_rts())) {
-
 		if (m_conn_state == TCP_CONN_CONNECTING) {
 			si_tcp_logdbg("TX while async-connect on socket go to poll");
 			rx_wait_helper(poll_count, false);
@@ -828,6 +825,9 @@ retry_is_ready:
 
 	for (int i = 0; i < sz_iov; i++) {
 		si_tcp_logfunc("iov:%d base=%p len=%d", i, p_iov[i].iov_base, p_iov[i].iov_len);
+		if (unlikely(!p_iov[i].iov_base)) {
+			continue;
+		}
 
 		pos = 0;
 		tx_ptr = p_iov[i].iov_base;

--- a/src/vma/util/utils.cpp
+++ b/src/vma/util/utils.cpp
@@ -342,7 +342,7 @@ int memcpy_fromiovec(u_int8_t* p_dst, const struct iovec* p_iov, size_t sz_iov, 
 	/* Copy len size into pBuf */
 	int n_total = 0;
 	while (n_iovpos < (int)sz_iov && sz_data > 0) {
-		if (p_iov[n_iovpos].iov_len)
+		if (likely(p_iov[n_iovpos].iov_len) && likely(p_iov[n_iovpos].iov_base))
 		{
 			u_int8_t* p_src = ((u_int8_t*)(p_iov[n_iovpos].iov_base)) + sz_src_start_offset;
 			int sz_data_block_to_copy = min(sz_data, p_iov[n_iovpos].iov_len - sz_src_start_offset);

--- a/tests/gtest/common/base.cc
+++ b/tests/gtest/common/base.cc
@@ -76,6 +76,14 @@ void test_base::cleanup()
 {
 }
 
+int test_base::set_socket_rcv_timeout(int fd, int timeout_sec)
+{
+    struct timeval tv;
+    tv.tv_sec = timeout_sec;
+    tv.tv_usec = 0;
+    return setsockopt(fd, SOL_SOCKET, SO_RCVTIMEO, &tv, sizeof(tv));
+}
+
 bool test_base::barrier()
 {
     int ret = pthread_barrier_wait(&m_barrier);

--- a/tests/gtest/common/base.h
+++ b/tests/gtest/common/base.h
@@ -33,6 +33,18 @@
 #ifndef TESTS_GTEST_COMMON_BASE_H_
 #define TESTS_GTEST_COMMON_BASE_H_
 
+#define DO_WHILE0(x)                                                                               \
+    do {                                                                                           \
+        x                                                                                          \
+    } while (0)
+
+#define EXPECT_LE_ERRNO(val1, val2)                                                                \
+    DO_WHILE0(EXPECT_LE((val1), (val2));                                                           \
+              if (val1 > val2) { log_trace("Failed. errno = %d\n", errno); })
+
+#define EXPECT_EQ_ERRNO(val1, val2)                                                                \
+    DO_WHILE0(EXPECT_EQ((val1), (val2));                                                           \
+              if (val1 != val2) { log_trace("Failed. errno = %d\n", errno); })
 
 /**
  * Base class for tests
@@ -42,6 +54,7 @@ public:
 	static int sock_noblock(int fd);
 	static int event_wait(struct epoll_event *event);
 	static int wait_fork(int pid);
+	static int set_socket_rcv_timeout(int fd, int timeout_sec);
 	static void handle_signal(int signo);
 
 protected:

--- a/tests/gtest/tcp/tcp_send.cc
+++ b/tests/gtest/tcp/tcp_send.cc
@@ -29,14 +29,12 @@
  * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
-
+#include <sys/uio.h>
 #include "common/def.h"
 #include "common/log.h"
 #include "common/sys.h"
 #include "common/base.h"
-
 #include "tcp_base.h"
-
 
 class tcp_send : public tcp_base {};
 
@@ -94,4 +92,156 @@ TEST_F(tcp_send, ti_2) {
 	(void)signal(SIGPIPE, SIG_DFL);
 
 	close(fd);
+}
+
+/**
+ * @test tcp_send.null_iov_elements
+ * @brief
+ *    Sending null iov elements.
+ *
+ * @details
+ */
+TEST_F(tcp_send, null_iov_elements) {
+	std::string buff1("abcd");
+	std::string buff2("efgh");
+	std::string buff3("ijkl");
+	std::string buff4("mnop");
+	char buff5[] = "Dummy Control";
+
+	int pid = fork();
+	if (0 == pid) {  // Child
+		barrier_fork(pid);
+
+		int fd = tcp_base::sock_create();
+		EXPECT_LE_ERRNO(0, fd);
+		if (0 <= fd) {
+			int rc = set_socket_rcv_timeout(fd, 5);
+			EXPECT_EQ_ERRNO(0, rc);
+
+			log_trace("Establishing connection: fd=%d to %s from %s\n", fd,
+					  sys_addr2str(&server_addr), sys_addr2str(&client_addr));
+
+			rc = bind(fd, reinterpret_cast<sockaddr *>(&client_addr), sizeof(client_addr));
+			EXPECT_EQ_ERRNO(0, rc);
+			if (0 == rc) {
+				rc = connect(fd, reinterpret_cast<sockaddr *>(&server_addr), sizeof(server_addr));
+				EXPECT_EQ_ERRNO(0, rc);
+				if (0 == rc) {
+					log_trace("Established connection.\n");
+
+					iovec vec[4];
+					vec[0].iov_base = nullptr;
+					vec[0].iov_len = 0U;
+					vec[1].iov_base = const_cast<std::string::value_type *>(buff1.data());
+					vec[1].iov_len = buff1.size();
+					vec[2].iov_base = nullptr;
+					vec[2].iov_len = 0U;
+					vec[3].iov_base = const_cast<std::string::value_type *>(buff2.data());
+					vec[3].iov_len = buff2.size();
+
+					ssize_t rcs = writev(fd, vec, sizeof(vec) / sizeof(iovec));
+					EXPECT_EQ_ERRNO(static_cast<ssize_t>(vec[1].iov_len + vec[3].iov_len), rcs);
+					log_trace("Sent1: %zd.\n", rcs);
+
+					vec[1].iov_base = const_cast<std::string::value_type *>(buff3.data());
+					vec[1].iov_len = buff3.size();
+					vec[3].iov_base = const_cast<std::string::value_type *>(buff4.data());
+					vec[3].iov_len = buff4.size();
+
+					msghdr msg;
+					msg.msg_iov = vec;
+					msg.msg_iovlen = sizeof(vec) / sizeof(iovec);
+					msg.msg_name = nullptr;
+					msg.msg_namelen = 0U;
+					msg.msg_control = nullptr;
+					msg.msg_controllen = 0;
+					rcs = sendmsg(fd, &msg, 0);
+					EXPECT_EQ_ERRNO(static_cast<ssize_t>(vec[1].iov_len + vec[3].iov_len), rcs);
+					log_trace("Sent2: %zd.\n", rcs);
+
+					vec[1].iov_len = 0U;
+					vec[3].iov_base = nullptr;
+					vec[3].iov_len = 0U;
+					rcs = sendmsg(fd, &msg, 0);
+					EXPECT_EQ_ERRNO(0U, rcs);
+					log_trace("Sent3: %zd.\n", rcs);
+
+					vec[1].iov_base = nullptr;
+					rcs = sendmsg(fd, &msg, 0);
+					EXPECT_EQ_ERRNO(0U, rcs);
+					log_trace("Sent4: %zd.\n", rcs);
+
+					vec[0].iov_base = nullptr;
+					vec[0].iov_len = 0U;
+					msg.msg_iovlen = 1U;
+					msg.msg_control = buff5;
+					msg.msg_controllen = sizeof(buff5);
+					rcs = sendmsg(fd, &msg, 0);
+
+					// Kernel checks access for every iov memory address and in this case returns errno=14.
+					// VMA can handle this situation and just igonre this element and saving CPU cycles.
+					vec[1].iov_len = 1000U;
+					rcs = sendmsg(fd, &msg, 0);
+					EXPECT_LE_ERRNO(rcs, 0);
+					EXPECT_TRUE(rcs == 0 || 14 == errno);
+					log_trace("Sent5: %zd.\n", rcs);
+
+					peer_wait(fd);
+				}
+			}
+
+			close(fd);
+		}
+
+		/* This exit is very important, otherwise the fork
+		 * keeps running and may duplicate other tests.
+		 */
+		exit(testing::Test::HasFailure());
+	} else {  /* I am the parent */
+		int l_fd = tcp_base::sock_create();
+		EXPECT_LE_ERRNO(0, l_fd);
+		if (0 <= l_fd) {
+			int rc = set_socket_rcv_timeout(l_fd, 5);
+			EXPECT_EQ_ERRNO(0, rc);
+
+			rc = bind(l_fd, reinterpret_cast<sockaddr *>(&server_addr), sizeof(server_addr));
+			EXPECT_EQ_ERRNO(0, rc);
+			if (0 == rc) {
+				rc = listen(l_fd, 5);
+				EXPECT_EQ_ERRNO(0, rc);
+				if (0 == rc) {
+					barrier_fork(pid);
+
+					int fd = accept(l_fd, nullptr, 0U);
+					EXPECT_LE_ERRNO(0, fd);
+					if (0 <= fd) {
+						log_trace("Accepted connection: fd=%d\n", fd);
+
+						char buff[32] = {0};
+						size_t received = 0U;
+						size_t recvsize = buff1.size() + buff2.size() + buff3.size() + buff4.size();
+						while (received < recvsize) {
+							rc = recv(fd, buff + received, sizeof(buff) - received, 0);
+							if (0 == rc || (rc < 0 && errno != EINTR)) {
+								break;
+							}
+
+							received += static_cast<size_t>(rc);
+							log_trace("Received %zd\n", received);
+						}
+
+						log_trace("Received Final %zd\n", received);
+						std::string result = buff1 + buff2 + buff3 + buff4;
+						EXPECT_EQ(result, std::string(buff));
+
+						close(fd);
+					}
+				}
+			}
+
+			close(l_fd);
+		}
+
+		EXPECT_EQ(0, wait_fork(pid));
+	}
 }

--- a/tests/gtest/udp/udp_send.cc
+++ b/tests/gtest/udp/udp_send.cc
@@ -30,6 +30,8 @@
  * SOFTWARE.
  */
 
+#include <sys/uio.h>
+#include <string>
 #include "common/def.h"
 #include "common/log.h"
 #include "common/sys.h"
@@ -65,9 +67,9 @@ TEST_F(udp_send, ti_1) {
 	EXPECT_EQ(0, rc);
 
 	errno = EOK;
-	rc = send(fd, (void *)buf, sizeof(buf), 0);
+	ssize_t rcz = send(fd, (void *)buf, sizeof(buf), 0);
 	EXPECT_EQ(EOK, errno);
-	EXPECT_EQ(sizeof(buf), rc);
+	EXPECT_EQ(static_cast<ssize_t>(sizeof(buf)), rcz);
 
 	close(fd);
 }
@@ -228,9 +230,336 @@ TEST_F(udp_send, ti_6) {
 	EXPECT_EQ(0, rc);
 
 	errno = EOK;
-	rc = send(fd, (void *)buf, sizeof(buf), 0);
+	ssize_t rcz = send(fd, (void *)buf, sizeof(buf), 0);
 	EXPECT_EQ(EOK, errno);
-	EXPECT_EQ(sizeof(buf), rc);
+	EXPECT_EQ(static_cast<ssize_t>(sizeof(buf)), rcz);
 
 	close(fd);
+}
+
+/**
+ * @test udp_send.null_iov_elements
+ * @brief
+ *    Sending null iov elements.
+ *
+ * @details
+ */
+TEST_F(udp_send, null_iov_elements) {
+	std::string buff1("abcd");
+	std::string buff2("efgh");
+	std::string buff3("ijkl");
+	std::string buff4("mnop");
+
+	int pid = fork();
+	if (0 == pid) {  // Child
+		barrier_fork(pid);
+
+		int fd = udp_base::sock_create();
+		EXPECT_LE_ERRNO(0, fd);
+		if (0 <= fd) {
+			iovec vec[4];
+			vec[0].iov_base = nullptr;
+			vec[0].iov_len = 0U;
+			vec[1].iov_base = const_cast<std::string::value_type *>(buff1.data());
+			vec[1].iov_len = buff1.size();
+			vec[2].iov_base = nullptr;
+			vec[2].iov_len = 0U;
+			vec[3].iov_base = const_cast<std::string::value_type *>(buff2.data());
+			vec[3].iov_len = buff2.size();
+
+			msghdr msg;
+			msg.msg_iov = vec;
+			msg.msg_iovlen = sizeof(vec) / sizeof(iovec);
+			msg.msg_name = &server_addr;
+			msg.msg_namelen = sizeof(server_addr);
+			msg.msg_control = nullptr;
+			msg.msg_controllen = 0;
+
+			ssize_t rcs = sendmsg(fd, &msg, 0);
+			EXPECT_EQ_ERRNO(static_cast<ssize_t>(vec[1].iov_len + vec[3].iov_len), rcs);
+			log_trace("Sent1: %zd.\n", rcs);
+
+			vec[1].iov_base = const_cast<std::string::value_type *>(buff3.data());
+			vec[1].iov_len = buff3.size();
+			vec[3].iov_base = const_cast<std::string::value_type *>(buff4.data());
+			vec[3].iov_len = buff4.size();
+
+			rcs = sendmsg(fd, &msg, 0);
+			EXPECT_EQ_ERRNO(static_cast<ssize_t>(vec[1].iov_len + vec[3].iov_len), rcs);
+			log_trace("Sent2: %zd.\n", rcs);
+
+			vec[1].iov_len = 0U;
+			vec[3].iov_base = nullptr;
+			vec[3].iov_len = 0U;
+			rcs = sendmsg(fd, &msg, 0);
+			EXPECT_EQ_ERRNO(0U, rcs);
+			log_trace("Sent3: %zd.\n", rcs);
+
+			vec[1].iov_base = nullptr;
+			rcs = sendmsg(fd, &msg, 0);
+			EXPECT_EQ_ERRNO(0U, rcs);
+			log_trace("Sent4: %zd.\n", rcs);
+
+			vec[1].iov_len = 1000U;
+			rcs = sendmsg(fd, &msg, 0);
+			EXPECT_LE_ERRNO(rcs, -1);
+			EXPECT_TRUE(14 == errno);
+			log_trace("Sent5: %zd.\n", rcs);
+
+			close(fd);
+		}
+
+		/* This exit is very important, otherwise the fork
+		 * keeps running and may duplicate other tests.
+		 */
+		exit(testing::Test::HasFailure());
+	} else {  /* I am the parent */
+		int fd = udp_base::sock_create();
+		EXPECT_LE_ERRNO(0, fd);
+		if (0 <= fd) {
+			int rc = set_socket_rcv_timeout(fd, 5);
+			EXPECT_EQ_ERRNO(0, rc);
+
+			rc = bind(fd, reinterpret_cast<sockaddr *>(&server_addr), sizeof(server_addr));
+			EXPECT_EQ_ERRNO(0, rc);
+			if (0 == rc) {
+				barrier_fork(pid);
+
+				char buff[32] = {0};
+				size_t received = 0U;
+				size_t recvsize = buff1.size() + buff2.size() + buff3.size() + buff4.size();
+				while (received < recvsize) {
+					rc = recv(fd, buff + received, sizeof(buff) - received, 0);
+					if (rc < 0 && errno != EINTR) {
+						break;
+					}
+
+					received += static_cast<size_t>(rc);
+					log_trace("Received %zd\n", received);
+				}
+
+				log_trace("Received Final %zd\n", received);
+				std::string result = buff1 + buff2 + buff3 + buff4;
+				EXPECT_EQ(result, std::string(buff));
+
+				rc = recv(fd, buff, sizeof(buff), 0);
+				EXPECT_EQ_ERRNO(0, rc);
+			}
+
+			close(fd);
+		}
+
+		EXPECT_EQ(0, wait_fork(pid));
+	}
+}
+
+/**
+ * @test udp_send.null_iov_elements_single_iov
+ * @brief
+ *    Sending null iov elements fragmented.
+ *
+ * @details
+ */
+TEST_F(udp_send, null_iov_elements_single_iov) {
+	std::string buff3("efgh");
+	char buff4[] = "Dummy Control";
+
+	int pid = fork();
+	if (0 == pid) {  // Child
+		barrier_fork(pid);
+
+		int fd = udp_base::sock_create();
+		EXPECT_LE_ERRNO(0, fd);
+		if (0 <= fd) {
+			int rc = connect(fd, reinterpret_cast<sockaddr *>(&server_addr), sizeof(server_addr));
+			EXPECT_EQ_ERRNO(0, rc);
+
+			iovec vec[1];
+			vec[0].iov_base = const_cast<std::string::value_type *>(buff3.data());
+			vec[0].iov_len = buff3.size();
+
+			ssize_t rcs = writev(fd, vec, sizeof(vec) / sizeof(iovec));
+			EXPECT_EQ_ERRNO(static_cast<ssize_t>(buff3.size()), rcs);
+
+			vec[0].iov_base = nullptr;
+			vec[0].iov_len = 0U;
+			msghdr msg;
+			msg.msg_iov = vec;
+			msg.msg_iovlen = 1U;
+			msg.msg_name = &server_addr;
+			msg.msg_namelen = sizeof(server_addr);
+			msg.msg_control = nullptr;
+			msg.msg_controllen = 0;
+			rcs = sendmsg(fd, &msg, 0); // Kernel writev doe not send empty packet.
+			EXPECT_EQ_ERRNO(0U, rcs);
+
+			msg.msg_control = buff4;
+			msg.msg_controllen = sizeof(buff4);
+
+			rcs = sendmsg(fd, &msg, 0); // Kernel writev doe not send empty packet.
+			EXPECT_EQ_ERRNO(0U, rcs);
+
+			close(fd);
+		}
+
+		/* This exit is very important, otherwise the fork
+		 * keeps running and may duplicate other tests.
+		 */
+		exit(testing::Test::HasFailure());
+	} else {  /* I am the parent */
+		int fd = udp_base::sock_create();
+		EXPECT_LE_ERRNO(0, fd);
+		if (0 <= fd) {
+			int rc = set_socket_rcv_timeout(fd, 5);
+			EXPECT_EQ_ERRNO(0, rc);
+
+			rc = bind(fd, reinterpret_cast<sockaddr *>(&server_addr), sizeof(server_addr));
+			EXPECT_EQ_ERRNO(0, rc);
+			if (0 == rc) {
+				barrier_fork(pid);
+
+				char buff[32];
+				ssize_t rcz = recv(fd, buff, sizeof(buff), 0);
+				EXPECT_EQ_ERRNO(static_cast<ssize_t>(buff3.size()), rcz);
+				EXPECT_TRUE(0 == memcmp(buff, buff3.c_str(), buff3.size()));
+
+				rc = recv(fd, buff, sizeof(buff), 0);
+				EXPECT_EQ_ERRNO(0, rc);
+
+				rc = recv(fd, buff, sizeof(buff), 0);
+				EXPECT_EQ_ERRNO(0, rc);
+			}
+
+			close(fd);
+		}
+
+		EXPECT_EQ(0, wait_fork(pid));
+	}
+}
+
+/**
+ * @test udp_send.null_iov_elements_too_big_msg
+ * @brief
+ *    Sending null iov elements with send size > 65507.
+ *
+ * @details
+ */
+TEST_F(udp_send, null_iov_elements_too_big_msg) {
+	std::vector<char> vec_data(65508);
+	std::vector<char> vec_data2(35000);
+
+	int fd = udp_base::sock_create();
+	EXPECT_LE_ERRNO(0, fd);
+	if (0 <= fd) {
+		iovec vec[2];
+		vec[0].iov_base = vec_data.data();
+		vec[0].iov_len = vec_data.size();
+
+		msghdr msg;
+		msg.msg_iov = vec;
+		msg.msg_iovlen = 1U;
+		msg.msg_name = &server_addr;
+		msg.msg_namelen = sizeof(server_addr);
+		msg.msg_control = nullptr;
+		msg.msg_controllen = 0;
+		ssize_t rcs = sendmsg(fd, &msg, 0);
+		EXPECT_LE_ERRNO(rcs, -1);
+		EXPECT_EQ(EMSGSIZE, errno);
+
+		vec[0].iov_base = vec_data2.data();
+		vec[0].iov_len = vec_data2.size();
+		vec[1].iov_base = vec_data2.data();
+		vec[1].iov_len = vec_data2.size();
+		msg.msg_iovlen = 2U;
+
+		rcs = sendmsg(fd, &msg, 0);
+		EXPECT_LE_ERRNO(rcs, -1);
+		EXPECT_EQ(EMSGSIZE, errno);
+
+		close(fd);
+	}
+}
+
+/**
+ * @test udp_send.DISABLED_null_iov_elements_fragmented
+ * @brief
+ *    Sending null iov elements fragmented.
+ *
+ * @details
+ */
+TEST_F(udp_send, DISABLED_null_iov_elements_fragmented) {
+	char buff1[8000] = {0};
+	char buff2[8000] = {0};
+
+	int pid = fork();
+	if (0 == pid) {  // Child
+		barrier_fork(pid);
+
+		int fd = udp_base::sock_create();
+		EXPECT_LE_ERRNO(0, fd);
+		if (0 <= fd) {
+			int rc = connect(fd, reinterpret_cast<sockaddr *>(&server_addr), sizeof(server_addr));
+			EXPECT_EQ_ERRNO(0, rc);
+
+			iovec vec[4];
+			vec[0].iov_base = nullptr;
+			vec[0].iov_len = 0U;
+			vec[1].iov_base = buff1;
+			vec[1].iov_len = sizeof(buff1);
+			vec[2].iov_base = nullptr;
+			vec[2].iov_len = 0U;
+			vec[3].iov_base = buff2;
+			vec[3].iov_len = sizeof(buff2);
+
+			ssize_t rcs = writev(fd, vec, sizeof(vec) / sizeof(iovec));
+			EXPECT_EQ_ERRNO(static_cast<ssize_t>(sizeof(buff1) + sizeof(buff2)), rcs);
+
+			rcs = writev(fd, vec + 1, 1U);
+			EXPECT_EQ_ERRNO(static_cast<ssize_t>(sizeof(buff1)), rcs);
+
+			close(fd);
+		}
+
+		/* This exit is very important, otherwise the fork
+		 * keeps running and may duplicate other tests.
+		 */
+		exit(testing::Test::HasFailure());
+	} else {  /* I am the parent */
+		int fd = udp_base::sock_create();
+		EXPECT_LE_ERRNO(0, fd);
+		if (0 <= fd) {
+			int rc = set_socket_rcv_timeout(fd, 5);
+			EXPECT_EQ_ERRNO(0, rc);
+
+			rc = bind(fd, reinterpret_cast<sockaddr *>(&server_addr), sizeof(server_addr));
+			EXPECT_EQ_ERRNO(0, rc);
+			if (0 == rc) {
+				barrier_fork(pid);
+
+				size_t recvsize = sizeof(buff1) + sizeof(buff1) + sizeof(buff2);
+				std::vector<char> vec(recvsize);
+				size_t received = 0U;
+
+				while (received < recvsize) {
+					rc = recv(fd, vec.data() + received, vec.size(), 0);
+					if (rc < 0 && errno != EINTR) {
+						break;
+					}
+
+					received += static_cast<size_t>(rc);
+					log_trace("Received %d\n", rc);
+				}
+
+				log_trace("Received Final %zd\n", received);
+				const char *raw_buff = vec.data();
+				EXPECT_TRUE(0 == memcmp(raw_buff, buff1, sizeof(buff1))); raw_buff += sizeof(buff1);
+				EXPECT_TRUE(0 == memcmp(raw_buff, buff2, sizeof(buff2))); raw_buff += sizeof(buff2);
+				EXPECT_TRUE(0 == memcmp(raw_buff, buff1, sizeof(buff1)));
+			}
+
+			close(fd);
+		}
+
+		EXPECT_EQ(0, wait_fork(pid));
+	}
 }


### PR DESCRIPTION
Signed-off-by: Alexander Grissik <agrissik@nvidia.com>

## Description
VMA passes tx to OS in case the one element of the iov vector is null. Thus, breaking the connection.

##### What
Skip null elements in iov vector but process those that are not null.

##### Why ?

1. It is not forbidden to have null element in the iov vector. 
2. Kernel handles that well. 
3. Couchbase server behaves like this.

## Change type
What kind of change does this PR introduce?
- [X] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Tests
- [ ] Other

## Check list
- [X] Code follows the style de facto guidelines of this project
- [X] Comments have been inserted in hard to understand places
- [ ] Documentation has been updated (if necessary)
- [ ] Test has been added (if possible)

