### PR TITLE
issue: 3202977 Fix type overflow during trimming TCP seg

### DIFF
--- a/src/vma/lwip/pbuf.c
+++ b/src/vma/lwip/pbuf.c
@@ -87,10 +87,10 @@
  * @note Despite its name, pbuf_realloc cannot grow the size of a pbuf (chain).
  */
 void
-pbuf_realloc(struct pbuf *p, u16_t new_len)
+pbuf_realloc(struct pbuf *p, u32_t new_len)
 {
   struct pbuf *q;
-  u16_t rem_len; /* remaining length */
+  u32_t rem_len; /* remaining length */
   s32_t grow;
 
   LWIP_ASSERT("pbuf_realloc: p != NULL", p != NULL);
@@ -117,7 +117,6 @@ pbuf_realloc(struct pbuf *p, u16_t new_len)
     /* decrease remaining length by pbuf length */
     rem_len -= q->len;
     /* decrease total length indicator */
-    LWIP_ASSERT("grow < max_u16_t", grow < 0xffff);
     q->tot_len += grow;
     /* proceed to next pbuf in chain */
     q = q->next;
@@ -166,11 +165,11 @@ pbuf_realloc(struct pbuf *p, u16_t new_len)
  *
  */
 u8_t
-pbuf_header(struct pbuf *p, s16_t header_size_increment)
+pbuf_header(struct pbuf *p, s32_t header_size_increment)
 {
   u16_t type;
+  u32_t increment_magnitude;
   void *payload;
-  u16_t increment_magnitude;
 
   LWIP_ASSERT("p != NULL", p != NULL);
   if ((header_size_increment == 0) || (p == NULL)) {
@@ -209,7 +208,7 @@ pbuf_header(struct pbuf *p, s16_t header_size_increment)
   p->len += header_size_increment;
   p->tot_len += header_size_increment;
 
-  LWIP_DEBUGF(PBUF_DEBUG | LWIP_DBG_TRACE, ("pbuf_header: old %p new %p (%"S16_F")\n",
+  LWIP_DEBUGF(PBUF_DEBUG | LWIP_DBG_TRACE, ("pbuf_header: old %p new %p (%"S32_F")\n",
     (void *)payload, (void *)p->payload, header_size_increment));
   (void)payload; /* Fix warning -Wunused-but-set-variable */
 

--- a/src/vma/lwip/pbuf.h
+++ b/src/vma/lwip/pbuf.h
@@ -118,8 +118,8 @@ struct pbuf_custom {
 /* Initializes the pbuf module. This call is empty for now, but may not be in future. */
 #define pbuf_init()
 
-void pbuf_realloc(struct pbuf *p, u16_t size); 
-u8_t pbuf_header(struct pbuf *p, s16_t header_size);
+void pbuf_realloc(struct pbuf *p, u32_t size);
+u8_t pbuf_header(struct pbuf *p, s32_t header_size);
 void pbuf_ref(struct pbuf *p);
 u8_t pbuf_free(struct pbuf *p);
 u8_t pbuf_clen(struct pbuf *p);  

--- a/src/vma/lwip/tcp_in.c
+++ b/src/vma/lwip/tcp_in.c
@@ -115,7 +115,7 @@ L3_level_tcp_input(struct pbuf *p, struct tcp_pcb* pcb)
 
 
     /* remove header from payload */
-    if (pbuf_header(p, -((s16_t)(IPH_HL(in_data.iphdr) * 4))) || (p->tot_len < sizeof(struct tcp_hdr))) {
+    if (pbuf_header(p, -((s32_t)(IPH_HL(in_data.iphdr) * 4))) || (p->tot_len < sizeof(struct tcp_hdr))) {
         /* drop short packets */
         LWIP_DEBUGF(TCP_INPUT_DEBUG, ("tcp_input: short packet (%"U16_F" bytes) discarded\n", (u16_t)p->tot_len));
         TCP_STATS_INC(tcp.lenerr);
@@ -903,7 +903,7 @@ tcp_receive(struct tcp_pcb *pcb, tcp_in_data* in_data)
   s32_t off;
   s16_t m;
   u32_t right_wnd_edge;
-  u16_t new_tot_len;
+  u32_t new_tot_len;
   int found_dupack = 0;
   s8_t persist = 0;
 
@@ -1251,36 +1251,30 @@ tcp_receive(struct tcp_pcb *pcb, tcp_in_data* in_data)
       off = pcb->rcv_nxt - in_data->seqno;
       p = in_data->inseg.p;
       LWIP_ASSERT("inseg.p != NULL", in_data->inseg.p);
-      LWIP_ASSERT("insane offset!", (off < 0x7fff));
       if (in_data->inseg.p->len < off) {
         LWIP_ASSERT("pbuf too short!", (((s32_t)in_data->inseg.p->tot_len) >= off));
-        new_tot_len = (u16_t)(in_data->inseg.p->tot_len - off);
+        new_tot_len = in_data->inseg.p->tot_len - off;
         while (p->len < off) {
           off -= p->len;
-          /* KJM following line changed (with addition of new_tot_len var)
-             to fix bug #9076
-             inseg.p->tot_len -= p->len; */
           p->tot_len = new_tot_len;
           p->len = 0;
           p = p->next;
         }
-        if(pbuf_header(p, (s16_t)-off)) {
+        if(pbuf_header(p, -off)) {
           /* Do we need to cope with this failing?  Assert for now */
           LWIP_ASSERT("pbuf_header failed", 0);
         }
       } else {
-        if(pbuf_header(in_data->inseg.p, (s16_t)-off)) {
+        if(pbuf_header(in_data->inseg.p, -off)) {
           /* Do we need to cope with this failing?  Assert for now */
           LWIP_ASSERT("pbuf_header failed", 0);
         }
       }
-      /* KJM following line changed to use p->payload rather than inseg->p->payload
-         to fix bug #9076 */
 #if LWIP_TSO
 #else
       in_data->inseg.dataptr = p->payload;
 #endif /* LWIP_TSO */
-      in_data->inseg.len -= (u16_t)(pcb->rcv_nxt - in_data->seqno);
+      in_data->inseg.len -= pcb->rcv_nxt - in_data->seqno;
       in_data->inseg.tcphdr->seqno = in_data->seqno = pcb->rcv_nxt;
     }
     else {


### PR DESCRIPTION
## Description

With LRO/GRO, TCP segments can be large and 16bit type is not enough to fit possible offsets/lengths. This can lead to a type overflow and broken pbuf chains as result. Further, a broken chain breaks accounting of received data what leads to a warning or even a segfault.

Increase type length for pbuf_header() and the trimming code. This fixes pbuf chain. Also increase type length for pbuf_realloc() to avoid similar issues in the future.

##### What
Fix type overflow.

##### Why ?
Bugfix.

## Change type
What kind of change does this PR introduce?
- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Tests
- [ ] Other

## Check list
- [ ] Code follows the style de facto guidelines of this project
- [ ] Comments have been inserted in hard to understand places
- [ ] Documentation has been updated (if necessary)
- [ ] Test has been added (if possible)

