### PR TITLE
[CI] issue: 4007026 Remove latest file link from release script

### DIFF
--- a/.ci/do_release.sh
+++ b/.ci/do_release.sh
@@ -70,12 +70,7 @@ if [ "${do_release}" = true ] ; then
 
     sudo -E -u swx-jenkins mkdir -p "$DST_DIR"
     sudo -E -u swx-jenkins cp -v "${pkg_name}" "$DST_DIR"
-
-    cd "${release_folder}"
-    sudo -E -u swx-jenkins ln -s "$DST_DIR/${pkg_name}" latest_release
-
     echo "Release found at $DST_DIR"
-
 else
      echo "do_release is set to false, skipping package release."
 fi

--- a/.ci/proj_jjb.yaml
+++ b/.ci/proj_jjb.yaml
@@ -99,7 +99,7 @@
         - github-pull-request:
             cron: 'H/5 * * * *'
             trigger-phrase: '.*\bbot:retest\b.*'
-            status-context: ""{jjb_proj}""
+            status-context: "{jjb_proj}"
             success-status: "[PASS]"
             failure-status: "[FAIL]"
             error-status:   "[FAIL]"


### PR DESCRIPTION
## Description
The new release pipeline links the latest release to a file called latest release, the dev team requested this feature to be removed

##### What
Remove ln line from do_release script

##### Why ?
Requested by the dev team

## Change type
What kind of change does this PR introduce?
- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [x] CI related changes
- [ ] Documentation content changes
- [ ] Tests
- [ ] Other

## Check list
- [ ] Code follows the style de facto guidelines of this project
- [ ] Comments have been inserted in hard to understand places
- [ ] Documentation has been updated (if necessary)
- [ ] Test has been added (if possible)