### PR TITLE
issue: 3591039 Fixing Out of order buffer leak and TCP stream corruption

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -4,7 +4,7 @@ AC_PREREQ(2.59)
 #
 define([vma_ver_major], 8)
 define([vma_ver_minor], 4)
-define([vma_ver_revision], 101)
+define([vma_ver_revision], 104)
 define([vma_ver_release], 0)
 
 AC_INIT(libvma, [vma_ver_major.vma_ver_minor.vma_ver_revision], support@mellanox.com)
@@ -43,7 +43,7 @@ VMA_LIBRARY_MINOR=4
 AC_SUBST(VMA_LIBRARY_MINOR)
 
 #VMA_LIBRARY_REVISION-vma_ver_revision
-VMA_LIBRARY_REVISION=101
+VMA_LIBRARY_REVISION=104
 AC_SUBST(VMA_LIBRARY_REVISION)
 
 #VMA_LIBRARY_RELEASE-vma_ver_release

--- a/journal.txt
+++ b/journal.txt
@@ -1,3 +1,12 @@
+Version 8.4.104-0:
+Date + Time 2023-09-04
+=============================================================
+Fixed:
+        - RM #3591039 Fix lwip seqno wrap around condition
+        - RM #3591039 Fix ref count for mem_buf chains
+        - RM #3591039 Fix type overflow during trimming TCP seg
+        - RM #3591039 Fix GRO retransmitted TCP stream
+
 Version 8.4.101-0:
 Date + Time 2018-02-05
 =============================================================

--- a/src/vma/dev/rfs_uc_tcp_gro.cpp
+++ b/src/vma/dev/rfs_uc_tcp_gro.cpp
@@ -35,6 +35,7 @@
 #include "vma/dev/gro_mgr.h"
 #include "vma/dev/ring_simple.h"
 #include "vma/proto/route_rule_table_key.h"
+#include <sock/sockinfo_tcp.h>
 
 #define MODULE_NAME 		"rfs_uc_tcp_gro"
 
@@ -45,7 +46,7 @@
 
 rfs_uc_tcp_gro::rfs_uc_tcp_gro(flow_tuple *flow_spec_5t, ring_simple *p_ring, rfs_rule_filter* rule_filter, uint32_t flow_tag_id) :
 	rfs_uc(flow_spec_5t, p_ring, rule_filter, flow_tag_id),
-	m_p_gro_mgr(&(p_ring->m_gro_mgr)), m_b_active(false), m_b_reserved(false)
+	m_p_gro_mgr(&(p_ring->m_gro_mgr)), m_b_active(false), m_b_reserved(false), m_pcb(nullptr)
 {
 	m_n_buf_max = m_p_gro_mgr->get_buf_max();
 	uint32_t mtu = p_ring->get_mtu(route_rule_table_key(flow_spec_5t->get_dst_ip(), flow_spec_5t->get_src_ip(), 0));
@@ -220,6 +221,21 @@ bool rfs_uc_tcp_gro::tcp_ip_check(mem_buf_desc_t* mem_buf_desc, iphdr* p_ip_h, t
 	}
 
 	if (p_tcp_h->doff != TCP_H_LEN_NO_OPTIONS && p_tcp_h->doff != TCP_H_LEN_TIMESTAMP) {
+		return false;
+	}
+
+	// Set pbc once here since in constructor we don't have sockinfo yet
+	if (unlikely(!m_pcb)) {
+		sockinfo_tcp *sock = dynamic_cast<sockinfo_tcp *>(m_sinks_list[0]);
+		if (unlikely(!sock)) {
+			__log_err("sockinfo_tcp is null, can't check for already received packets");
+			return false;
+		}
+		m_pcb = sock->get_pcb();
+	}
+
+	// Dont accumulate packets that already received before
+	if (TCP_SEQ_LT(ntohl(p_tcp_h->seq) + mem_buf_desc->rx.sz_payload - 1, m_pcb->rcv_nxt)) {
 		return false;
 	}
 

--- a/src/vma/dev/rfs_uc_tcp_gro.h
+++ b/src/vma/dev/rfs_uc_tcp_gro.h
@@ -85,6 +85,7 @@ private:
 	struct  gro_mem_buf_desc m_gro_desc;
 	uint32_t m_n_buf_max;
 	uint32_t m_n_byte_max;
+	struct tcp_pcb *m_pcb;
 };
 
 

--- a/src/vma/lwip/pbuf.c
+++ b/src/vma/lwip/pbuf.c
@@ -158,10 +158,10 @@ pbuf_alloced_custom(pbuf_layer l, u16_t length, pbuf_type type, struct pbuf_cust
  * @note Despite its name, pbuf_realloc cannot grow the size of a pbuf (chain).
  */
 void
-pbuf_realloc(struct pbuf *p, u16_t new_len)
+pbuf_realloc(struct pbuf *p, u32_t new_len)
 {
   struct pbuf *q;
-  u16_t rem_len; /* remaining length */
+  u32_t rem_len; /* remaining length */
   s32_t grow;
 
   LWIP_ASSERT("pbuf_realloc: p != NULL", p != NULL);
@@ -188,7 +188,6 @@ pbuf_realloc(struct pbuf *p, u16_t new_len)
     /* decrease remaining length by pbuf length */
     rem_len -= q->len;
     /* decrease total length indicator */
-    LWIP_ASSERT("grow < max_u16_t", grow < 0xffff);
     q->tot_len += grow;
     /* proceed to next pbuf in chain */
     q = q->next;
@@ -237,11 +236,11 @@ pbuf_realloc(struct pbuf *p, u16_t new_len)
  *
  */
 u8_t
-pbuf_header(struct pbuf *p, s16_t header_size_increment)
+pbuf_header(struct pbuf *p, s32_t header_size_increment)
 {
   u16_t type;
+  u32_t increment_magnitude;
   void *payload;
-  u16_t increment_magnitude;
 
   LWIP_ASSERT("p != NULL", p != NULL);
   if ((header_size_increment == 0) || (p == NULL)) {
@@ -280,7 +279,7 @@ pbuf_header(struct pbuf *p, s16_t header_size_increment)
   p->len += header_size_increment;
   p->tot_len += header_size_increment;
 
-  LWIP_DEBUGF(PBUF_DEBUG | LWIP_DBG_TRACE, ("pbuf_header: old %p new %p (%"S16_F")\n",
+  LWIP_DEBUGF(PBUF_DEBUG | LWIP_DBG_TRACE, ("pbuf_header: old %p new %p (%"S32_F")\n",
     (void *)payload, (void *)p->payload, header_size_increment));
   (void)payload; /* Fix warning -Wunused-but-set-variable */
 

--- a/src/vma/lwip/pbuf.h
+++ b/src/vma/lwip/pbuf.h
@@ -132,8 +132,8 @@ struct pbuf *pbuf_alloced_custom(pbuf_layer l, u16_t length, pbuf_type type,
                                  struct pbuf_custom *p, void *payload_mem,
                                  u16_t payload_mem_len);
 #endif /* LWIP_SUPPORT_CUSTOM_PBUF */
-void pbuf_realloc(struct pbuf *p, u16_t size); 
-u8_t pbuf_header(struct pbuf *p, s16_t header_size);
+void pbuf_realloc(struct pbuf *p, u32_t size);
+u8_t pbuf_header(struct pbuf *p, s32_t header_size);
 void pbuf_ref(struct pbuf *p);
 u8_t pbuf_free(struct pbuf *p);
 u8_t pbuf_clen(struct pbuf *p);  

--- a/src/vma/lwip/tcp_in.c
+++ b/src/vma/lwip/tcp_in.c
@@ -1386,7 +1386,7 @@ tcp_receive(struct tcp_pcb *pcb, tcp_in_data* in_data)
                     pbuf_realloc(next->p, next->len);
                   }
                   /* check if the remote side overruns our receive window */
-                  if ((u32_t)in_data->tcplen + in_data->seqno > pcb->rcv_nxt + (u32_t)pcb->rcv_wnd) {
+                  if (TCP_SEQ_GT(in_data->seqno + in_data->tcplen, pcb->rcv_nxt + pcb->rcv_wnd)) {
                     LWIP_DEBUGF(TCP_INPUT_DEBUG, 
                                 ("tcp_receive: other end overran receive window"
                                  "seqno %"U32_F" len %"U16_F" right edge %"U32_F"\n",

--- a/src/vma/proto/mem_buf_desc.h
+++ b/src/vma/proto/mem_buf_desc.h
@@ -132,6 +132,7 @@ public:
 
 	inline int get_ref_count() const {return atomic_read(&n_ref_count);}
 	inline void  reset_ref_count() {atomic_set(&n_ref_count, 0);}
+	inline void set_ref_count(int x) {atomic_set(&n_ref_count, x);}
 	inline int inc_ref_count() {return atomic_fetch_and_inc(&n_ref_count);}
 	inline int dec_ref_count() {return atomic_fetch_and_dec(&n_ref_count);}
 

--- a/src/vma/sock/sockinfo_tcp.cpp
+++ b/src/vma/sock/sockinfo_tcp.cpp
@@ -1541,7 +1541,15 @@ err_t sockinfo_tcp::rx_lwip_cb(void *arg, struct tcp_pcb *pcb,
 	pbuf *p_curr_buff = p;
 	conn->m_connected.get_sa(p_first_desc->rx.src);
 
+	// To avoid reset ref count for first mem_buf_desc, save it and set after the while
+	int head_ref = p_first_desc->get_ref_count();
 	while (p_curr_buff) {
+		/* Here we reset ref count for all mem_buf_desc except for the head (p_first_desc).
+		Chain of pbufs can contain some pbufs with ref count >=1 like in ooo or flow tag flows.
+		While processing Rx packets we may split buffer chains and we increment ref count
+		for the new head of the chain after the split. It will cause a wrong ref count,
+		and the buffer won't be reclaimed. Resetting it here will migitate the issue. */
+		p_curr_desc->reset_ref_count();
 #ifdef DEFINED_VMAPOLL		
 		p_curr_desc->rx.context = conn;
 #endif // DEFINED_VMAPOLL				
@@ -1552,6 +1560,7 @@ err_t sockinfo_tcp::rx_lwip_cb(void *arg, struct tcp_pcb *pcb,
 		p_curr_buff = p_curr_buff->next;
 		p_curr_desc = p_curr_desc->p_next_desc;
 	}
+	p_first_desc->set_ref_count(head_ref);
 		
 	vma_recv_callback_retval_t callback_retval = VMA_PACKET_RECV;
 	


### PR DESCRIPTION
## Description
1. RX buffer leak
2. TCP stream corruptions in case of GRO/OOO

##### What
1. Fix RX buffer leak
2. Fix GRO/OOO TCP stream corruptions

##### Why ?
1. Memory leak
2. Corrupted TCP stream

## Change type
What kind of change does this PR introduce?
- [X] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Tests
- [ ] Other

## Check list
- [X] Code follows the style de facto guidelines of this project
- [X] Comments have been inserted in hard to understand places
- [ ] Documentation has been updated (if necessary)
- [ ] Test has been added (if possible)

