### PR TITLE
issue: 3977246 ngci connecting to the wrong url

### DIFF
--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -2,7 +2,7 @@
 
 // load pipeline functions
 // Requires pipeline-github-lib plugin to load library from github
-@Library('github.com/Mellanox/ci-demo@stable')
+@Library('github.com/Mellanox/ci-demo@stable_media')
 def matrix = new com.mellanox.cicd.Matrix()
 
 matrix.main()

--- a/.ci/matrix_job.yaml
+++ b/.ci/matrix_job.yaml
@@ -7,7 +7,7 @@ registry_host: harbor.mellanox.com
 registry_auth: swx-storage
 
 kubernetes:
-  privileged: false
+  privileged: true
   cloud: swx-k8s-spray
   nodeSelector: 'beta.kubernetes.io/os=linux'
 
@@ -37,7 +37,6 @@ runs_on_dockers:
   - {name: 'ub20.04-mofed-aarch64', url: 'harbor.mellanox.com/swx-infra/aarch64/ubuntu20.04/builder:mofed-5.2-1.0.4.0', category: 'base', arch: 'aarch64'}
   - {name: 'rhel8.6-inbox-x86_64', url: 'harbor.mellanox.com/hpcx/x86_64/rhel8.6/builder:inbox', category: 'base', arch: 'x86_64'}
   - {name: 'ub22.04-mofed-x86_64', url: 'harbor.mellanox.com/hpcx/x86_64/ubuntu22.04/builder:mofed-5.7-0.1.1.0', category: 'base', arch: 'x86_64'}
-#  - {name: 'fc36-x86_64',  url: 'harbor.mellanox.com/rivermax/x86_64/fedora36:builder', category: 'base', arch: 'x86_64'}
 # tool
   - {name: 'toolbox', url: 'harbor.mellanox.com/hpcx/x86_64/rhel8.3/builder:inbox', category: 'tool', arch: 'x86_64'}
   - {name: 'blackduck', url: 'harbor.mellanox.com/toolbox/ngci-centos:7.9.2009.2', category: 'tool', arch: 'x86_64'}
@@ -289,12 +288,14 @@ steps:
     module: ngci
     run: NGCIBlackDuckScan
     args:
-      projectName: ${jjb_proj}
-      projectVersion: ${ghprbPullId}
+      projectName: "LibVMA"
+      projectVersion: "0.1.0"
       projectSrcPath: "src"
       attachArtifact: true
       reportName: "BlackDuck report"
       scanMode: "source"
+      skipDockerDaemonCheck: true
+      credentialsId: "b68aedbd-e39f-4ee2-acce-e25a5b91fe18"
     env:
       SPRING_APPLICATION_JSON: '{"blackduck.url":"https://blackduck.mellanox.com/","blackduck.api.token":"ODMwOWYwMzEtODA2ZC00MzBjLWI1ZDEtNmFiMjBkYzQzMzkwOjNmNjExN2M1LWE2ZmEtNDZlYS1hZjRiLTZlNDgwNjAwOTVjNw=="}'
 


### PR DESCRIPTION
## Description
BlackDuck scan fails due to ngci connecting to the old gerrit url, fix is made to both this repo and the ci-demo repo (Changes made in this PR: https://github.com/Mellanox/ci-demo/pull/90)

##### What
Add credentialsId to login into the new gerrit url
skipDockerDaemonCheck configuration provided by the gerrit team.

##### Why ?
Issue: HPCINFRA-2289

## Change type
What kind of change does this PR introduce?
- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [x] CI related changes
- [ ] Documentation content changes
- [ ] Tests
- [ ] Other

## Check list
- [ ] Code follows the style de facto guidelines of this project
- [ ] Comments have been inserted in hard to understand places
- [ ] Documentation has been updated (if necessary)
- [ ] Test has been added (if possible)

