### PR TITLE
Fix compilation with GCC 14

### DIFF
--- a/src/vma/util/vma_list.h
+++ b/src/vma/util/vma_list.h
@@ -207,7 +207,7 @@ public:
 		}
 	}
 
-	vma_list_t<T, offset> (const vma_list_t<T, offset>& other) {
+	vma_list_t(const vma_list_t<T, offset>& other) {
 		if (!other.empty())
 			vlist_logwarn("Copy constructor is not supported for non-empty list! other.size=%zu", other.m_size);
 		init_list();


### PR DESCRIPTION
## Description
C++20 has changed the syntax for nested template constructors:
```
In file included from ../../src/vma/proto/mem_buf_desc.h:39,
                 from ../../src/vma/util/utils.h:47,
                 from vlogger.cpp:46:
../../src/vma/util/vma_list.h:210:31: error: template-id not allowed for constructor in C++20 [-Werror=template-id-cdtor]
  210 |         vma_list_t<T, offset> (const vma_list_t<T, offset>& other) {
      |                               ^
../../src/vma/util/vma_list.h:210:31: note: remove the '< >'
```

##### What
Fixes compilation with GCC 14 and C++20.

##### Why ?
GCC 14 is the default compiler for RHEL 10 and Fedora 40, and newer.

## Change type
What kind of change does this PR introduce?
- [x] Bugfix

## Check list
- [x] Code follows the style de facto guidelines of this project
- [x] Comments have been inserted in hard to understand places
- [x] Documentation has been updated (if necessary)
- [x] Test has been added (if possible)

