### PR TITLE
issue: 1214066 Update some unsigned char -> uint32_t for table_id

### DIFF
--- a/src/vma/proto/route_table_mgr.cpp
+++ b/src/vma/proto/route_table_mgr.cpp
@@ -182,7 +182,7 @@ void route_table_mgr::rt_mgr_update_source_ip()
 			if (p_val->get_gw_addr() && !p_val->get_src_addr()) {
 				route_val* p_val_dst;
 				in_addr_t in_addr = p_val->get_gw_addr();
-				unsigned char table_id = p_val->get_table_id();
+				uint32_t table_id = p_val->get_table_id();
 				if (find_route_val(in_addr, table_id, p_val_dst)) {
 					if (p_val_dst->get_src_addr()) {
 						p_val->set_src_addr(p_val_dst->get_src_addr());
@@ -318,7 +318,7 @@ void route_table_mgr::parse_attr(struct rtattr *rt_attribute, route_val *p_val)
 	}
 }
 
-bool route_table_mgr::find_route_val(in_addr_t &dst, unsigned char table_id, route_val* &p_val)
+bool route_table_mgr::find_route_val(in_addr_t &dst, uint32_t table_id, route_val* &p_val)
 {
 	ip_address dst_addr = dst;
 	rt_mgr_logfunc("dst addr '%s'", dst_addr.to_str().c_str());
@@ -357,12 +357,12 @@ bool route_table_mgr::route_resolve(IN route_rule_table_key key, OUT route_resul
 	rt_mgr_logdbg("dst addr '%s'", dst_addr.to_str().c_str());
 
 	route_val *p_val = NULL;
-	std::deque<unsigned char> table_id_list;
+	std::deque<uint32_t> table_id_list;
 	
 	g_p_rule_table_mgr->rule_resolve(key, table_id_list);
 
 	auto_unlocker lock(m_lock);
-	std::deque<unsigned char>::iterator table_id_iter = table_id_list.begin();
+	std::deque<uint32_t>::iterator table_id_iter = table_id_list.begin();
 	for (; table_id_iter != table_id_list.end(); table_id_iter++) {
 		if (find_route_val(dst, *table_id_iter, p_val)) {
 			res.p_src = p_val->get_src_addr();
@@ -392,7 +392,7 @@ void route_table_mgr::update_entry(INOUT route_entry* p_ent, bool b_register_to_
 		if (p_rr_entry && p_rr_entry->get_val(p_rr_val)) {
 			route_val* p_val = NULL;
 			in_addr_t peer_ip = p_ent->get_key().get_dst_ip();
-			unsigned char table_id;
+			uint32_t table_id;
 			for (std::deque<rule_val*>::iterator p_rule_val = p_rr_val->begin(); p_rule_val != p_rr_val->end(); p_rule_val++) {
 				table_id = (*p_rule_val)->get_table_id();
 				if (find_route_val(peer_ip, table_id, p_val)) {

--- a/src/vma/proto/route_table_mgr.h
+++ b/src/vma/proto/route_table_mgr.h
@@ -75,7 +75,7 @@ private:
 	// in constructor creates route_entry for each net_dev, to receive events in case there are no other route_entrys
 	in_addr_route_entry_map_t m_rte_list_for_each_net_dev;
 
-	bool		find_route_val(in_addr_t &dst_addr, unsigned char table_id, route_val* &p_val);
+	bool		find_route_val(in_addr_t &dst_addr, uint32_t table_id, route_val* &p_val);
 	
 	// save current main rt table
 	void		update_tbl();

--- a/src/vma/proto/rule_table_mgr.cpp
+++ b/src/vma/proto/rule_table_mgr.cpp
@@ -261,7 +261,7 @@ bool rule_table_mgr::is_matching_rule(route_rule_table_key key, rule_val* p_val)
 //		key			: key object that contain information about destination.
 //		table_id_list	: list that will contain table ID for all rule that match destination info   
 // Returns true if at least one rule match destination info, false otherwise.
-bool rule_table_mgr::rule_resolve(route_rule_table_key key, std::deque<unsigned char> &table_id_list)
+bool rule_table_mgr::rule_resolve(route_rule_table_key key, std::deque<uint32_t> &table_id_list)
 {
 	rr_mgr_logdbg("dst info: '%s'", key.to_str().c_str());
 

--- a/src/vma/proto/rule_table_mgr.h
+++ b/src/vma/proto/rule_table_mgr.h
@@ -51,7 +51,7 @@ public:
 	
 	rule_entry* 	create_new_entry(route_rule_table_key key, const observer *obs);
 	void 	   	update_entry(rule_entry* p_ent);
-	bool	 	rule_resolve(route_rule_table_key key, std::deque<unsigned char> &table_id_list);
+	bool	 	rule_resolve(route_rule_table_key key, std::deque<uint32_t> &table_id_list);
 
 protected:
 	virtual bool	parse_enrty(nlmsghdr *nl_header, rule_val *p_val);


### PR DESCRIPTION
## Description
This fixes a few places that weren't updated from `unsigned char` to `uint32_t` when support for extended route and rule tables was done for issue 1214066 (a90d08dd5140e0cbc6b6a45ddf71ebda69bb4141)

##### What
Changes type for `table_id` from `unsigned char` -> `uint32_t` in more places.

##### Why ?
Extended routing table IDs overflow when used in these functions since unsigned char can only contain values up to 255 (8 bits) but extended table IDs can be 32 bits.

## Change type
What kind of change does this PR introduce?
- [X] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Tests
- [ ] Other

## Check list
- [ ] Code follows the style de facto guidelines of this project
- [ ] Comments have been inserted in hard to understand places
- [ ] Documentation has been updated (if necessary)
- [ ] Test has been added (if possible)

