### PR TITLE
issue: 4251780 Add ioctl() extra api

### DIFF
--- a/contrib/jenkins_tests/gtest.sh
+++ b/contrib/jenkins_tests/gtest.sh
@@ -56,7 +56,11 @@ make -C tests/gtest CPPFLAGS="-DEXTRA_API_ENABLED=1"
 rc=$(($rc+$?))
 
 # Verify VMA EXTRA API tests
-eval "${sudo_cmd} $timeout_exe env GTEST_TAP=2 LD_PRELOAD=$gtest_lib $gtest_app $gtest_opt --gtest_filter=vma_*:-vma_poll.*:vma_ring.*:vma_send_zc.* --gtest_output=xml:${WORKSPACE}/${prefix}/test-extra.xml"
+eval "${sudo_cmd} $timeout_exe env GTEST_TAP=2 LD_PRELOAD=$gtest_lib $gtest_app $gtest_opt --gtest_filter=vma_*:-vma_ioctl.*:vma_poll.*:vma_ring.*:vma_send_zc.* --gtest_output=xml:${WORKSPACE}/${prefix}/test-extra.xml"
+rc=$(($rc+$?))
+
+# Verify VMA EXTRA API ioctl tests (should be launched alone)
+eval "${sudo_cmd} $timeout_exe env GTEST_TAP=2 LD_PRELOAD=$gtest_lib $gtest_app $gtest_opt --gtest_filter=vma_ioctl.* --gtest_output=xml:${WORKSPACE}/${prefix}/test-extra.xml"
 rc=$(($rc+$?))
 
 # Verify VMA EXTRA API socketxtreme mode tests

--- a/src/vma/dev/allocator.cpp
+++ b/src/vma/dev/allocator.cpp
@@ -128,8 +128,9 @@ void* vma_allocator::alloc_and_reg_mr(size_t size, ib_ctx_handler *p_ib_ctx_h, v
 	case ALLOC_TYPE_EXTERNAL:
 		ptr = m_memalloc(size);
 		if (NULL == ptr) {
-			__log_info_dbg("Failed allocating using external functions, "
-				       "falling back to another memory allocation method");
+			__log_info_warn("Failed allocating using external functions, "
+				       "falling back to another memory allocation method"
+					   "(errno=%d %m)", errno);
 		} else {
 			m_data_block = ptr;
 			m_length = size;

--- a/src/vma/dev/allocator.cpp
+++ b/src/vma/dev/allocator.cpp
@@ -60,8 +60,9 @@ vma_allocator::~vma_allocator()
 		return;
 	}
 	switch (m_mem_alloc_type) {
-		case ALLOC_TYPE_EXTERNAL:
+		case ALLOC_TYPE_REGISTER_MEMORY:
 			// not allocated by us
+			break;
 		case ALLOC_TYPE_CONTIG:
 			// freed as part of deregister_memory
 			break;
@@ -94,10 +95,10 @@ void* vma_allocator::alloc_and_reg_mr(size_t size, ib_ctx_handler *p_ib_ctx_h, v
 	uint64_t access = VMA_IBV_ACCESS_LOCAL_WRITE;
 
 	if (ptr) {
-		m_mem_alloc_type = ALLOC_TYPE_EXTERNAL;
+		m_mem_alloc_type = ALLOC_TYPE_REGISTER_MEMORY;
 	}
 	switch (m_mem_alloc_type) {
-	case ALLOC_TYPE_EXTERNAL:
+	case ALLOC_TYPE_REGISTER_MEMORY:
 		m_data_block = ptr;
 		register_memory(size, p_ib_ctx_h, access);
 		break;

--- a/src/vma/dev/allocator.h
+++ b/src/vma/dev/allocator.h
@@ -43,7 +43,11 @@ typedef std::unordered_map<ib_ctx_handler*, uint32_t> lkey_map_ib_ctx_map_t;
 
 class vma_allocator {
 public:
+	typedef void* (*alloc_t)(size_t);
+	typedef void (*free_t)(void*);
+public:
 	vma_allocator();
+	vma_allocator(alloc_t alloc_func, free_t free_func);
 	~vma_allocator();
 	void* alloc_and_reg_mr(size_t size, ib_ctx_handler *p_ib_ctx_h, void *ptr = NULL);
 	uint32_t find_lkey_by_ib_ctx(ib_ctx_handler *p_ib_ctx_h) const;
@@ -59,6 +63,8 @@ private:
 	size_t m_length;
 	void *m_data_block;
 	alloc_mode_t m_mem_alloc_type;
+	alloc_t m_memalloc;
+	free_t m_memfree;
 };
 
 #endif /* SRC_VMA_DEV_ALLOCATOR_H_ */

--- a/src/vma/dev/allocator.h
+++ b/src/vma/dev/allocator.h
@@ -43,9 +43,6 @@ typedef std::unordered_map<ib_ctx_handler*, uint32_t> lkey_map_ib_ctx_map_t;
 
 class vma_allocator {
 public:
-	typedef void* (*alloc_t)(size_t);
-	typedef void (*free_t)(void*);
-public:
 	vma_allocator();
 	vma_allocator(alloc_t alloc_func, free_t free_func);
 	~vma_allocator();

--- a/src/vma/dev/buffer_pool.cpp
+++ b/src/vma/dev/buffer_pool.cpp
@@ -75,11 +75,16 @@ void buffer_pool::free_tx_lwip_pbuf_custom(struct pbuf *p_buff)
 	g_buffer_pool_tx->put_buffers_thread_safe((mem_buf_desc_t *)p_buff);
 }
 
-buffer_pool::buffer_pool(size_t buffer_count, size_t buf_size, pbuf_free_custom_fn custom_free_function) :
+buffer_pool::buffer_pool(size_t buffer_count,
+			size_t buf_size,
+			pbuf_free_custom_fn custom_free_function,
+			vma_allocator::alloc_t alloc_func,
+			vma_allocator::free_t free_func) :
 			m_lock_spin("buffer_pool"),
 			m_n_buffers(0),
 			m_n_buffers_created(buffer_count),
-			m_p_head(NULL)
+			m_p_head(NULL),
+			m_allocator(alloc_func, free_func)
 {
 	size_t sz_aligned_element = 0;
 	uint8_t *ptr_buff, *ptr_desc;

--- a/src/vma/dev/buffer_pool.cpp
+++ b/src/vma/dev/buffer_pool.cpp
@@ -78,8 +78,8 @@ void buffer_pool::free_tx_lwip_pbuf_custom(struct pbuf *p_buff)
 buffer_pool::buffer_pool(size_t buffer_count,
 			size_t buf_size,
 			pbuf_free_custom_fn custom_free_function,
-			vma_allocator::alloc_t alloc_func,
-			vma_allocator::free_t free_func) :
+			alloc_t alloc_func,
+			free_t free_func) :
 			m_lock_spin("buffer_pool"),
 			m_n_buffers(0),
 			m_n_buffers_created(buffer_count),

--- a/src/vma/dev/buffer_pool.h
+++ b/src/vma/dev/buffer_pool.h
@@ -55,8 +55,8 @@ public:
 	buffer_pool(size_t buffer_count,
 		size_t size,
 		pbuf_free_custom_fn custom_free_function,
-		vma_allocator::alloc_t alloc_func = NULL,
-		vma_allocator::free_t free_func = NULL);
+		alloc_t alloc_func = NULL,
+		free_t free_func = NULL);
 	~buffer_pool();
 
 	void register_memory(ib_ctx_handler *p_ib_ctx_h);

--- a/src/vma/dev/buffer_pool.h
+++ b/src/vma/dev/buffer_pool.h
@@ -52,7 +52,11 @@ inline static void free_lwip_pbuf(struct pbuf_custom *pbuf_custom)
 class buffer_pool
 {
 public:
-	buffer_pool(size_t buffer_count, size_t size, pbuf_free_custom_fn custom_free_function);
+	buffer_pool(size_t buffer_count,
+		size_t size,
+		pbuf_free_custom_fn custom_free_function,
+		vma_allocator::alloc_t alloc_func = NULL,
+		vma_allocator::free_t free_func = NULL);
 	~buffer_pool();
 
 	void register_memory(ib_ctx_handler *p_ib_ctx_h);

--- a/src/vma/libvma.c
+++ b/src/vma/libvma.c
@@ -32,19 +32,15 @@
  */
 
 
-extern int main_init(void);
-extern int main_destroy(void);
+extern int vma_init(void);
+extern int vma_exit(void);
 
-/*  library init function
------------------------------------------------------------------------------
-__attribute__((constructor)) causes the function to be called when
-library is firsrt loaded */
 int __attribute__((constructor)) sock_redirect_lib_load_constructor(void)
 {
-        return main_init();
+        return vma_init();
 }
 
 int __attribute__((destructor)) sock_redirect_lib_load_destructor(void)
 {
-        return main_destroy();
+        return vma_exit();
 }

--- a/src/vma/main.cpp
+++ b/src/vma/main.cpp
@@ -704,10 +704,12 @@ static void do_global_ctors_helper()
 
 	NEW_CTOR(g_buffer_pool_rx, buffer_pool(safe_mce_sys().rx_num_bufs,
 			RX_BUF_SIZE(g_p_net_device_table_mgr->get_max_mtu()),
-			buffer_pool::free_rx_lwip_pbuf_custom));
+			buffer_pool::free_rx_lwip_pbuf_custom,
+			(safe_mce_sys().m_ioctl.user_alloc.flags & VMA_IOCTL_USER_ALLOC_FLAG_RX ? safe_mce_sys().m_ioctl.user_alloc.memalloc : NULL),
+			(safe_mce_sys().m_ioctl.user_alloc.flags & VMA_IOCTL_USER_ALLOC_FLAG_RX ? safe_mce_sys().m_ioctl.user_alloc.memfree : NULL)));
  	g_buffer_pool_rx->set_RX_TX_for_stats(true);
 
- #ifdef DEFINED_TSO
+#ifdef DEFINED_TSO
 	safe_mce_sys().tx_buf_size = MIN((int)safe_mce_sys().tx_buf_size, (int)0xFF00);
  	if (safe_mce_sys().tx_buf_size <= get_lwip_tcp_mss(g_p_net_device_table_mgr->get_max_mtu(), safe_mce_sys().lwip_mss)) {
  		safe_mce_sys().tx_buf_size = 0;
@@ -716,11 +718,15 @@ static void do_global_ctors_helper()
  			TX_BUF_SIZE(safe_mce_sys().tx_buf_size ?
  					safe_mce_sys().tx_buf_size :
 					get_lwip_tcp_mss(g_p_net_device_table_mgr->get_max_mtu(), safe_mce_sys().lwip_mss)),
-			buffer_pool::free_tx_lwip_pbuf_custom));
+			buffer_pool::free_tx_lwip_pbuf_custom,
+			(safe_mce_sys().m_ioctl.user_alloc.flags & VMA_IOCTL_USER_ALLOC_FLAG_TX ? safe_mce_sys().m_ioctl.user_alloc.memalloc : NULL),
+			(safe_mce_sys().m_ioctl.user_alloc.flags & VMA_IOCTL_USER_ALLOC_FLAG_TX ? safe_mce_sys().m_ioctl.user_alloc.memfree : NULL)));
 #else
  	NEW_CTOR(g_buffer_pool_tx, buffer_pool(safe_mce_sys().tx_num_bufs,
 			TX_BUF_SIZE(get_lwip_tcp_mss(g_p_net_device_table_mgr->get_max_mtu(), safe_mce_sys().lwip_mss)),
-			buffer_pool::free_tx_lwip_pbuf_custom));
+			buffer_pool::free_tx_lwip_pbuf_custom,
+			(safe_mce_sys().m_ioctl.user_alloc.flags & VMA_IOCTL_USER_ALLOC_FLAG_TX ? safe_mce_sys().m_ioctl.user_alloc.memalloc : NULL),
+			(safe_mce_sys().m_ioctl.user_alloc.flags & VMA_IOCTL_USER_ALLOC_FLAG_TX ? safe_mce_sys().m_ioctl.user_alloc.memfree : NULL)));
 #endif /* DEFINED_TSO */
  	g_buffer_pool_tx->set_RX_TX_for_stats(false);
 

--- a/src/vma/sock/sock-redirect.cpp
+++ b/src/vma/sock/sock-redirect.cpp
@@ -1072,33 +1072,41 @@ int getsockopt(int __fd, int __level, int __optname,
 	srdr_logdbg_entry("fd=%d, level=%d, optname=%d", __fd, __level, __optname);
 
 	if (__fd == -1 && __level == SOL_SOCKET && __optname == SO_VMA_GET_API &&
-	    __optlen && *__optlen >= sizeof(struct vma_api_t*)) {
-		DO_GLOBAL_CTORS();
-		bool enable_socketxtreme = safe_mce_sys().enable_socketxtreme;
-		srdr_logdbg("User request for VMA Extra API pointers");
-		struct vma_api_t *vma_api = new struct vma_api_t();
+		__optlen && *__optlen >= sizeof(struct vma_api_t *)) {
+		static struct vma_api_t *vma_api = NULL;
 
-		vma_api->vma_extra_supported_mask = 0;
-		SET_EXTRA_API(register_recv_callback, vma_register_recv_callback, VMA_EXTRA_API_REGISTER_RECV_CALLBACK);
-		SET_EXTRA_API(recvfrom_zcopy, vma_recvfrom_zcopy, VMA_EXTRA_API_RECVFROM_ZCOPY);
-		SET_EXTRA_API(free_packets, vma_free_packets, VMA_EXTRA_API_FREE_PACKETS);
-		SET_EXTRA_API(add_conf_rule, vma_add_conf_rule, VMA_EXTRA_API_ADD_CONF_RULE);
-		SET_EXTRA_API(thread_offload, vma_thread_offload, VMA_EXTRA_API_THREAD_OFFLOAD);
-		SET_EXTRA_API(get_socket_rings_num, vma_get_socket_rings_num, VMA_EXTRA_API_GET_SOCKET_RINGS_NUM);
-		SET_EXTRA_API(get_socket_rings_fds, vma_get_socket_rings_fds, VMA_EXTRA_API_GET_SOCKET_RINGS_FDS);
-		SET_EXTRA_API(get_socket_tx_ring_fd, vma_get_socket_tx_ring_fd, VMA_EXTRA_API_GET_SOCKET_TX_RING_FD);
-		SET_EXTRA_API(vma_add_ring_profile, vma_add_ring_profile, VMA_EXTRA_API_ADD_RING_PROFILE);
-		SET_EXTRA_API(get_socket_network_header, vma_get_socket_netowrk_header, VMA_EXTRA_API_GET_SOCKET_NETWORK_HEADER);
-		SET_EXTRA_API(get_ring_direct_descriptors, vma_get_ring_direct_descriptors, VMA_EXTRA_API_GET_RING_DIRECT_DESCRIPTORS);
-		SET_EXTRA_API(register_memory_on_ring, vma_reg_mr_on_ring, VMA_EXTRA_API_REGISTER_MEMORY_ON_RING);
-		SET_EXTRA_API(deregister_memory_on_ring, vma_dereg_mr_on_ring, VMA_EXTRA_API_DEREGISTER_MEMORY_ON_RING);
-		SET_EXTRA_API(socketxtreme_free_vma_packets, enable_socketxtreme ? vma_socketxtreme_free_vma_packets : dummy_vma_socketxtreme_free_vma_packets, VMA_EXTRA_API_SOCKETXTREME_FREE_VMA_PACKETS);
-		SET_EXTRA_API(socketxtreme_poll, enable_socketxtreme ? vma_socketxtreme_poll : dummy_vma_socketxtreme_poll, VMA_EXTRA_API_SOCKETXTREME_POLL);
-		SET_EXTRA_API(socketxtreme_ref_vma_buff, enable_socketxtreme ? vma_socketxtreme_ref_vma_buff : dummy_vma_socketxtreme_ref_vma_buff, VMA_EXTRA_API_SOCKETXTREME_REF_VMA_BUFF);
-		SET_EXTRA_API(socketxtreme_free_vma_buff, enable_socketxtreme ? vma_socketxtreme_free_vma_buff : dummy_vma_socketxtreme_free_vma_buff, VMA_EXTRA_API_SOCKETXTREME_FREE_VMA_BUFF);
-		SET_EXTRA_API(dump_fd_stats, vma_dump_fd_stats, VMA_EXTRA_API_DUMP_FD_STATS);
-		SET_EXTRA_API(vma_modify_ring, vma_modify_ring, VMA_EXTRA_API_MODIFY_RING);
-		*((vma_api_t**)__optval) = vma_api;
+		srdr_logdbg("User request for VMA Extra API pointers");
+
+		if (NULL == vma_api) {
+			bool enable_socketxtreme = safe_mce_sys().enable_socketxtreme;
+
+			vma_api = new struct vma_api_t();
+
+			memset(vma_api, 0, sizeof(struct vma_api_t));
+			vma_api->vma_extra_supported_mask = 0;
+			SET_EXTRA_API(register_recv_callback, vma_register_recv_callback, VMA_EXTRA_API_REGISTER_RECV_CALLBACK);
+			SET_EXTRA_API(recvfrom_zcopy, vma_recvfrom_zcopy, VMA_EXTRA_API_RECVFROM_ZCOPY);
+			SET_EXTRA_API(free_packets, vma_free_packets, VMA_EXTRA_API_FREE_PACKETS);
+			SET_EXTRA_API(add_conf_rule, vma_add_conf_rule, VMA_EXTRA_API_ADD_CONF_RULE);
+			SET_EXTRA_API(thread_offload, vma_thread_offload, VMA_EXTRA_API_THREAD_OFFLOAD);
+			SET_EXTRA_API(get_socket_rings_num, vma_get_socket_rings_num, VMA_EXTRA_API_GET_SOCKET_RINGS_NUM);
+			SET_EXTRA_API(get_socket_rings_fds, vma_get_socket_rings_fds, VMA_EXTRA_API_GET_SOCKET_RINGS_FDS);
+			SET_EXTRA_API(get_socket_tx_ring_fd, vma_get_socket_tx_ring_fd, VMA_EXTRA_API_GET_SOCKET_TX_RING_FD);
+			SET_EXTRA_API(vma_add_ring_profile, vma_add_ring_profile, VMA_EXTRA_API_ADD_RING_PROFILE);
+			SET_EXTRA_API(get_socket_network_header, vma_get_socket_netowrk_header, VMA_EXTRA_API_GET_SOCKET_NETWORK_HEADER);
+			SET_EXTRA_API(get_ring_direct_descriptors, vma_get_ring_direct_descriptors, VMA_EXTRA_API_GET_RING_DIRECT_DESCRIPTORS);
+			SET_EXTRA_API(register_memory_on_ring, vma_reg_mr_on_ring, VMA_EXTRA_API_REGISTER_MEMORY_ON_RING);
+			SET_EXTRA_API(deregister_memory_on_ring, vma_dereg_mr_on_ring, VMA_EXTRA_API_DEREGISTER_MEMORY_ON_RING);
+			SET_EXTRA_API(socketxtreme_free_vma_packets, enable_socketxtreme ? vma_socketxtreme_free_vma_packets : dummy_vma_socketxtreme_free_vma_packets, VMA_EXTRA_API_SOCKETXTREME_FREE_VMA_PACKETS);
+			SET_EXTRA_API(socketxtreme_poll, enable_socketxtreme ? vma_socketxtreme_poll : dummy_vma_socketxtreme_poll, VMA_EXTRA_API_SOCKETXTREME_POLL);
+			SET_EXTRA_API(socketxtreme_ref_vma_buff, enable_socketxtreme ? vma_socketxtreme_ref_vma_buff : dummy_vma_socketxtreme_ref_vma_buff, VMA_EXTRA_API_SOCKETXTREME_REF_VMA_BUFF);
+			SET_EXTRA_API(socketxtreme_free_vma_buff, enable_socketxtreme ? vma_socketxtreme_free_vma_buff : dummy_vma_socketxtreme_free_vma_buff, VMA_EXTRA_API_SOCKETXTREME_FREE_VMA_BUFF);
+			SET_EXTRA_API(dump_fd_stats, vma_dump_fd_stats, VMA_EXTRA_API_DUMP_FD_STATS);
+			SET_EXTRA_API(vma_modify_ring, vma_modify_ring, VMA_EXTRA_API_MODIFY_RING);
+		}
+
+		*((vma_api_t **)__optval) = vma_api;
+		*__optlen = sizeof(struct vma_api_t *);
 		return 0;
 	}
 

--- a/src/vma/util/sys_vars.cpp
+++ b/src/vma/util/sys_vars.cpp
@@ -77,7 +77,7 @@
 
 void check_netperf_flags();
 
-// Do not rely on global variable initialization in code that might be called from library constructor (main_init)
+// Do not rely on global variable initialization in code that might be called from library constructor
 mce_sys_var & safe_mce_sys() {return mce_sys_var::instance();}
 
 #define MAX_BACKTRACE		25

--- a/src/vma/util/sys_vars.h
+++ b/src/vma/util/sys_vars.h
@@ -66,6 +66,7 @@ typedef enum {
 	ALLOC_TYPE_ANON = 0,
 	ALLOC_TYPE_CONTIG,
 	ALLOC_TYPE_HUGEPAGES,
+	ALLOC_TYPE_EXTERNAL,
 	ALLOC_TYPE_LAST_ALLOWED_TO_USE,
 	ALLOC_TYPE_REGISTER_MEMORY /* not allowed as a global parameter */
 } alloc_mode_t;

--- a/src/vma/util/sys_vars.h
+++ b/src/vma/util/sys_vars.h
@@ -67,7 +67,7 @@ typedef enum {
 	ALLOC_TYPE_CONTIG,
 	ALLOC_TYPE_HUGEPAGES,
 	ALLOC_TYPE_LAST_ALLOWED_TO_USE,
-	ALLOC_TYPE_EXTERNAL, /* not allowed as a global parameter */
+	ALLOC_TYPE_REGISTER_MEMORY /* not allowed as a global parameter */
 } alloc_mode_t;
 
 typedef enum {

--- a/src/vma/util/sys_vars.h
+++ b/src/vma/util/sys_vars.h
@@ -71,6 +71,9 @@ typedef enum {
 	ALLOC_TYPE_REGISTER_MEMORY /* not allowed as a global parameter */
 } alloc_mode_t;
 
+typedef void* (*alloc_t)(size_t);
+typedef void (*free_t)(void*);
+
 typedef enum {
 	TS_CONVERSION_MODE_DISABLE = 0, // TS_CONVERSION_MODE_DISABLE must be the first enum
 	TS_CONVERSION_MODE_RAW,
@@ -417,6 +420,10 @@ public:
 	bool		rx_poll_on_tx_tcp;
 	hyper_t		hypervisor;
 	bool		trigger_dummy_send_getsockname;
+	/* This field should be used to store and use data for VMA_EXTRA_API_IOCTL */
+	struct {
+		vma_cmsg_ioctl_user_alloc_t user_alloc;
+	} m_ioctl;
 private:
 	void print_vma_load_failure_msg();
 	int list_to_cpuset(char *cpulist, cpu_set_t *cpu_set);

--- a/src/vma/vma_extra.h
+++ b/src/vma/vma_extra.h
@@ -712,6 +712,7 @@ struct __attribute__ ((packed)) vma_api_t {
 	/**
 	 * Used to identify which methods were initialized by VMA as part of vma_get_api().
 	 * The value content is based on vma_extra_api_mask enum.
+	 * Order of fields in this structure should not be changed to keep abi compatibility.
 	 */
 	uint64_t vma_extra_supported_mask;
 
@@ -719,8 +720,12 @@ struct __attribute__ ((packed)) vma_api_t {
 
 /**
  * Retrieve VMA extended API.
+ * This function can be called as an alternative to getsockopt() call
+ * when library is preloaded using LD_PRELOAD
+ * getsockopt() call should be used in case application loads library
+ * using dlopen()/dlsym().
  *
- * @return Pointer to the VMA Extended Socket API, of NULL if VMA not found. 
+ * @return Pointer to the VMA Extended Socket API, of NULL if VMA not found.
  */
 static inline struct vma_api_t* vma_get_api()
 {

--- a/tests/gtest/Makefile.am
+++ b/tests/gtest/Makefile.am
@@ -117,6 +117,7 @@ gtest_SOURCES = \
 	vma/vma_poll.cc \
 	vma/vma_sockopt.cc \
 	vma/vma_recvfrom_zcopy.cc \
+	vma/vma_ioctl.cc \
 	\
 	vmad/vmad_base.cc \
 	vmad/vmad_bitmap.cc \

--- a/tests/gtest/common/def.h
+++ b/tests/gtest/common/def.h
@@ -102,6 +102,12 @@
 #define EOK 0         /* no error */
 #endif
 
+#define CHECK_ERR_OK(rc)                                                                           \
+	EXPECT_EQ(0, (rc));                                                                            \
+	if ((rc) < 0) {                                                                                \
+		ASSERT_EQ(EOK, errno);                                                                     \
+	}
+
 #ifndef container_of
 /**
  * container_of - cast a member of a structure out to the containing structure

--- a/tests/gtest/vma/vma_ioctl.cc
+++ b/tests/gtest/vma/vma_ioctl.cc
@@ -1,0 +1,214 @@
+/*
+ * SPDX-FileCopyrightText: NVIDIA CORPORATION & AFFILIATES
+ * Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ *
+ * This software is available to you under a choice of one of two
+ * licenses.  You may choose to be licensed under the terms of the GNU
+ * General Public License (GPL) Version 2, available from the file
+ * COPYING in the main directory of this source tree, or the
+ * BSD license below:
+ *
+ *     Redistribution and use in source and binary forms, with or
+ *     without modification, are permitted provided that the following
+ *     conditions are met:
+ *
+ *      - Redistributions of source code must retain the above
+ *        copyright notice, this list of conditions and the following
+ *        disclaimer.
+ *
+ *      - Redistributions in binary form must reproduce the above
+ *        copyright notice, this list of conditions and the following
+ *        disclaimer in the documentation and/or other materials
+ *        provided with the distribution.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+ * BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ * ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#include "common/def.h"
+#include "common/log.h"
+#include "common/sys.h"
+#include "common/base.h"
+#include "common/cmn.h"
+
+#include "tcp/tcp_base.h"
+
+#if defined(EXTRA_API_ENABLED) && (EXTRA_API_ENABLED == 1)
+
+#include "vma_base.h"
+
+class vma_ioctl : public vma_base {
+protected:
+	void SetUp() {
+		uint64_t vma_extra_api_cap = VMA_EXTRA_API_IOCTL;
+
+		vma_base::SetUp();
+
+		SKIP_TRUE((vma_api->vma_extra_supported_mask & vma_extra_api_cap) == vma_extra_api_cap,
+				"This test requires VMA capabilities as VMA_EXTRA_API_IOCTL");
+	}
+	void TearDown()	{
+		vma_base::TearDown();
+	}
+};
+
+static size_t allocated_size = 0;
+void *test_malloc(size_t size) {
+	allocated_size += size;
+	return malloc(size);
+};
+
+/**
+ * @test vma_ioctl.ti_1
+ * @note
+ *    Should be launched individually (it depends on library init ordering)
+ * @brief
+ *    CMSG_XLIO_IOCTL_USER_ALLOC command message format check
+ * @details
+ */
+TEST_F(vma_ioctl, ti_1) {
+	int rc = EOK;
+	int fd;
+	vma_cmsg_ioctl_user_alloc_t data;
+	struct cmsghdr *cmsg;
+	char cbuf[CMSG_SPACE(sizeof(data))];
+
+	ASSERT_TRUE((sizeof(uint8_t) + sizeof(uintptr_t) + sizeof(uintptr_t)) == sizeof(data));
+
+	/* scenario #1: Wrong cmsg length */
+	errno = EOK;
+	cmsg = (struct cmsghdr *)cbuf;
+	cmsg->cmsg_level = SOL_SOCKET;
+	cmsg->cmsg_type = CMSG_VMA_IOCTL_USER_ALLOC;
+	cmsg->cmsg_len = CMSG_LEN(sizeof(data)) - 1;
+	data.flags = VMA_IOCTL_USER_ALLOC_FLAG_RX;
+	data.memalloc = malloc;
+	data.memfree = free;
+	memcpy(CMSG_DATA(cmsg), &data, sizeof(data));
+
+	rc = vma_api->ioctl(cmsg, cmsg->cmsg_len);
+	EXPECT_EQ(-1, rc);
+	EXPECT_TRUE(EINVAL == errno);
+
+	/* scenario #2: invalid function pointer */
+	errno = EOK;
+	cmsg = (struct cmsghdr *)cbuf;
+	cmsg->cmsg_level = SOL_SOCKET;
+	cmsg->cmsg_type = CMSG_VMA_IOCTL_USER_ALLOC;
+	cmsg->cmsg_len = CMSG_LEN(sizeof(data));
+	data.flags = VMA_IOCTL_USER_ALLOC_FLAG_RX;
+	data.memalloc = malloc;
+	data.memfree = NULL;
+	memcpy(CMSG_DATA(cmsg), &data, sizeof(data));
+
+	rc = vma_api->ioctl(cmsg, cmsg->cmsg_len);
+	EXPECT_EQ(-1, rc);
+	EXPECT_TRUE(EINVAL == errno);
+
+	/* scenario #3: Check memory functions are activated */
+	errno = EOK;
+	cmsg = (struct cmsghdr *)cbuf;
+	cmsg->cmsg_level = SOL_SOCKET;
+	cmsg->cmsg_type = CMSG_VMA_IOCTL_USER_ALLOC;
+	cmsg->cmsg_len = CMSG_LEN(sizeof(data));
+	data.flags = VMA_IOCTL_USER_ALLOC_FLAG_RX;
+	data.memalloc = &test_malloc;
+	data.memfree = free;
+	memcpy(CMSG_DATA(cmsg), &data, sizeof(data));
+
+	rc = vma_api->ioctl(cmsg, cmsg->cmsg_len);
+	EXPECT_EQ(0, rc);
+
+	/* the library initialization trigger */
+	allocated_size = 0;
+	fd = socket(PF_INET, SOCK_DGRAM, IPPROTO_IP);
+	ASSERT_LE(0, fd);
+	EXPECT_LT(1500, allocated_size);
+
+	/* scenario #4: Command can not be used after initialization of internals */
+	errno = EOK;
+	cmsg = (struct cmsghdr *)cbuf;
+	cmsg->cmsg_level = SOL_SOCKET;
+	cmsg->cmsg_type = CMSG_VMA_IOCTL_USER_ALLOC;
+	cmsg->cmsg_len = CMSG_LEN(sizeof(data));
+	data.flags = VMA_IOCTL_USER_ALLOC_FLAG_TX | VMA_IOCTL_USER_ALLOC_FLAG_RX;
+	data.memalloc = malloc;
+	data.memfree = free;
+	memcpy(CMSG_DATA(cmsg), &data, sizeof(data));
+
+	rc = vma_api->ioctl(cmsg, cmsg->cmsg_len);
+	EXPECT_EQ(-1, rc);
+	EXPECT_TRUE(EINVAL == errno);
+
+	/* scenario #5: Successfull connection with customer memalloc */
+	rc = EOK;
+	char send_buf[] = "test";
+	char recv_buf[sizeof(send_buf)];
+
+	int pid = fork();
+
+	if (0 == pid) {  /* I am the child */
+		barrier_fork(pid);
+
+		fd = tcp_base::sock_create();
+		ASSERT_LE(0, fd);
+
+		rc = bind(fd, (struct sockaddr *)&client_addr, sizeof(client_addr));
+		ASSERT_EQ(0, rc);
+
+		rc = connect(fd, (struct sockaddr *)&server_addr, sizeof(server_addr));
+		ASSERT_EQ(0, rc);
+
+		log_trace("Established connection: fd=%d to %s\n",
+				fd, sys_addr2str((struct sockaddr_in *)&server_addr));
+
+		rc = send(fd, send_buf, sizeof(send_buf), 0);
+		EXPECT_GE(rc, 0);
+
+		close(fd);
+
+		/* This exit is very important, otherwise the fork
+		 * keeps running and may duplicate other tests.
+		 */
+		exit(testing::Test::HasFailure());
+	} else {  /* I am the parent */
+		int fd_peer;
+		struct sockaddr peer_addr;
+		socklen_t socklen;
+
+		fd_peer = tcp_base::sock_create();
+		ASSERT_LE(0, fd_peer);
+
+		rc = bind(fd_peer, (struct sockaddr *)&server_addr, sizeof(server_addr));
+		ASSERT_EQ(0, rc);
+
+		rc = listen(fd_peer, 5);
+		ASSERT_EQ(0, rc);
+
+		barrier_fork(pid);
+
+		socklen = sizeof(peer_addr);
+		fd = accept(fd_peer, &peer_addr, &socklen);
+		ASSERT_LE(0, fd);
+
+		log_trace("Accepted connection: fd=%d from %s\n",
+				fd, sys_addr2str((struct sockaddr_in *)&peer_addr));
+
+		rc = recv(fd, (void *)recv_buf, sizeof(recv_buf), MSG_WAITALL);
+		EXPECT_GE(rc, 0);
+		EXPECT_EQ(memcmp(send_buf, recv_buf, sizeof(send_buf)), 0);
+
+		close(fd_peer);
+		close(fd);
+
+		ASSERT_EQ(0, wait_fork(pid));
+	}
+}
+
+#endif /* EXTRA_API_ENABLED */

--- a/tests/gtest/vma/vma_poll.cc
+++ b/tests/gtest/vma/vma_poll.cc
@@ -81,7 +81,7 @@ TEST_F(vma_poll, ti_1) {
 		ASSERT_LE(0, fd);
 
 		rc = bind(fd, (struct sockaddr *)&client_addr, sizeof(client_addr));
-		ASSERT_EQ(0, rc);
+		CHECK_ERR_OK(rc);
 
 		rc = connect(fd, (struct sockaddr *)&server_addr, sizeof(server_addr));
 		ASSERT_EQ(EINPROGRESS, errno);
@@ -112,11 +112,10 @@ TEST_F(vma_poll, ti_1) {
 		ASSERT_LE(0, fd);
 
 		rc = bind(fd, (struct sockaddr *)&server_addr, sizeof(server_addr));
-		ASSERT_EQ(0, rc);
+		CHECK_ERR_OK(rc);
 
 		rc = listen(fd, 5);
-		ASSERT_EQ(EOK, errno);
-		ASSERT_EQ(0, rc);
+		CHECK_ERR_OK(rc);
 
 		rc = vma_api->get_socket_rings_fds(fd, &_vma_ring_fd, 1);
 		ASSERT_EQ(1, rc);
@@ -126,6 +125,9 @@ TEST_F(vma_poll, ti_1) {
 		rc = 0;
 		while (rc == 0 && !child_fork_exit()) {
 			rc = vma_api->socketxtreme_poll(_vma_ring_fd, &vma_comps, 1, 0);
+			if (rc == 0) {
+				continue;
+			}
 			if (vma_comps.events & VMA_SOCKETXTREME_NEW_CONNECTION_ACCEPTED) {
 				EXPECT_EQ(fd, (int)vma_comps.listen_fd);
 				fd_peer = (int)vma_comps.user_data;
@@ -166,7 +168,7 @@ TEST_F(vma_poll, ti_2) {
 		ASSERT_LE(0, fd);
 
 		rc = bind(fd, (struct sockaddr *)&client_addr, sizeof(client_addr));
-		ASSERT_EQ(0, rc);
+		CHECK_ERR_OK(rc);
 
 		rc = connect(fd, (struct sockaddr *)&server_addr, sizeof(server_addr));
 		ASSERT_EQ(0, rc);
@@ -193,11 +195,10 @@ TEST_F(vma_poll, ti_2) {
 		ASSERT_LE(0, fd);
 
 		rc = bind(fd, (struct sockaddr *)&server_addr, sizeof(server_addr));
-		ASSERT_EQ(0, rc);
+		CHECK_ERR_OK(rc);
 
 		rc = listen(fd, 5);
-		ASSERT_EQ(EOK, errno);
-		ASSERT_EQ(0, rc);
+		CHECK_ERR_OK(rc);
 
 		rc = vma_api->get_socket_rings_fds(fd, &_vma_ring_fd, 1);
 		ASSERT_EQ(1, rc);
@@ -207,6 +208,9 @@ TEST_F(vma_poll, ti_2) {
 		rc = 0;
 		while (rc == 0 && !child_fork_exit()) {
 			rc = vma_api->socketxtreme_poll(_vma_ring_fd, &vma_comps, 1, 0);
+			if (rc == 0) {
+				continue;
+			}
 			if ((vma_comps.events & EPOLLERR) ||
 					(vma_comps.events & EPOLLHUP) ||
 					(vma_comps.events & EPOLLRDHUP)) {
@@ -264,7 +268,7 @@ TEST_F(vma_poll, ti_3) {
 		ASSERT_LE(0, fd);
 
 		rc = bind(fd, (struct sockaddr *)&client_addr, sizeof(client_addr));
-		ASSERT_EQ(0, rc);
+		CHECK_ERR_OK(rc);
 
 		rc = connect(fd, (struct sockaddr *)&server_addr, sizeof(server_addr));
 		ASSERT_EQ(0, rc);
@@ -292,11 +296,10 @@ TEST_F(vma_poll, ti_3) {
 		ASSERT_LE(0, fd);
 
 		rc = bind(fd, (struct sockaddr *)&server_addr, sizeof(server_addr));
-		ASSERT_EQ(0, rc);
+		CHECK_ERR_OK(rc);
 
 		rc = listen(fd, 5);
-		ASSERT_EQ(EOK, errno);
-		ASSERT_EQ(0, rc);
+		CHECK_ERR_OK(rc);
 
 		rc = vma_api->get_socket_rings_fds(fd, &_vma_ring_fd, 1);
 		ASSERT_EQ(1, rc);
@@ -306,6 +309,9 @@ TEST_F(vma_poll, ti_3) {
 		rc = 0;
 		while (rc == 0 && !child_fork_exit()) {
 			rc = vma_api->socketxtreme_poll(_vma_ring_fd, &vma_comps, 1, 0);
+			if (rc == 0) {
+				continue;
+			}
 			if ((vma_comps.events & EPOLLERR) ||
 					(vma_comps.events & EPOLLHUP) ||
 					(vma_comps.events & EPOLLRDHUP)) {
@@ -367,7 +373,7 @@ TEST_F(vma_poll, ti_4) {
 		ASSERT_LE(0, fd);
 
 		rc = bind(fd, (struct sockaddr *)&client_addr, sizeof(client_addr));
-		ASSERT_EQ(0, rc);
+		CHECK_ERR_OK(rc);
 
 		rc = sendto(fd, (void *)msg, sizeof(msg), 0,
 				(struct sockaddr *)&server_addr, sizeof(server_addr));
@@ -388,7 +394,7 @@ TEST_F(vma_poll, ti_4) {
 		ASSERT_LE(0, fd);
 
 		rc = bind(fd, (struct sockaddr *)&server_addr, sizeof(server_addr));
-		ASSERT_EQ(0, rc);
+		CHECK_ERR_OK(rc);
 
 		rc = vma_api->get_socket_rings_fds(fd, &_vma_ring_fd, 1);
 		ASSERT_EQ(1, rc);
@@ -398,6 +404,9 @@ TEST_F(vma_poll, ti_4) {
 		rc = 0;
 		while (rc == 0 && !child_fork_exit()) {
 			rc = vma_api->socketxtreme_poll(_vma_ring_fd, &vma_comps, 1, 0);
+			if (rc == 0) {
+				continue;
+			}
 			if ((vma_comps.events & EPOLLERR) ||
 					(vma_comps.events & EPOLLHUP) ||
 					(vma_comps.events & EPOLLRDHUP)) {


### PR DESCRIPTION
## Description

This function allows to communicate with library using extendable protocol
based on struct cmshdr.
Ancillary data is a sequence of cmsghdr structures with appended data.
The sequence of cmsghdr structures should never be accessed directly.
Instead, use only the following macros: CMSG_ALIGN, CMSG_SPACE, CMSG_DATA,
CMSG_LEN.

Added ioctl command message as CMSG_VMA_IOCTL_USER_ALLOC with format
    1. uint8_t - control flags
    2. uintptr_t - pointer to memory allocation function
    3. uintptr_t - pointer to memory free function

control flags manage usage of memory functions for global rx, tx  memory pools.

It allows an user to get full control on requested memory.

**Important note:**
- User should deallocate memory after unloading library.
- CMSG_VMA_IOCTL_USER_ALLOC must be called before the library
 initialization that is done during first call of following functions
 as socket(), epoll_create(), epoll_create1(), pipe().

##### Usage
```
	vma_cmsg_ioctl_user_alloc_t data;
	struct cmsghdr *cmsg;
	char cbuf[CMSG_SPACE(sizeof(data))];

	cmsg = (struct cmsghdr *)cbuf;
	cmsg->cmsg_level = SOL_SOCKET;
	cmsg->cmsg_type = CMSG_VMA_IOCTL_USER_ALLOC;
	cmsg->cmsg_len = CMSG_LEN(sizeof(data));
	data.flags = VMA_IOCTL_USER_ALLOC_FLAG_RX;
	data.memalloc = malloc;
	data.memfree = free;
	memcpy(CMSG_DATA(cmsg), &data, sizeof(data));
	rc = vma_api->ioctl(cmsg, cmsg->cmsg_len);
```

##### What
RM: 4251780 

##### Why ?
New Feature.

## Change type
What kind of change does this PR introduce?
- [ ] Bugfix
- [x] Feature
- [ ] Code style update
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [X] Tests
- [ ] Other

## Check list
- [x] Code follows the style de facto guidelines of this project
- [x] Comments have been inserted in hard to understand places
- [ ] Documentation has been updated (if necessary)
- [x] Test has been added (if possible)

