### PR TITLE
Issue: 3697720 Fixes for segmentation faults

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -176,7 +176,6 @@ Example:
  VMA DETAILS: Internal Thread Affinity       -1                         [VMA_INTERNAL_THREAD_AFFINITY]
  VMA DETAILS: Internal Thread Cpuset                                    [VMA_INTERNAL_THREAD_CPUSET]
  VMA DETAILS: Internal Thread Arm CQ         Disabled                   [VMA_INTERNAL_THREAD_ARM_CQ]
- VMA DETAILS: Internal Thread TCP Handling   0 (deferred)               [VMA_INTERNAL_THREAD_TCP_TIMER_HANDLING]
  VMA DETAILS: Thread mode                    Multi spin lock            [VMA_THREAD_MODE]
  VMA DETAILS: Buffer batching mode           1 (Batch and reclaim buffers) [VMA_BUFFER_BATCHING_MODE]
  VMA DETAILS: Mem Allocate type              1 (Contig Pages)           [VMA_MEM_ALLOC_TYPE]
@@ -810,14 +809,6 @@ Select a cpuset for VMA internal thread (see man page of cpuset).
 The value is the path to the cpuset (for example: /dev/cpuset/my_set), or an empty
 string to run it on the same cpuset the process runs on.
 Default value is an empty string.
-
-VMA_INTERNAL_THREAD_TCP_TIMER_HANDLING
-Select the internal thread policy when handling TCP timers
-Use value of 0 for deferred handling. The internal thread will not handle TCP timers upon timer
-expiration (once every 100ms) in order to let application threads handling it first
-Use value of 1 for immediate handling. The internal thread will try locking and handling TCP timers upon
-timer expiration (once every 100ms).  Application threads may be blocked till internal thread finishes handling TCP timers
-Default value is 0 (deferred handling)
 
 VMA_INTERNAL_THREAD_ARM_CQ
 Wakeup the internal thread for each packet that the CQ receive.

--- a/src/vma/main.cpp
+++ b/src/vma/main.cpp
@@ -573,6 +573,7 @@ void print_vma_global_settings()
 		VLOG_PARAM_NUMBER("MSS", safe_mce_sys().lwip_mss, MCE_DEFAULT_MSS, SYS_VAR_MSS);	break;
 	}
 	VLOG_PARAM_NUMSTR("TCP CC Algorithm", safe_mce_sys().lwip_cc_algo_mod, MCE_DEFAULT_LWIP_CC_ALGO_MOD, SYS_VAR_TCP_CC_ALGO, lwip_cc_algo_str(safe_mce_sys().lwip_cc_algo_mod));
+	VLOG_PARAM_STRING("Deferred close", safe_mce_sys().deferred_close, MCE_DEFAULT_DEFERRED_CLOSE, SYS_VAR_DEFERRED_CLOSE, safe_mce_sys().deferred_close ? "Enabled " : "Disabled");
 	VLOG_PARAM_STRING("Polling Rx on Tx TCP", safe_mce_sys().rx_poll_on_tx_tcp, MCE_DEFAULT_RX_POLL_ON_TX_TCP, SYS_VAR_VMA_RX_POLL_ON_TX_TCP, safe_mce_sys().rx_poll_on_tx_tcp ? "Enabled " : "Disabled");
 	VLOG_PARAM_STRING("Trig dummy send getsockname()", safe_mce_sys().trigger_dummy_send_getsockname, MCE_DEFAULT_TRIGGER_DUMMY_SEND_GETSOCKNAME, SYS_VAR_VMA_TRIGGER_DUMMY_SEND_GETSOCKNAME, safe_mce_sys().trigger_dummy_send_getsockname ? "Enabled " : "Disabled");
 

--- a/src/vma/main.cpp
+++ b/src/vma/main.cpp
@@ -536,7 +536,6 @@ void print_vma_global_settings()
 	VLOG_STR_PARAM_STRING("Internal Thread Affinity", safe_mce_sys().internal_thread_affinity_str, MCE_DEFAULT_INTERNAL_THREAD_AFFINITY_STR, SYS_VAR_INTERNAL_THREAD_AFFINITY, safe_mce_sys().internal_thread_affinity_str);
 	VLOG_STR_PARAM_STRING("Internal Thread Cpuset", safe_mce_sys().internal_thread_cpuset, MCE_DEFAULT_INTERNAL_THREAD_CPUSET, SYS_VAR_INTERNAL_THREAD_CPUSET, safe_mce_sys().internal_thread_cpuset);
 	VLOG_PARAM_STRING("Internal Thread Arm CQ", safe_mce_sys().internal_thread_arm_cq_enabled, MCE_DEFAULT_INTERNAL_THREAD_ARM_CQ_ENABLED, SYS_VAR_INTERNAL_THREAD_ARM_CQ, safe_mce_sys().internal_thread_arm_cq_enabled ? "Enabled " : "Disabled");
-	VLOG_PARAM_NUMSTR("Internal Thread TCP Handling", safe_mce_sys().internal_thread_tcp_timer_handling, MCE_DEFAULT_INTERNAL_THREAD_TCP_TIMER_HANDLING, SYS_VAR_INTERNAL_THREAD_TCP_TIMER_HANDLING, internal_thread_tcp_timer_handling_str(safe_mce_sys().internal_thread_tcp_timer_handling));	
 	VLOG_PARAM_STRING("Thread mode", safe_mce_sys().thread_mode, MCE_DEFAULT_THREAD_MODE, SYS_VAR_THREAD_MODE, thread_mode_str(safe_mce_sys().thread_mode));
 	VLOG_PARAM_NUMSTR("Buffer batching mode", safe_mce_sys().buffer_batching_mode, MCE_DEFAULT_BUFFER_BATCHING_MODE, SYS_VAR_BUFFER_BATCHING_MODE, buffer_batching_mode_str(safe_mce_sys().buffer_batching_mode));
 	switch (safe_mce_sys().mem_alloc_type) {

--- a/src/vma/sock/sock-redirect.h
+++ b/src/vma/sock/sock-redirect.h
@@ -177,7 +177,7 @@ extern iomux_stats_t* g_p_epoll_stats;
 
 int do_global_ctors();
 void reset_globals();
-void handle_close(int fd, bool cleanup = false, bool passthrough = false);
+bool handle_close(int fd, bool cleanup = false, bool passthrough = false);
 
 // allow calling our socket(...) implementation safely from within libvma.so
 // this is critical in case VMA was loaded using dlopen and not using LD_PRELOAD

--- a/src/vma/sock/socket_fd_api.cpp
+++ b/src/vma/sock/socket_fd_api.cpp
@@ -56,6 +56,9 @@ socket_fd_api::socket_fd_api(int fd) : m_epoll_event_flags(0), m_fd(fd), m_n_sys
 
 socket_fd_api::~socket_fd_api()
 {
+	if (safe_mce_sys().deferred_close && (m_fd >= 0)) {
+		orig_os_api.close(m_fd);
+	}
 }
 
 

--- a/src/vma/sock/sockinfo_tcp.cpp
+++ b/src/vma/sock/sockinfo_tcp.cpp
@@ -1199,23 +1199,19 @@ void sockinfo_tcp::err_lwip_cb(void *pcb_container, err_t err)
 	}
 
 	if (conn->m_parent != NULL) {
-		//in case we got RST before we accepted the connection
-		int delete_fd = 0;
-		sockinfo_tcp *parent = conn->m_parent;
-		bool locked_by_me = false;
-		if (conn->m_tcp_con_lock.is_locked_by_me()) {
-			locked_by_me = true;
-			conn->unlock_tcp_con();
-		}
-		if ((delete_fd = parent->handle_child_FIN(conn))) {
-			//close will clean sockinfo_tcp object and the opened OS socket
+		//in case we got RST or abandon() before we accepted the connection
+		conn->unlock_tcp_con();
+		int delete_fd = conn->m_parent->handle_child_FIN(conn);
+		conn->lock_tcp_con();
+
+		if (delete_fd) {
+			// Object destruction is expected to happen in internal thread. Unless VMA is in late
+			// terminating stage, in which case we don't expect to handle packets.
+			// Calling close() under lock will prevent internal thread to delete the object before
+			// we finish with the current processing.
 			close(delete_fd);
-			if (locked_by_me)
-				conn->lock_tcp_con(); //todo sock and fd_collection destruction race? if so, conn might be invalid? delay close to internal thread?
 			return;
 		}
-		if (locked_by_me)
-			conn->lock_tcp_con();
 	}
 
 	/*
@@ -1639,18 +1635,21 @@ err_t sockinfo_tcp::rx_lwip_cb(void *arg, struct tcp_pcb *pcb,
 		tcp_recv(&(conn->m_pcb), sockinfo_tcp::rx_drop_lwip_cb);
 
 		if (conn->m_parent != NULL) {
-			//in case we got FIN before we accepted the connection
-			int delete_fd = 0;
-			sockinfo_tcp *parent = conn->m_parent;
-			/* TODO need to add some refcount inside parent in case parent and child are closed together*/
+			// in case we got FIN before we accepted the connection
+			/* TODO need to add some refcount inside parent in case parent and child are closed
+			* together*/
 			conn->unlock_tcp_con();
-			if ((delete_fd = parent->handle_child_FIN(conn))) {
-				//close will clean sockinfo_tcp object and the opened OS socket
+			int delete_fd = conn->m_parent->handle_child_FIN(conn);
+			conn->lock_tcp_con();
+
+			if (delete_fd) {
+				// Object destruction is expected to happen in internal thread. Unless XLIO is in late
+				// terminating stage, in which case we don't expect to handle packets.
+				// Calling close() under lock will prevent internal thread to delete the object before
+				// we finish with the current processing.
 				close(delete_fd);
-				conn->lock_tcp_con(); //todo sock and fd_collection destruction race? if so, conn might be invalid? delay close to internal thread?
 				return ERR_ABRT;
 			}
-			conn->lock_tcp_con();
 		}
 		return ERR_OK;
 	}

--- a/src/vma/sock/sockinfo_tcp.cpp
+++ b/src/vma/sock/sockinfo_tcp.cpp
@@ -127,10 +127,6 @@ inline void sockinfo_tcp::lock_tcp_con()
 
 inline void sockinfo_tcp::unlock_tcp_con()
 {
-	if (m_timer_pending) {
-		tcp_timer();
-	}
-
 	m_tcp_con_lock.unlock();
 }
 
@@ -156,12 +152,6 @@ inline int sockinfo_tcp::rx_wait(int &poll_count, bool is_blocking)
 
 inline int sockinfo_tcp::rx_wait_lockless(int & poll_count, bool is_blocking)
 {
-	if (m_timer_pending) {
-		m_tcp_con_lock.lock();
-		tcp_timer();
-		m_tcp_con_lock.unlock();
-	}
-
 	return rx_wait_helper(poll_count, is_blocking);
 }
 
@@ -223,10 +213,8 @@ inline void sockinfo_tcp::reuse_buffer(mem_buf_desc_t *buff)
 sockinfo_tcp::sockinfo_tcp(int fd):
         sockinfo(fd),
         m_timer_handle(NULL),
-        m_timer_pending(false),
         m_sysvar_buffer_batching_mode(safe_mce_sys().buffer_batching_mode),
         m_sysvar_tcp_ctl_thread(safe_mce_sys().tcp_ctl_thread),
-        m_sysvar_internal_thread_tcp_timer_handling(safe_mce_sys().internal_thread_tcp_timer_handling),
         m_sysvar_rx_poll_on_tx_tcp(safe_mce_sys().rx_poll_on_tx_tcp)
 {
 	si_tcp_logfuncall("");
@@ -615,7 +603,6 @@ void sockinfo_tcp::tcp_timer()
 	}
 
 	tcp_tmr(&m_pcb);
-	m_timer_pending = false;
 
 	return_pending_rx_buffs();
 	return_pending_tx_buffs();
@@ -1494,34 +1481,9 @@ void sockinfo_tcp::handle_timer_expired(void* user_data)
 	if (m_sysvar_tcp_ctl_thread > CTL_THREAD_DISABLE)
 		process_rx_ctl_packets();
 
-	if (m_sysvar_internal_thread_tcp_timer_handling == INTERNAL_THREAD_TCP_TIMER_HANDLING_DEFERRED) {
-		// DEFERRED. if Internal thread is here first and m_timer_pending is false it jsut 
-		// sets it as true for its next iteration (within 100ms), letting 
-		// application threads have a chance of running tcp_timer()
-		if (m_timer_pending) {
-			if (m_tcp_con_lock.trylock()) {
-				return;
-			}
-			tcp_timer();
-			m_tcp_con_lock.unlock();
-		}
-		m_timer_pending = true;
-	}
-	else { // IMMEDIATE
-		// Set the pending flag before getting the lock, so in the rare case of
-		// a race with unlock_tcp_con(), the timer will be called twice. If we set
-		// the flag after trylock(), the timer may not be called in case of a race.
-		
-		// any thread (internal or application) will try locking 
-		// and running the tcp_timer
-		m_timer_pending = true;
-		if (m_tcp_con_lock.trylock()) {
-			return;
-		}
-
-		tcp_timer();
-		m_tcp_con_lock.unlock();
-	}
+	m_tcp_con_lock.lock();
+	tcp_timer();
+	m_tcp_con_lock.unlock();
 }
 
 void sockinfo_tcp::abort_connection()

--- a/src/vma/sock/sockinfo_tcp.h
+++ b/src/vma/sock/sockinfo_tcp.h
@@ -279,7 +279,6 @@ private:
 
 	void *m_timer_handle;
 	lock_spin_recursive m_tcp_con_lock;
-	bool m_timer_pending;
 
 	bool report_connected; //used for reporting 'connected' on second non-blocking call to connect.
 
@@ -287,7 +286,6 @@ private:
 
 	const buffer_batching_mode_t m_sysvar_buffer_batching_mode;
 	const tcp_ctl_thread_t m_sysvar_tcp_ctl_thread;
-	const internal_thread_tcp_timer_handling_t m_sysvar_internal_thread_tcp_timer_handling;
 
 	struct tcp_seg * m_tcp_seg_list;
 	int m_tcp_seg_count;

--- a/src/vma/util/sys_vars.cpp
+++ b/src/vma/util/sys_vars.cpp
@@ -619,6 +619,7 @@ void mce_sys_var::get_env_params()
 	neigh_wait_till_send_arp_msec = MCE_DEFAULT_NEIGH_UC_ARP_DELAY_MSEC;
 	timer_netlink_update_msec = MCE_DEFAULT_NETLINK_TIMER_MSEC;
 
+	deferred_close = MCE_DEFAULT_DEFERRED_CLOSE;
 	rx_poll_on_tx_tcp	= MCE_DEFAULT_RX_POLL_ON_TX_TCP;
 	trigger_dummy_send_getsockname = MCE_DEFAULT_TRIGGER_DUMMY_SEND_GETSOCKNAME;
 
@@ -1266,6 +1267,10 @@ void mce_sys_var::get_env_params()
 
 	if ((env_ptr = getenv(SYS_VAR_TCP_CC_ALGO)) != NULL)
 		lwip_cc_algo_mod = (uint32_t)atoi(env_ptr);
+
+	if ((env_ptr = getenv(SYS_VAR_DEFERRED_CLOSE)) != NULL) {
+		deferred_close = atoi(env_ptr) ? true : false;
+	}
 
 	if ((env_ptr = getenv(SYS_VAR_VMA_RX_POLL_ON_TX_TCP)) != NULL)
 		rx_poll_on_tx_tcp = atoi(env_ptr) ? true : false;

--- a/src/vma/util/sys_vars.h
+++ b/src/vma/util/sys_vars.h
@@ -424,6 +424,9 @@ public:
 	uint32_t 	vma_time_measure_num_samples;
 	char 		vma_time_measure_filename[PATH_MAX];
 	sysctl_reader_t & sysctl_reader;
+	// Workaround for #3440429: postpone close(2) to the socket destructor, so the sockfd is closed
+	// after the rfs rule is destroyed. Otherwise, flow_tag or TCP port can be reused too early.
+	bool deferred_close;
 	bool		rx_poll_on_tx_tcp;
 	hyper_t		hypervisor;
 	bool		trigger_dummy_send_getsockname;
@@ -567,6 +570,7 @@ extern mce_sys_var & safe_mce_sys();
 
 #define SYS_VAR_VMA_TIME_MEASURE_NUM_SAMPLES		"VMA_TIME_MEASURE_NUM_SAMPLES"
 #define SYS_VAR_VMA_TIME_MEASURE_DUMP_FILE		"VMA_TIME_MEASURE_DUMP_FILE"
+#define SYS_VAR_DEFERRED_CLOSE "VMA_DEFERRED_CLOSE"
 #define SYS_VAR_VMA_RX_POLL_ON_TX_TCP			"VMA_RX_POLL_ON_TX_TCP"
 #define SYS_VAR_VMA_TRIGGER_DUMMY_SEND_GETSOCKNAME	"VMA_TRIGGER_DUMMY_SEND_GETSOCKNAME"
 
@@ -701,6 +705,7 @@ extern mce_sys_var & safe_mce_sys();
 #endif /* DEFINED_TSO */
 #define MCE_DEFAULT_RX_POLL_ON_TX_TCP			(false)
 #define MCE_DEFAULT_TRIGGER_DUMMY_SEND_GETSOCKNAME	(false)
+#define MCE_DEFAULT_DEFERRED_CLOSE (false)
 
 #define MCE_ALIGNMENT					((unsigned long)63)
 #define RX_BUF_SIZE(mtu)				((mtu) + IPOIB_HDR_LEN + GRH_HDR_LEN) // RX buffers are larger in IB


### PR DESCRIPTION
1. Stop processing TCP timers in the main thread.
2. Add a locking mechanism for incoming TCP connections that haven't been accepted yet by the application.

## Change type
What kind of change does this PR introduce?
- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Tests
- [ ] Other

## Check list
- [ ] Code follows the style de facto guidelines of this project
- [ ] Comments have been inserted in hard to understand places
- [ ] Documentation has been updated (if necessary)
- [ ] Test has been added (if possible)

