### PR TITLE
issue: 3604029 Fix releasing ring flow

### DIFF
--- a/src/vma/sock/sockinfo.cpp
+++ b/src/vma/sock/sockinfo.cpp
@@ -817,11 +817,7 @@ bool sockinfo::destroy_nd_resources(const ip_address ip_local)
 		BULLSEYE_EXCLUDE_BLOCK_START
 		unlock_rx_q();
 		resource_allocation_key *key;
-		if (m_ring_alloc_logic.is_logic_support_migration()) {
-			key = m_ring_alloc_logic.get_key();
-		} else {
-			key = m_ring_alloc_logic.create_new_key(ip_local.get_in_addr());
-		}
+		key = m_ring_alloc_logic.get_key();
 		if (p_nd_resources->p_ndv->release_ring(key) < 0) {
 			lock_rx_q();
 			si_logerr("Failed to release ring for allocation key %s on ip %s",


### PR DESCRIPTION

## Description
For rx flow create key basing on allocation logic during ring creation and store it in sockinfo object.
Use actual key (w/o or w/ migration sceanrio) from sockinfo object.

##### What
RM#3604029 

##### Why ?
Bug fix.

##### How ?
_It is optional but for complex PRs please provide information about the design,
architecture, approach, etc._

## Change type
What kind of change does this PR introduce?
- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Tests
- [ ] Other

## Check list
- [ ] Code follows the style de facto guidelines of this project
- [ ] Comments have been inserted in hard to understand places
- [ ] Documentation has been updated (if necessary)
- [ ] Test has been added (if possible)

