### PR TITLE
[CI] issue: 4283986 Move build steps to Blossom K8s

### DIFF
--- a/.ci/matrix_job.yaml
+++ b/.ci/matrix_job.yaml
@@ -8,9 +8,9 @@ registry_auth: swx-storage
 
 kubernetes:
   privileged: true
-  cloud: swx-k8s-spray
+  cloud: il-ipp-blossom-prod
+  namespace: swx-media
   nodeSelector: 'beta.kubernetes.io/os=linux'
-
   limits: '{memory: 8Gi, cpu: 8000m}'
   requests: '{memory: 8Gi, cpu: 8000m}'
 


### PR DESCRIPTION
 ## Description
We want to move all build steps and test CI steps to the Blossom K8s cluster.

##### What
Switch to the Blossom K8s cluster.

##### Why ?
Blossom cluster is more stable, visibly managed and has 24/7 SRE/NOC support.

##### How ?
_It is optional but for complex PRs please provide information about the design,
architecture, approach, etc._

## Change type
What kind of change does this PR introduce?
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [x] CI related changes
- [ ] Documentation content changes
- [ ] Tests
- [ ] Other

## Check list
- [ ] Code follows the style de facto guidelines of this project
- [ ] Comments have been inserted in hard to understand places
- [ ] Documentation has been updated (if necessary)
- [ ] Test has been added (if possible)

