### PR TITLE
issue: 3591039 Fix ref count for mem_buf chains

### DIFF
--- a/src/vma/dev/rfs_uc_tcp_gro.cpp
+++ b/src/vma/dev/rfs_uc_tcp_gro.cpp
@@ -35,6 +35,7 @@
 #include "vma/dev/gro_mgr.h"
 #include "vma/dev/ring_simple.h"
 #include "vma/proto/route_rule_table_key.h"
+#include <sock/sockinfo_tcp.h>
 
 #define MODULE_NAME 		"rfs_uc_tcp_gro"
 
@@ -45,7 +46,7 @@
 
 rfs_uc_tcp_gro::rfs_uc_tcp_gro(flow_tuple *flow_spec_5t, ring_slave *p_ring, rfs_rule_filter* rule_filter, uint32_t flow_tag_id) :
 	rfs_uc(flow_spec_5t, p_ring, rule_filter, flow_tag_id),
-	m_b_active(false), m_b_reserved(false)
+	m_b_active(false), m_b_reserved(false), m_pcb(nullptr)
 {
 	ring_simple* p_check_ring = dynamic_cast<ring_simple*>(p_ring);
 
@@ -233,6 +234,21 @@ bool rfs_uc_tcp_gro::tcp_ip_check(mem_buf_desc_t* mem_buf_desc, iphdr* p_ip_h, t
 	}
 
 	if (p_tcp_h->doff != TCP_H_LEN_NO_OPTIONS && p_tcp_h->doff != TCP_H_LEN_TIMESTAMP) {
+		return false;
+	}
+
+	// Set pbc once here since in constructor we don't have sockinfo yet
+	if (unlikely(!m_pcb)) {
+		sockinfo_tcp *sock = dynamic_cast<sockinfo_tcp *>(m_sinks_list[0]);
+		if (unlikely(!sock)) {
+			__log_err("sockinfo_tcp is null, can't check for already received packets");
+			return false;
+		}
+		m_pcb = sock->get_pcb();
+	}
+
+	// Dont accumulate packets that already received before
+	if (TCP_SEQ_LT(ntohl(p_tcp_h->seq) + mem_buf_desc->rx.sz_payload - 1, m_pcb->rcv_nxt)) {
 		return false;
 	}
 

--- a/src/vma/dev/rfs_uc_tcp_gro.h
+++ b/src/vma/dev/rfs_uc_tcp_gro.h
@@ -85,6 +85,7 @@ private:
 	struct  gro_mem_buf_desc m_gro_desc;
 	uint32_t m_n_buf_max;
 	uint32_t m_n_byte_max;
+	struct tcp_pcb *m_pcb;
 };
 
 

--- a/src/vma/lwip/tcp_out.c
+++ b/src/vma/lwip/tcp_out.c
@@ -1209,7 +1209,7 @@ tcp_rexmit_segment(struct tcp_pcb *pcb, struct tcp_seg *seg, u32_t wnd)
     }
 
     cur_p->len += optlen;
-    cur_p->tot_len = cur_p->len;
+    cur_p->tot_len += optlen;
     cur_p->payload = (u8_t *)cur_p->payload - optlen;
 
     /* Fill in tcp_seg (allocation was done before).
@@ -1220,6 +1220,9 @@ tcp_rexmit_segment(struct tcp_pcb *pcb, struct tcp_seg *seg, u32_t wnd)
       if (cur_seg->len > pcb->mss) {
         cur_seg->flags |= TF_SEG_OPTS_TSO;
       }
+      cur_p->len -= optlen;
+      cur_p->tot_len -= optlen;
+      cur_p->payload = (u8_t *)cur_p->payload + optlen;
       return seg;
     }
 

--- a/src/vma/proto/mem_buf_desc.h
+++ b/src/vma/proto/mem_buf_desc.h
@@ -132,6 +132,7 @@ public:
 
 	inline int get_ref_count() const {return atomic_read(&n_ref_count);}
 	inline void  reset_ref_count() {atomic_set(&n_ref_count, 0);}
+	inline void set_ref_count(int x) {atomic_set(&n_ref_count, x);}
 	inline int inc_ref_count() {return atomic_fetch_and_inc(&n_ref_count);}
 	inline int dec_ref_count() {return atomic_fetch_and_dec(&n_ref_count);}
 

--- a/src/vma/sock/sockinfo_tcp.cpp
+++ b/src/vma/sock/sockinfo_tcp.cpp
@@ -1677,7 +1677,16 @@ err_t sockinfo_tcp::rx_lwip_cb(void *arg, struct tcp_pcb *pcb,
 	pbuf *p_curr_buff = p;
 	conn->m_connected.get_sa(p_first_desc->rx.src);
 
+	// To avoid reset ref count for first mem_buf_desc, save it and set after the while
+	int head_ref = p_first_desc->get_ref_count();
 	while (p_curr_buff) {
+		/* Here we reset ref count for all mem_buf_desc except for the head (p_first_desc).
+		Chain of pbufs can contain some pbufs with ref count >=1 like in ooo or flow tag flows.
+		While processing Rx packets we may split buffer chains and we increment ref count
+		for the new head of the chain after the split. It will cause a wrong ref count,
+		and the buffer won't be reclaimed. Resetting it here will migitate the issue.
+		TODO: remove ref count for TCP. */
+		p_curr_desc->reset_ref_count();
 		p_curr_desc->rx.context = conn;
 		p_first_desc->rx.n_frags++;
 		p_curr_desc->rx.frag.iov_base = p_curr_buff->payload;
@@ -1687,6 +1696,7 @@ err_t sockinfo_tcp::rx_lwip_cb(void *arg, struct tcp_pcb *pcb,
 		p_curr_buff = p_curr_buff->next;
 		p_curr_desc = p_curr_desc->p_next_desc;
 	}
+	p_first_desc->set_ref_count(head_ref);
 		
 	vma_recv_callback_retval_t callback_retval = VMA_PACKET_RECV;
 	

--- a/src/vma/sock/sockinfo_tcp.h
+++ b/src/vma/sock/sockinfo_tcp.h
@@ -158,7 +158,8 @@ public:
 	/* This function is used for socketxtreme mode */
 	virtual int free_buffs(uint16_t len);
 
-	virtual void statistics_print(vlog_levels_t log_level = VLOG_DEBUG);	
+	virtual void statistics_print(vlog_levels_t log_level = VLOG_DEBUG);
+	inline struct tcp_pcb *get_pcb(void) { return &m_pcb; }	
 
 	//Returns the connected pcb, with 5 tuple which matches the input arguments,
 	//in state "SYN Received" or NULL if pcb wasn't found


### PR DESCRIPTION
Chain of pbufs can contain some pbufs with ref count >=1 like in ooo or flow tag flows. While processing Rx packets we may split buffer chains and we increment ref count for the new head of the chain after the split.
It will cause a wrong ref count, and the buffer won't be reclaimed. Therefore we reset ref count 0 for chained mem_buf_desc in m_rx_pkt_ready_list except for the head. Related to issue 3231710.

## Change type
What kind of change does this PR introduce?
- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Tests
- [ ] Other

## Check list
- [ ] Code follows the style de facto guidelines of this project
- [ ] Comments have been inserted in hard to understand places
- [ ] Documentation has been updated (if necessary)
- [ ] Test has been added (if possible)

