### PR TITLE
issue: 3604175 Fixing stuck empty rx ring cleanup

### DIFF
--- a/src/vma/dev/qp_mgr.cpp
+++ b/src/vma/dev/qp_mgr.cpp
@@ -412,7 +412,8 @@ void qp_mgr::release_rx_buffers()
 	qp_logdbg("draining rx cq_mgr %p (last_posted_rx_wr_id = %lu)", m_p_cq_mgr_rx, m_last_posted_rx_wr_id);
 	uintptr_t last_polled_rx_wr_id = 0;
 	while (m_p_cq_mgr_rx && last_polled_rx_wr_id != m_last_posted_rx_wr_id &&
-			errno != EIO && !m_p_ib_ctx_handler->is_removed()) {
+			errno != EIO && !m_p_ib_ctx_handler->is_removed() &&
+			!is_rq_empty()) {
 
 		// Process the FLUSH'ed WQE's
 		int ret = m_p_cq_mgr_rx->drain_and_proccess(&last_polled_rx_wr_id);

--- a/src/vma/dev/qp_mgr.h
+++ b/src/vma/dev/qp_mgr.h
@@ -188,6 +188,7 @@ protected:
 
 	virtual int     send_to_wire(vma_ibv_send_wr* p_send_wqe, vma_wr_tx_packet_attr attr, bool request_comp);
 	virtual bool    is_completion_need() { return !m_n_unsignaled_count; };
+	virtual bool    is_rq_empty() const { return false; }
 };
 
 class qp_mgr_eth : public qp_mgr

--- a/src/vma/dev/qp_mgr_eth_mlx5.h
+++ b/src/vma/dev/qp_mgr_eth_mlx5.h
@@ -66,6 +66,8 @@ protected:
 	void		trigger_completion_for_all_sent_packets();
 	void		init_sq();
 
+	virtual bool is_rq_empty() const { return (m_mlx5_qp.rq.head == m_mlx5_qp.rq.tail); }
+
 	uint64_t*   m_sq_wqe_idx_to_wrid;
 	uint64_t    m_rq_wqe_counter;
 private:


### PR DESCRIPTION
## Description
VMA hangs infinitely in ring destruction

##### What
If the RQ is empty, ring destruction will loop inifintely.
See more details in commit message

##### Why ?
Fixing infinitely hanging VMA

##### How ?
Try to fetch last posted wqe only if the RQ is not empty.

## Change type
What kind of change does this PR introduce?
- [X] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Tests
- [ ] Other

## Check list
- [X] Code follows the style de facto guidelines of this project
- [ ] Comments have been inserted in hard to understand places
- [ ] Documentation has been updated (if necessary)
- [ ] Test has been added (if possible)

