### PR TITLE
issue: 3465282 Fix IB clock converter inaccuracy

### DIFF
--- a/src/vma/dev/time_converter_ib_ctx.cpp
+++ b/src/vma/dev/time_converter_ib_ctx.cpp
@@ -52,7 +52,7 @@
 
 #define IB_CTX_TC_DEVIATION_THRESHOLD 10
 
-time_converter_ib_ctx::time_converter_ib_ctx(struct ibv_context* ctx, ts_conversion_mode_t ctx_time_converter_mode, uint64_t hca_core_clock) :
+time_converter_ib_ctx::time_converter_ib_ctx(struct ibv_context* ctx, ts_conversion_mode_t ctx_time_converter_mode, uint64_t hca_core_clock_khz) :
 	m_p_ibv_context(ctx), m_ctx_parmeters_id(0)
 {
 #ifdef DEFINED_IBV_CQ_TIMESTAMP
@@ -60,7 +60,7 @@ time_converter_ib_ctx::time_converter_ib_ctx(struct ibv_context* ctx, ts_convers
 		ctx_timestamping_params_t* current_parameters_set = &m_ctx_convert_parmeters[m_ctx_parmeters_id];
 
 		m_converter_status = TS_CONVERSION_MODE_RAW;
-		current_parameters_set->hca_core_clock = hca_core_clock * USEC_PER_SEC;
+		current_parameters_set->hca_core_clock = hca_core_clock_khz * MSEC_PER_SEC;
 
 		if (ctx_time_converter_mode != TS_CONVERSION_MODE_RAW) {
 			if (sync_clocks(&current_parameters_set->sync_systime, &current_parameters_set->sync_hw_clock)) {
@@ -73,7 +73,7 @@ time_converter_ib_ctx::time_converter_ib_ctx(struct ibv_context* ctx, ts_convers
 		}
 	}
 #else
-	NOT_IN_USE(hca_core_clock);
+	NOT_IN_USE(hca_core_clock_khz);
 #endif
 	if (ctx_time_converter_mode != m_converter_status) {
 		ibchtc_logwarn("converter status different then expected (ibv context %p, value = %d , expected = %d)"

--- a/src/vma/dev/time_converter_ib_ctx.h
+++ b/src/vma/dev/time_converter_ib_ctx.h
@@ -42,7 +42,7 @@
 class time_converter_ib_ctx : public time_converter
 {
 public:
-	time_converter_ib_ctx(struct ibv_context* ctx, ts_conversion_mode_t ctx_time_converter_mode, uint64_t hca_core_clock);
+	time_converter_ib_ctx(struct ibv_context* ctx, ts_conversion_mode_t ctx_time_converter_mode, uint64_t hca_core_clock_khz);
 
 	virtual ~time_converter_ib_ctx() {};
 


### PR DESCRIPTION
## Description
Use proper multiplier while converting HCA core clock frequency into Hz.

##### What
Fix IB clock converter inaccuracy

##### Why ?
Invalid value for hca core clock frequency was used in time_converter_ib_ctx::calculate_delta.

##### How ?
We used hca_core_clock for [clock conversion ](https://github.com/Mellanox/libvma/blob/35833967e9ff708a5fbab90798e0fea34c0e1dfe/src/vma/dev/time_converter_ib_ctx.cpp#L178) from HW timestamp to system clock. But the value for hca_core_clock variable [is converted ](https://github.com/Mellanox/libvma/blob/35833967e9ff708a5fbab90798e0fea34c0e1dfe/src/vma/dev/time_converter_ib_ctx.cpp#L63) from device capabilities as it's in MHz (multiplied to 1000000=USEC_PER_SEC). That's look wrong because [ibv_device_attr_ex.hca_core_clock](https://man7.org/linux/man-pages/man3/ibv_query_device_ex.3.html) is in Khz.

## Change type
What kind of change does this PR introduce?
- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Tests
- [ ] Other

## Check list
- [+] Code follows the style de facto guidelines of this project
- [+] Comments have been inserted in hard to understand places
- [-] Documentation has been updated (if necessary)
- [-] Test has been added (if possible)