### PR TITLE
issue: 4223310 VMA support for kernel 6.10

### DIFF
--- a/src/vma/proto/route_table_mgr.h
+++ b/src/vma/proto/route_table_mgr.h
@@ -70,7 +70,7 @@ public:
 	virtual void 	notify_cb(event *ev);
 
 protected:
-	virtual bool	parse_enrty(nlmsghdr *nl_header, route_val *p_val);
+	virtual bool	parse_entry(struct nl_object *nl_obj, void *p_val_context);
 
 private:
 	// in constructor creates route_entry for each net_dev, to receive events in case there are no other route_entrys
@@ -80,7 +80,7 @@ private:
 	
 	// save current main rt table
 	void		update_tbl();
-	void		parse_attr(struct rtattr *rt_attribute, route_val *p_val);
+	void		parse_attr(struct rtnl_route *route, route_val *p_val);
 	
 	void		rt_mgr_update_source_ip();
 

--- a/src/vma/proto/rule_table_mgr.h
+++ b/src/vma/proto/rule_table_mgr.h
@@ -55,12 +55,12 @@ public:
 	bool	 	rule_resolve(route_rule_table_key key, std::deque<uint32_t> &table_id_list);
 
 protected:
-	virtual bool	parse_enrty(nlmsghdr *nl_header, rule_val *p_val);
+	virtual bool	parse_entry(struct nl_object *nl_obj, void *p_val_context);
 	virtual void	update_tbl();
 	
 private:
 
-	void		parse_attr(struct rtattr *rt_attribute, rule_val *p_val);
+	void		parse_attr(struct rtnl_rule *rule, rule_val *p_val);
 	
 	bool		find_rule_val(route_rule_table_key key, std::deque<rule_val*>* &p_val);
 	bool 		is_matching_rule(route_rule_table_key rrk, rule_val* p_val);

--- a/src/vma/proto/rule_val.cpp
+++ b/src/vma/proto/rule_val.cpp
@@ -47,9 +47,6 @@
 
 rule_val::rule_val(): cache_observer()
 {
-	m_protocol = 0;
-	m_scope = 0;
-	m_type = 0;
 	m_dst_addr = 0;
 	m_src_addr = 0;
 	memset(m_oif_name, 0, IFNAMSIZ * sizeof(char));

--- a/src/vma/proto/rule_val.h
+++ b/src/vma/proto/rule_val.h
@@ -53,9 +53,6 @@ public:
 
 	inline void set_dst_addr(in_addr_t const &dst_addr) 	{ m_dst_addr = dst_addr; };
 	inline void set_src_addr(in_addr_t const &src_addr) 	{ m_src_addr = src_addr; };
-	inline void set_protocol(unsigned char protocol) 	{ m_protocol = protocol; };
-	inline void set_scope(unsigned char scope) 		{ m_scope = scope; };
-	inline void set_type(unsigned char type) 		{ m_type = type; };
 	inline void set_tos(unsigned char tos) 			{ m_tos = tos; };
 	inline void set_table_id(uint32_t table_id) 		{ m_table_id = table_id; };
 	inline void set_iif_name(char *iif_name) 		{ memcpy(m_iif_name, iif_name, IFNAMSIZ); };
@@ -79,9 +76,6 @@ public:
 
 private:
 
-	unsigned char	m_protocol;
-	unsigned char	m_scope;
-	unsigned char	m_type;
 	unsigned char	m_tos;
 
 	union {


### PR DESCRIPTION
Kernel 6.10 netlink has breaked VMA functionality. 
Transitioned to libnl - an abstraction that wraps netlink.

This both solves the issue and makes us more robust.

## What
Build routing and rules table using libnl instead of netlink.
removed protocol field in rule_val as:
1. it wasn't in use.
2. the api to populate it in libnl - `rtnl_rule_get_protocol` isn't available in sles on the CI.

## Why ?
solves https://redmine.mellanox.com/issues/4223310

## How ?
Tested on kernel 5.21 and kernel 6.10.

## Change type
What kind of change does this PR introduce?
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Tests
- [ ] Other

## Check list
- [ ] Code follows the style de facto guidelines of this project
- [ ] Comments have been inserted in hard to understand places
- [ ] Documentation has been updated (if necessary)
- [ ] Test has been added (if possible)

