### PR TITLE
[CI] Migrate pipeline to Blossom

### DIFF
--- a/.ci/matrix_job.yaml
+++ b/.ci/matrix_job.yaml
@@ -102,8 +102,6 @@ steps:
       ./.ci/artifacts.sh
     archiveArtifacts-onfail: |
       jenkins/**/arch-*.tar.gz
-    archiveTap-onfail: |
-      jenkins/**/*.tap
 
   - name: Service
     enable: ${do_service}
@@ -119,8 +117,6 @@ steps:
       ./.ci/artifacts.sh
     archiveArtifacts-onfail: |
       jenkins/**/arch-*.tar.gz
-    archiveTap-onfail: |
-      jenkins/**/*.tap
 
   - name: Package
     enable: ${do_package}
@@ -132,8 +128,6 @@ steps:
       ./.ci/artifacts.sh
     archiveArtifacts-onfail: |
       jenkins/**/arch-*.tar.gz
-    archiveTap-onfail: |
-      jenkins/**/*.tap
 
   - name: Style
     enable: ${do_style}
@@ -149,8 +143,6 @@ steps:
       ./.ci/artifacts.sh
     archiveArtifacts-onfail: |
       jenkins/**/arch-*.tar.gz
-    archiveTap-onfail: |
-      jenkins/**/*.tap
 
   - name: Compiler
     enable: ${do_compiler}
@@ -166,8 +158,6 @@ steps:
       ./.ci/artifacts.sh
     archiveArtifacts-onfail: |
       jenkins/**/arch-*.tar.gz
-    archiveTap-onfail: |
-      jenkins/**/*.tap
 
   - name: Coverity
     enable: ${do_coverity}
@@ -185,8 +175,6 @@ steps:
     archiveArtifacts-onfail: |
       jenkins/**/arch-*.tar.gz,
       jenkins/**/output/errors/**/*.html
-    archiveTap-onfail: |
-      jenkins/**/*.tap
 
   - name: Cppcheck
     enable: ${do_cppcheck}
@@ -202,8 +190,6 @@ steps:
       ./.ci/artifacts.sh
     archiveArtifacts-onfail: |
       jenkins/**/arch-*.tar.gz
-    archiveTap-onfail: |
-      jenkins/**/*.tap
 
   - name: Csbuild
     enable: ${do_csbuild}
@@ -219,8 +205,6 @@ steps:
       ./.ci/artifacts.sh
     archiveArtifacts-onfail: |
       jenkins/**/arch-*.tar.gz
-    archiveTap-onfail: |
-      jenkins/**/*.tap
 
   - name: Test
     enable: ${do_test}
@@ -236,8 +220,6 @@ steps:
       ./.ci/artifacts.sh
     archiveArtifacts-onfail: |
       jenkins/**/arch-*.tar.gz
-    archiveTap-onfail: |
-      jenkins/**/*.tap
 
   - name: Gtest
     enable: ${do_gtest}
@@ -253,8 +235,6 @@ steps:
       ./.ci/artifacts.sh
     archiveArtifacts-onfail: |
       jenkins/**/arch-*.tar.gz
-    archiveTap-onfail: |
-      jenkins/**/*.tap
     archiveJunit-onfail: |
       jenkins/**/*.xml
 
@@ -273,8 +253,6 @@ steps:
     archiveArtifacts-onfail: |
       jenkins/**/arch-*.tar.gz,
       jenkins/**/vg/*valgrind*.log
-    archiveTap-onfail: |
-      jenkins/**/*.tap
 
   - name: Commit
     enable: ${do_commit}
@@ -290,8 +268,6 @@ steps:
       ./.ci/artifacts.sh
     archiveArtifacts-onfail: |
       jenkins/**/arch-*.tar.gz
-    archiveTap-onfail: |
-      jenkins/**/*.tap
 
   - name: Artifacts
     enable: ${do_artifact}
@@ -300,8 +276,6 @@ steps:
     parallel: false
     archiveArtifacts: |
       jenkins/**/arch-*.tar.gz
-    archiveTap: |
-      jenkins/**/*.tap
     archiveJunit: |
       jenkins/**/*.xml
 

--- a/.ci/proj_jjb.yaml
+++ b/.ci/proj_jjb.yaml
@@ -1,9 +1,10 @@
 - job-template:
     name: "{jjb_proj}"
     project-type: pipeline
+    folder: libvma
     properties:
         - github:
-             url: "{jjb_git}"
+             url: "https://github.com/Mellanox/libvma"
         - build-discarder:
             days-to-keep: 50
             num-to-keep: 20
@@ -98,12 +99,12 @@
         - github-pull-request:
             cron: 'H/5 * * * *'
             trigger-phrase: '.*\bbot:retest\b.*'
-            status-context: "Mellanox Lab"
+            status-context: ""{jjb_proj}""
             success-status: "[PASS]"
             failure-status: "[FAIL]"
             error-status:   "[FAIL]"
             status-add-test-results: true
-            auth-id: '549927eb-7f38-4a8f-997a-81dd63605782'
+            auth-id: '2806c206-c725-4d8c-af4b-bedfc463b401'
             org-list: ["Mellanox"]
             white-list: ["swx-jenkins","swx-jenkins2","swx-jenkins3","mellanox-github"]
             allow-whitelist-orgs-as-admins: true
@@ -112,7 +113,7 @@
         scm:
             - git:
                 url: "{jjb_git}"
-                credentials-id: 'ef94fa95-5480-41ea-863f-6525aace5bc9'
+                credentials-id: 'b7d08ca7-378c-45d6-ac4b-3f30bdf49168'
                 branches: ['$sha1']
                 shallow-clone: true
                 depth: 2
@@ -121,10 +122,10 @@
                 browser-url: "{jjb_git}"
         script-path: ".ci/Jenkinsfile"
 - project:
-    name: proj_name
-    jjb_email: 'lennyb@nvidia.com'
+    name: libvma
+    jjb_email: 'nwolfer@nvidia.com'
     jjb_proj: 'LibVMA'
-    jjb_git: 'https://github.com/Mellanox/libvma'
-    jjb_owner: 'Lenny Verkhovsky'
+    jjb_git: 'git@github.com:Mellanox/libvma.git'
+    jjb_owner: 'Nir Wolfer'
     jobs:
         - "{jjb_proj}"


### PR DESCRIPTION
## Description
Changes related to migration of CI to Blossom Jenkins

##### What
Change proj_jjb.yaml and job_matrix.yaml to fit the new nbu jenkins master, to allow it to run on the new jenkins instance Remove tap archives from job matrix, as it is not in use by anyone and the plugin is not installed on the new Blossom master

##### Why ?
Issue: HPCINFRA-2277

##### How ?
_It is optional but for complex PRs please provide information about the design,
architecture, approach, etc._

## Change type
What kind of change does this PR introduce?
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [x] CI related changes
- [ ] Documentation content changes
- [ ] Tests
- [ ] Other

## Check list
- [ ] Code follows the style de facto guidelines of this project
- [ ] Comments have been inserted in hard to understand places
- [ ] Documentation has been updated (if necessary)
- [ ] Test has been added (if possible)

