### PR TITLE
issue HPCINFRA-2469: [CI] remove support for old OS images

### DIFF
--- a/.ci/matrix_job.yaml
+++ b/.ci/matrix_job.yaml
@@ -30,7 +30,7 @@ env:
   build_dockers: false
 
 runs_on_dockers:
-# doca-hostw
+# doca-host
   - {name: 'rhel8.6-x86_64', url: 'harbor.mellanox.com/hpcx/x86_64/rhel8.6/base', category: 'base', arch: 'x86_64'}
   - {name: 'rhel9.0-x86_64', url: 'harbor.mellanox.com/hpcx/x86_64/rhel9.0/base', category: 'base', arch: 'x86_64'}
   - {name: 'ub24.04-x86_64', url: 'harbor.mellanox.com/hpcx/x86_64/ubuntu24.04/base', category: 'base', arch: 'x86_64'}
@@ -40,14 +40,12 @@ runs_on_dockers:
   - {name: 'ub22.04-x86_64', url: 'harbor.mellanox.com/hpcx/x86_64/ubuntu22.04/base', category: 'base', arch: 'x86_64'}
   - {name: 'ub22.04-aarch64', url: 'harbor.mellanox.com/hpcx/aarch64/ubuntu22.04/base', category: 'base', arch: 'aarch64'}
 # tool
-  - {name: 'toolbox', url: 'harbor.mellanox.com/hpcx/x86_64/rhel8.3/builder:inbox', category: 'tool', arch: 'x86_64'}
+  - {name: 'toolbox', url: 'harbor.mellanox.com/hpcx/x86_64/rhel8.6/builder:inbox', category: 'tool', arch: 'x86_64'}
   - {name: 'blackduck', url: 'harbor.mellanox.com/toolbox/ngci-centos:7.9.2009.2', category: 'tool', arch: 'x86_64'}
   - {name: 'header-check', url: 'harbor.mellanox.com/toolbox/header_check:0.0.51', category: 'tool', arch: 'x86_64', tag: '0.0.51'}
 
 runs_on_agents:
   - {nodeLabel: 'beni09', category: 'base'}
-  - {nodeLabel: 'r-aa-fatty22-005', category: 'azure'}
-  - {nodeLabel: 'r-aa-fatty22-006', category: 'azure'}
 
 matrix:
   axes:

--- a/.ci/redmine_matrix_job.yaml
+++ b/.ci/redmine_matrix_job.yaml
@@ -21,18 +21,17 @@ volumes:
   - {mountPath: /hpc/local/inst/hpc-internal-tools, hostPath: /hpc/local/inst/hpc-internal-tools}
 
 runs_on_dockers:
-# ubuntu 16.04 is used due to script dependency on python2 old print format
-  - {name: 'ub16.04-base', url: 'harbor.mellanox.com/swx-infra/x86_64/ubuntu16.04/base', arch: 'x86_64'}
+  - {name: 'ub22.04-base', url: 'harbor.mellanox.com/hpcx/x86_64/ubuntu22.04/base', arch: 'x86_64'}
 
 steps:
   - name: Redmine
     containerSelector:
-      - "{name: 'ub16.04-base'}"
+      - "{name: 'ub22.04-base'}"
     run: |
       #!/bin/bash -eExl
       env
-
-      /hpc/local/inst/hpc-internal-tools/tools/git_tools/git_redmine/update_redmine_from_git_commit.py --update --project_id=9 --on_email_mismatch=warn \
+      python3 -m pip install six
+      python3 /hpc/local/inst/hpc-internal-tools/tools/git_tools/git_redmine/update_redmine_from_git_commit_python3.py --update --project_id=9 --on_email_mismatch=warn \
       --on_issue_not_in_project=fail --pr_url=${ghprbPullLink} --commit_id=${ghprbActualCommit}
     parallel: false
 


### PR DESCRIPTION
issue: HPCINFRA-2469

## Description
Remove support for old OS images

##### What
- removed ubuntu20.x
- removed branches running on r-aa-fatty22-005 and r-aa-fatty22-005 (rhel7,5 and ubuntu16.04 accordingly)

##### Why ?
Old OS versions are not supported by DOCA which we're going to switch to

##### How ?
Update job_matrix config

## Change type
What kind of change does this PR introduce?
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [x] CI related changes
- [ ] Documentation content changes
- [ ] Tests
- [ ] Other