### PR TITLE
issue: 4072930 Secrets Scanner - rename Jenkins secrets IDs 

### DIFF
--- a/.ci/matrix_job.yaml
+++ b/.ci/matrix_job.yaml
@@ -23,8 +23,8 @@ volumes:
   - {mountPath: /hpc/local/etc/modulefiles, hostPath: /hpc/local/etc/modulefiles}
 
 credentials:
-  - {credentialsId: '925b0900-e273-4042-bc7c-facaefae0727', usernameVariable: 'VMA_COV_USER', passwordVariable: 'VMA_COV_PASSWORD'}
-  - {credentialsId: 'fb735938-fa1c-4b61-b568-a7c153b4fe74', usernameVariable: 'MELLANOX_GH_USER', passwordVariable: 'MELLANOX_GH_TOKEN'}
+  - {credentialsId: 'media_coverity_credentials', usernameVariable: 'VMA_COV_USER', passwordVariable: 'VMA_COV_PASSWORD'}
+  - {credentialsId: 'mellanox_github_credentials', usernameVariable: 'MELLANOX_GH_USER', passwordVariable: 'MELLANOX_GH_TOKEN'}
 
 env:
   build_dockers: false
@@ -80,7 +80,7 @@ steps:
 
   - name: Copyrights
     enable: ${do_copyrights}
-    credentialsId: 'fb735938-fa1c-4b61-b568-a7c153b4fe74'
+    credentialsId: 'mellanox_github_credentials'
     run: env WORKSPACE=$PWD GITHUB_TOKEN=$MELLANOX_GH_TOKEN ./contrib/jenkins_tests/copyrights.sh
     containerSelector:
       - "{name: 'header-check', category: 'tool'}"
@@ -181,7 +181,7 @@ steps:
 
   - name: Coverity
     enable: ${do_coverity}
-    credentialsId: '925b0900-e273-4042-bc7c-facaefae0727'
+    credentialsId: 'media_coverity_credentials'
     containerSelector:
       - "{name: 'toolbox', category: 'tool'}"
     agentSelector:

--- a/.ci/pipeline/release_jjb.yaml
+++ b/.ci/pipeline/release_jjb.yaml
@@ -47,7 +47,7 @@
         scm:
             - git:
                 url: "{jjb_git}"
-                credentials-id: 'b7d08ca7-378c-45d6-ac4b-3f30bdf49168'
+                credentials-id: 'swx-jenkins_ssh_key'
                 branches: ['$sha1']
                 shallow-clone: true
                 depth: 2
@@ -105,7 +105,7 @@
         scm:
             - git:
                 url: "{jjb_git}"
-                credentials-id: 'b7d08ca7-378c-45d6-ac4b-3f30bdf49168'
+                credentials-id: 'swx-jenkins_ssh_key'
                 branches: ['$sha1']
                 shallow-clone: true
                 depth: 2

--- a/.ci/pipeline/release_matrix_job.yaml
+++ b/.ci/pipeline/release_matrix_job.yaml
@@ -1,7 +1,7 @@
 ---
 job: LibVMA-release
 registry_host: harbor.mellanox.com
-registry_auth: 1daaea28-800e-425f-a91f-3bd3e9136eea
+registry_auth: swx-infra_harbor_credentials
 registry_path: /swx-infra/media/libvma
 
 kubernetes:

--- a/.ci/pipeline/release_matrix_job_dr.yaml
+++ b/.ci/pipeline/release_matrix_job_dr.yaml
@@ -1,7 +1,7 @@
 ---
 job: LibVMA-release-dr
 registry_host: harbor-pdc.nvidia.com
-registry_auth: 1daaea28-800e-425f-a91f-3bd3e9136eea
+registry_auth: swx-infra_harbor_credentials
 registry_path: /swx-infra/media/libvma
 
 kubernetes:

--- a/.ci/proj_jjb.yaml
+++ b/.ci/proj_jjb.yaml
@@ -115,7 +115,7 @@
             failure-status: "[FAIL]"
             error-status:   "[FAIL]"
             status-add-test-results: true
-            auth-id: '2806c206-c725-4d8c-af4b-bedfc463b401'
+            auth-id: 'swx-jenkins_ssh_key'
             org-list: ["Mellanox"]
             white-list: ["swx-jenkins","swx-jenkins2","swx-jenkins3","mellanox-github"]
             allow-whitelist-orgs-as-admins: true
@@ -124,7 +124,7 @@
         scm:
             - git:
                 url: "{jjb_git}"
-                credentials-id: 'b7d08ca7-378c-45d6-ac4b-3f30bdf49168'
+                credentials-id: 'swx-jenkins_ssh_key'
                 branches: ['$sha1']
                 shallow-clone: true
                 depth: 2

--- a/.ci/redmine_jjb.yaml
+++ b/.ci/redmine_jjb.yaml
@@ -42,7 +42,7 @@
             failure-status: "[FAIL]"
             error-status:   "[FAIL]"
             status-add-test-results: true
-            auth-id: '2806c206-c725-4d8c-af4b-bedfc463b401'
+            auth-id: 'swx-jenkins_ssh_key'
             admin-list: ["Mellanox"]
             org-list: ["Mellanox"]
             white-list: ["Mellanox"]
@@ -53,7 +53,7 @@
         scm:
             - git:
                 url: "{jjb_git}"
-                credentials-id: 'b7d08ca7-378c-45d6-ac4b-3f30bdf49168'
+                credentials-id: 'swx-jenkins_ssh_key'
                 branches: ['$sha1']
                 shallow-clone: true
                 depth: 2


### PR DESCRIPTION
## Description
Secrets Scanner - rename Jenkins secrets IDs to human-readable format

##### What
Update Jenkins's secrets reference in CI

##### Why ?
UUID format in secrets references confuses Secrets Scanner, which takes these data for passwords and fail.

## Change type
What kind of change does this PR introduce?
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [x] CI related changes
- [ ] Documentation content changes
- [ ] Tests
- [ ] Other

## Check list
- [ ] Code follows the style de facto guidelines of this project
- [ ] Comments have been inserted in hard to understand places
- [ ] Documentation has been updated (if necessary)
- [ ] Test has been added (if possible)

