### PR TITLE
issue: Set MLX5_SHUT_UP_BF if VMA_BF=0

### DIFF
--- a/src/vma/util/sys_vars.cpp
+++ b/src/vma/util/sys_vars.cpp
@@ -1317,6 +1317,9 @@ void set_env_params()
 		/* todo - these seem not to work if inline is on, since libmlx is doing (inl || bf) when deciding to bf*/
 		setenv("MLX4_POST_SEND_PREFER_BF", "0", 1);
 		setenv("MLX5_POST_SEND_PREFER_BF", "0", 1);
+		if (!getenv("MLX5_SHUT_UP_BF")) {
+			setenv("MLX5_SHUT_UP_BF", "1", 1);
+		}
 	}
 
 	switch (safe_mce_sys().mem_alloc_type) {


### PR DESCRIPTION
## Description

MLX5_SHUT_UP_BF forces rdma-core to create a single NC UAR instead of 16 BF registers. Since VMA_BF=0 is supposed to disable BlueFlame functionality, disable it in rdma-core as well.

##### What
Set MLX5_SHUT_UP_BF if VMA_BF=0

##### Why ?
Use NC UAR with disabled BlueFlame.

## Change type
What kind of change does this PR introduce?
- [ ] Bugfix
- [x] Feature
- [ ] Code style update
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Tests
- [ ] Other

## Check list
- [ ] Code follows the style de facto guidelines of this project
- [ ] Comments have been inserted in hard to understand places
- [ ] Documentation has been updated (if necessary)
- [ ] Test has been added (if possible)

