### PR TITLE
issue 3749337 Handle negative Keapalive params

### DIFF
--- a/src/vma/util/sysctl_reader.h
+++ b/src/vma/util/sysctl_reader.h
@@ -150,17 +150,19 @@ public :
 	const tcp_keepalive_info get_tcp_keepalive_info(bool update = false)
 	{
 		static tcp_keepalive_info val = {7200, 75, 9};
-		auto read_file_to_positive_int = [](const char *path, int default_value) {
+		auto read_positive_or_default = [](const char *path, int default_value) {
 			int ret = read_file_to_int(path, default_value);
 			return ret > 0 ? ret : default_value;
 		};
 		if (update) {
 			val.idle_secs =
-				read_file_to_positive_int("/proc/sys/net/ipv4/tcp_keepalive_time", val.idle_secs);
+				read_positive_or_default("/proc/sys/net/ipv4/tcp_keepalive_time", val.idle_secs);
 			val.interval_secs =
-				read_file_to_positive_int("/proc/sys/net/ipv4/tcp_keepalive_intvl", val.interval_secs);
+				std::max(0, read_file_to_int("/proc/sys/net/ipv4/tcp_keepalive_intvl",
+											 val.interval_secs));
 			val.num_probes =
-				read_file_to_positive_int("/proc/sys/net/ipv4/tcp_keepalive_probes", val.num_probes);
+				std::max(0, read_file_to_int("/proc/sys/net/ipv4/tcp_keepalive_probes",
+											 val.num_probes));
 		}
 		return val;
 	}


### PR DESCRIPTION
1. Probe and interval values may be negative in:
	- /proc/sys/net/ipv4/tcp_keepalive_intvl
	- /proc/sys/net/ipv4/tcp_keepalive_probe
2. Internally the values will be set to 0 if negative.

## Change type
What kind of change does this PR introduce?
- [X] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Tests
- [ ] Other

## Check list
- [ ] Code follows the style de facto guidelines of this project
- [ ] Comments have been inserted in hard to understand places
- [ ] Documentation has been updated (if necessary)
- [ ] Test has been added (if possible)