### PR TITLE
[CI] issue: 4322501 Add rhel9.4 aarch64 as build container

### DIFF
--- a/.ci/dockerfiles/Dockerfile.rhel9.4
+++ b/.ci/dockerfiles/Dockerfile.rhel9.4
@@ -1,0 +1,37 @@
+ARG HARBOR_URL=nbu-harbor.gtm.nvidia.com
+ARG ARCH=x86_64
+FROM $HARBOR_URL/swx-infra/media/$ARCH/base/rhel:9.4
+ARG WEBREPO_URL=webrepo.gtm.nvidia.com
+ARG ARCH
+ARG _UID=6213
+ARG _GID=101
+ARG _LOGIN=swx-jenkins
+ARG _HOME=/var/home/$_LOGIN
+
+RUN sed -i "s#http://webrepo#http://${WEBREPO_URL}#" /etc/yum.repos.d/* && \
+    sed -i 's/mirrorlist/#mirrorlist/;s!#baseurl=http://mirror.centos.org!baseurl=http://vault.centos.org!' /etc/yum.repos.d/* && \
+    echo "[mlnx-9.4-BaseOS]" > /etc/yum.repos.d/mlnx-9.4-BaseOS.repo && \
+    echo "name=RHEL 9.4 mirror BaseOS" >> /etc/yum.repos.d/mlnx-9.4-BaseOS.repo && \
+    echo "baseurl=http://${WEBREPO_URL}/RH/9.4/$ARCH/BaseOS/" >> /etc/yum.repos.d/mlnx-9.4-BaseOS.repo && \
+    echo "enabled=1" >> /etc/yum.repos.d/mlnx-9.4-BaseOS.repo && \
+    echo "gpgcheck=0" >> /etc/yum.repos.d/mlnx-9.4-BaseOS.repo && \
+    echo "[mlnx-9.4-AppStream]" > /etc/yum.repos.d/mlnx-9.4-AppStream.repo && \
+    echo "name=RHEL 9.4 mirror AppStream" >> /etc/yum.repos.d/mlnx-9.4-AppStream.repo && \
+    echo "baseurl=http://${WEBREPO_URL}/RH/9.4/$ARCH/AppStream/" >> /etc/yum.repos.d/mlnx-9.4-AppStream.repo && \
+    echo "enabled=1" >> /etc/yum.repos.d/mlnx-9.4-AppStream.repo && \
+    echo "gpgcheck=0" >> /etc/yum.repos.d/mlnx-9.4-AppStream.repo && \
+    yum makecache
+
+RUN echo "${_LOGIN} ALL=(ALL) NOPASSWD: ALL" >> /etc/sudoers && \
+    echo "root ALL=(ALL) NOPASSWD: ALL" >> /etc/sudoers && \
+    mkdir -p ${_HOME} && \
+    groupadd -f -g "$_GID" "$_LOGIN" && \
+    useradd -u "$_UID" -g "$_GID" -s /bin/bash -m -d ${_HOME} "${_LOGIN}" && \
+    chown -R ${_LOGIN} ${_HOME}
+
+RUN dnf install --allowerasing -y \
+    git autoconf automake libtool gcc \
+    sudo gcc-c++ libibverbs-devel rdma-core \
+    librdmacm unzip patch wget make \
+    libnl3-devel rpm-build && \
+    dnf clean all && rm -rf /var/cache/dnf/*

--- a/.ci/matrix_job.yaml
+++ b/.ci/matrix_job.yaml
@@ -4,7 +4,8 @@ job: LIBVMA
 step_allow_single_selector: false
 
 registry_host: harbor.mellanox.com
-registry_auth: swx-storage
+registry_auth: swx-infra_harbor_credentials
+registry_path: /swx-infra/media
 
 kubernetes:
   privileged: true
@@ -33,6 +34,7 @@ runs_on_dockers:
 # doca-host
   - {name: 'rhel8.6-x86_64', url: 'harbor.mellanox.com/hpcx/x86_64/rhel8.6/base', category: 'base', arch: 'x86_64'}
   - {name: 'rhel9.0-x86_64', url: 'harbor.mellanox.com/hpcx/x86_64/rhel9.0/base', category: 'base', arch: 'x86_64'}
+  - {name: 'rhel9.4-aarch64', file: '.ci/dockerfiles/Dockerfile.rhel9.4', category: 'base', arch: 'aarch64', tag: '20250203', uri: 'vma/$arch/$name/build', build_args: '--build-arg ARCH=aarch64 --no-cache'}
   - {name: 'ub24.04-x86_64', url: 'harbor.mellanox.com/hpcx/x86_64/ubuntu24.04/base', category: 'base', arch: 'x86_64'}
   - {name: 'ub24.04-aarch64', url: 'harbor.mellanox.com/hpcx/aarch64/ubuntu24.04/base', category: 'base', arch: 'aarch64'}
   - {name: 'sl15sp4-x86_64', url: 'harbor.mellanox.com/hpcx/x86_64/sles15sp4/base', category: 'base', arch: 'x86_64'}


### PR DESCRIPTION
## Description
Verify VMA on Grace Hopper with RH9.4

##### What
Add new rhel9.4 Dockerfile - supports both x86_64 and aarch64 
Add definition for rhel9.4 aarch64 under matrix job

##### Why ?
[HPCINFRA-3259](https://jirasw.nvidia.com/browse/HPCINFRA-3259)
https://redmine.mellanox.com/issues/4322501#change-35520800

## Change type
What kind of change does this PR introduce?
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [X] CI related changes
- [ ] Documentation content changes
- [ ] Tests
- [ ] Other

## Check list
- [ ] Code follows the style de facto guidelines of this project
- [ ] Comments have been inserted in hard to understand places
- [ ] Documentation has been updated (if necessary)
- [ ] Test has been added (if possible)

