### PR TITLE
issue: 3388776 Improve systemd check for chroot environment

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -20,14 +20,14 @@ mydocdir = $(if $(docdir),$(docdir),${datadir}/doc/$(distdir))
 mydoc_DATA = README CHANGES
 
 install-exec-hook:
-	if systemctl >/dev/null 2>&1; then \
+	if command -v systemctl >/dev/null 2>&1; then \
 		mkdir -p $(DESTDIR)$(prefix)/lib/systemd/system/; \
 		cp $(top_builddir)/contrib/scripts/vma.service $(DESTDIR)$(prefix)/lib/systemd/system/vma.service; \
 		chmod 644 $(DESTDIR)$(prefix)/lib/systemd/system/vma.service; \
 	fi
 
 uninstall-hook:
-	if systemctl >/dev/null 2>&1; then \
+	if command -v systemctl >/dev/null 2>&1; then \
 		rm -rf $(DESTDIR)$(prefix)/lib/systemd/system/vma.service; \
 	fi
 

--- a/contrib/scripts/libvma.spec.in
+++ b/contrib/scripts/libvma.spec.in
@@ -4,7 +4,7 @@
 %{!?make_build: %global make_build %{__make} %{?_smp_mflags} %{?mflags} V=1}
 %{!?run_ldconfig: %global run_ldconfig %{?ldconfig}}
 %{!?_pkgdocdir: %global _pkgdocdir %{_docdir}/%{name}-%{version}}
-%global use_systemd %(if systemctl >/dev/null 2>&1; then echo -n '1'; else echo -n '0'; fi)
+%global use_systemd %(if command -v systemctl >/dev/null 2>&1; then echo -n '1'; else echo -n '0'; fi)
 
 Name: libvma
 Version: @VERSION@
@@ -112,7 +112,7 @@ install -m 755 ./%{name}-debug.so $RPM_BUILD_ROOT/%{_libdir}/%{name}-debug.so
 %{run_ldconfig}
 %endif
 if [ $1 = 1 ]; then
-    if systemctl >/dev/null 2>&1; then
+    if command -v systemctl >/dev/null 2>&1; then
         %if 0%{?rhel} >= 9 || 0%{?fedora} >= 30 || 0%{?suse_version} >= 1210
             %if 0%{?suse_version}
             %service_add_post vma.service
@@ -127,7 +127,7 @@ fi
 
 %preun
 if [ $1 = 0 ]; then
-    if systemctl >/dev/null 2>&1; then
+    if command -v systemctl >/dev/null 2>&1; then
         %if 0%{?rhel} >= 9 || 0%{?fedora} >= 30 || 0%{?suse_version} >= 1210
             %if 0%{?suse_version}
             %service_del_preun vma.service
@@ -147,7 +147,7 @@ fi
 %else
 %{run_ldconfig}
 %endif
-if systemctl >/dev/null 2>&1; then
+if command -v systemctl >/dev/null 2>&1; then
         %if 0%{?rhel} >= 9 || 0%{?fedora} >= 30 || 0%{?suse_version} >= 1210
             %if 0%{?suse_version}
             %service_del_postun vma.service

--- a/debian/postinst
+++ b/debian/postinst
@@ -2,6 +2,6 @@
 
 /sbin/ldconfig
 
-if systemctl >/dev/null 2>&1; then
+if command -v systemctl >/dev/null 2>&1; then
     systemctl --no-reload enable vma.service >/dev/null 2>&1 || true
 fi

--- a/debian/postrm
+++ b/debian/postrm
@@ -1,5 +1,5 @@
 #!/bin/bash
 /sbin/ldconfig
-if systemctl >/dev/null 2>&1; then
+if command -v systemctl >/dev/null 2>&1; then
     systemctl --system daemon-reload >/dev/null 2>&1 || true
 fi

--- a/debian/prerm
+++ b/debian/prerm
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-if systemctl >/dev/null 2>&1; then
+if command -v systemctl >/dev/null 2>&1; then
     systemctl --no-reload disable vma.service >/dev/null 2>&1 || true
     systemctl stop vma.service || true
 fi


### PR DESCRIPTION
See: http://0pointer.de/blog/projects/changing-roots

First of all, systemctl detects when it is run in a chroot. If so, most of its operations will become NOPs, with the exception of systemctl enable and systemctl disable. If a package installation script hence calls these two commands, services will be enabled in the guest OS. However, should a package installation script include a command like systemctl restart as part of the package upgrade process this will have no effect at all when run in a chroot() environment.

## Description
Change systemctl call on `command -v systemctl`

##### What
Improve installation on systemd setup 

##### Why ?
RM:3388776

## Change type
What kind of change does this PR introduce?
- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Tests
- [ ] Other

## Check list
- [x] Code follows the style de facto guidelines of this project
- [ ] Comments have been inserted in hard to understand places
- [ ] Documentation has been updated (if necessary)
- [ ] Test has been added (if possible)

