### PR TITLE
issue: 3249310 Support only systemctl for vma service setup/removal

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -24,17 +24,11 @@ install-exec-hook:
 		mkdir -p $(DESTDIR)$(prefix)/lib/systemd/system/; \
 		cp $(top_builddir)/contrib/scripts/vma.service $(DESTDIR)$(prefix)/lib/systemd/system/vma.service; \
 		chmod 644 $(DESTDIR)$(prefix)/lib/systemd/system/vma.service; \
-	else \
-		mkdir -p $(DESTDIR)/$(sysconfdir)/init.d; \
-		cp $(top_builddir)/contrib/scripts/vma.init $(DESTDIR)$(sysconfdir)/init.d/vma; \
-		chmod 755 $(DESTDIR)$(sysconfdir)/init.d/vma; \
 	fi
 
 uninstall-hook:
 	if systemctl >/dev/null 2>&1; then \
 		rm -rf $(DESTDIR)$(prefix)/lib/systemd/system/vma.service; \
-	else \
-		rm -rf $(DESTDIR)$(sysconfdir)/init.d/vma; \
 	fi
 
 install-all: install

--- a/contrib/jenkins_tests/tool.sh
+++ b/contrib/jenkins_tests/tool.sh
@@ -53,31 +53,6 @@ function check_daemon()
         if [ "0" == "$ret" -a "" != "$(pgrep ${prj_service})" ]; then
             ret=1
         fi
-    else
-        service=${install_dir}/etc/init.d/vma
-        service_arg=""
-
-        echo "System has been booted with SystemV" >> ${out_log}
-        echo "daemon check output: ${service}" >> ${out_log}
-
-        if [ $(${sudo_cmd} ${service} start >>${out_log} 2>&1 || echo $?) ]; then
-            ret=1
-        fi
-        sleep 3
-        if [ "0" == "$ret" -a "" == "$(pgrep ${prj_service})" ]; then
-            ret=1
-        fi
-        if [ $(${sudo_cmd} ${service} status >>${out_log} 2>&1 || echo $?) ]; then
-            ret=1
-        fi
-        if [ $(${sudo_cmd} ${service} stop >>${out_log} 2>&1 || echo $?) ]; then
-            ret=1
-        fi
-        sleep 3
-        # Under docker containers service can be a zombie after killing
-        if [ "0" == "$ret" -a "" != "$(ps aux | grep ${prj_service} | egrep -v 'grep|defunct')" ]; then
-            ret=1
-        fi
     fi
 
     eval "${sudo_cmd} pkill -9 ${prj_service} 2>/dev/null || true"

--- a/contrib/scripts/libvma.spec.in
+++ b/contrib/scripts/libvma.spec.in
@@ -122,12 +122,6 @@ if [ $1 = 1 ]; then
         %else
             systemctl --no-reload enable vma.service >/dev/null 2>&1 || true
         %endif
-    elif [ -e /sbin/chkconfig ]; then
-        /sbin/chkconfig --add vma
-    elif [ -e /usr/sbin/update-rc.d ]; then
-        /usr/sbin/update-rc.d vma defaults
-    else
-        %{_libdir}/lsb/install_initd %{_sysconfdir}/init.d/vma
     fi
 fi
 
@@ -144,15 +138,6 @@ if [ $1 = 0 ]; then
             systemctl --no-reload disable vma.service >/dev/null 2>&1 || true
             systemctl stop vma.service || true
         %endif
-    elif [ -e /sbin/chkconfig ]; then
-        %{_sysconfdir}/init.d/vma stop
-        /sbin/chkconfig --del vma
-    elif [ -e /usr/sbin/update-rc.d ]; then
-        %{_sysconfdir}/init.d/vma stop
-        /usr/sbin/update-rc.d -f vma remove
-    else
-        %{_sysconfdir}/init.d/vma stop
-        %{_libdir}/lsb/remove_initd %{_sysconfdir}/init.d/vma
     fi
 fi
 
@@ -183,8 +168,6 @@ fi
 %{_sbindir}/vmad
 %if "%{use_systemd}" == "1"
 %{_prefix}/lib/systemd/system/vma.service
-%else
-%{_sysconfdir}/init.d/vma
 %endif
 %{_mandir}/man7/vma.*
 %{_mandir}/man8/vmad.*

--- a/debian/postinst
+++ b/debian/postinst
@@ -4,10 +4,4 @@
 
 if systemctl >/dev/null 2>&1; then
     systemctl --no-reload enable vma.service >/dev/null 2>&1 || true
-elif [ -e /sbin/chkconfig ]; then
-    /sbin/chkconfig --add vma || true
-elif [ -e /usr/sbin/update-rc.d ]; then
-    /usr/sbin/update-rc.d vma defaults || true
-else
-    /usr/lib/lsb/install_initd /etc/init.d/vma || true
 fi

--- a/debian/prerm
+++ b/debian/prerm
@@ -3,13 +3,4 @@
 if systemctl >/dev/null 2>&1; then
     systemctl --no-reload disable vma.service >/dev/null 2>&1 || true
     systemctl stop vma.service || true
-elif [ -e /sbin/chkconfig ]; then
-    /etc/init.d/vma stop || true
-    /sbin/chkconfig --del vma || true
-elif [ -e /usr/sbin/update-rc.d ]; then
-    /etc/init.d/vma stop || true
-    /usr/sbin/update-rc.d -f vma remove || true
-else
-    /etc/init.d/vma stop || true
-    /usr/lib/lsb/remove_initd /etc/init.d/vma || true
 fi


### PR DESCRIPTION
Signed-off-by: Alexander Grissik <agrissik@nvidia.com>

## Description
vma service setup/removal

##### What
Support only systemctl. Remove obsolete registration/deregistration methods.

##### Why ?
Compatibility with new systems and containers.

## Change type
What kind of change does this PR introduce?
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactoring (no functional changes, no api changes)
- [X] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Tests
- [ ] Other

## Check list
- [ ] Code follows the style de facto guidelines of this project
- [ ] Comments have been inserted in hard to understand places
- [ ] Documentation has been updated (if necessary)
- [ ] Test has been added (if possible)

