### PR TITLE
issue: 4337575 Init VMA in vma_thread_offload()

### DIFF
--- a/src/vma/sock/sock-redirect.cpp
+++ b/src/vma/sock/sock-redirect.cpp
@@ -609,6 +609,8 @@ int vma_add_conf_rule(const char *config_line)
 extern "C"
 int vma_thread_offload(int offload, pthread_t tid)
 {
+	DO_GLOBAL_CTORS();
+
 	if (g_p_fd_collection) {
 		g_p_fd_collection->offloading_rule_change_thread(offload, tid);
 	} else {


### PR DESCRIPTION
## Description

vma_get_api()->thread_offload() can be called before the 1st socket() syscall. In this case VMA is in uninitialized state and the thread_offload() call fails with -1.

Call DO_GLOBAL_CTORS() in the vma_thread_offload() to guarantee the initialized state in all scenarios.

Until VMA 9.8.70, the initialization was done in the vma_get_api() call, however, it was removed due to external allocator support which requires uninitialized state to guarantee buffers allocation with the configured allocator.

##### What
Fix vma_thread_offload() failure is called before the 1st socket() syscall. 

##### Why ?
Bugfix

## Change type
What kind of change does this PR introduce?
- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Tests
- [ ] Other

## Check list
- [ ] Code follows the style de facto guidelines of this project
- [ ] Comments have been inserted in hard to understand places
- [ ] Documentation has been updated (if necessary)
- [ ] Test has been added (if possible)

