### PR TITLE
issue: 3325307 Fedora 36 added to CI OS list

### DIFF
--- a/.ci/matrix_job.yaml
+++ b/.ci/matrix_job.yaml
@@ -32,8 +32,9 @@ runs_on_dockers:
   - {name: 'sl15sp4-mofed-x86_64', url: 'harbor.mellanox.com/hpcx/x86_64/sles15sp4/builder:mofed-5.6-2.0.9.0', category: 'base', arch: 'x86_64'}
   - {name: 'ub20.04-mofed-x86_64', url: 'harbor.mellanox.com/swx-infra/x86_64/ubuntu20.04/builder:mofed-5.2-2.2.0.0', category: 'base', arch: 'x86_64'}
   - {name: 'ub20.04-mofed-aarch64', url: 'harbor.mellanox.com/swx-infra/aarch64/ubuntu20.04/builder:mofed-5.2-1.0.4.0', category: 'base', arch: 'aarch64'}
-  - {name: 'ub20.04-inbox-aarch64', url: 'harbor.mellanox.com/hpcx/aarch64/ubuntu20.04/builder:inbox', category: 'base', arch: 'aarch64'}
+  - {name: 'rhel8.6-inbox-x86_64', url: 'harbor.mellanox.com/hpcx/x86_64/rhel8.6/builder:inbox', category: 'base', arch: 'x86_64'}
   - {name: 'ub22.04-mofed-x86_64', url: 'harbor.mellanox.com/hpcx/x86_64/ubuntu22.04/builder:mofed-5.7-0.1.1.0', category: 'base', arch: 'x86_64'}
+  - {name: 'fc36-x86_64',  url: 'harbor.mellanox.com/rivermax/x86_64/fedora36:builder', category: 'base', arch: 'x86_64'}
 # tool
   - {name: 'toolbox', url: 'harbor.mellanox.com/hpcx/x86_64/rhel8.3/builder:inbox', category: 'tool', arch: 'x86_64'}
   - {name: 'blackduck', url: 'harbor.mellanox.com/toolbox/ngci-centos:7.9.2009.2', category: 'tool', arch: 'x86_64'}


### PR DESCRIPTION
## Description
Added build in Fedora 36 and RHEL 8.6 x86_64 containers, ubuntu20.04-inbox-aarch64 removed.

## Change type
What kind of change does this PR introduce?
- [x] Build related changes
- [x] CI related changes