### PR TITLE
[CI] issue: 4411941 BlackDuck scan startup fix

### DIFF
--- a/.ci/blackduck_source.sh
+++ b/.ci/blackduck_source.sh
@@ -1,0 +1,51 @@
+#!/bin/bash -Exel
+
+topdir=$(git rev-parse --show-toplevel)
+cd "$topdir"
+
+# Check if the variables and pipeline attributes are set
+[[ -z "${WORKSPACE}" ]] && { echo "Error: WORKSPACE variable is not set"; exit 1; }
+[[ -z "$BLACKDUCK_API_TOKEN" ]] && { echo "Error: BLACKDUCK_API_TOKEN variable is not set"; exit 1; }
+[[ ! -d "${WORKSPACE}/logs" ]] && mkdir -p "${WORKSPACE}/logs"
+
+# Create valid JSON for further authentication in BlackDuck server
+json=$(jq -n \
+  --arg token "$BLACKDUCK_API_TOKEN" \
+  '{"blackduck.url": "https://blackduck.mellanox.com/", "blackduck.api.token": $token }')
+
+export SPRING_APPLICATION_JSON="$json"
+export PROJECT_NAME=LibVMA
+export PROJECT_VERSION="$sha1"
+export PROJECT_SRC_PATH="$topdir"/src/
+
+echo "Running BlackDuck (SRC) on $name"
+echo "CONFIG:"
+echo "        NAME: ${PROJECT_NAME}"
+echo "     VERSION: ${PROJECT_VERSION}"
+echo "    SRC_PATH: ${PROJECT_SRC_PATH}"
+
+# clone BlackDuck
+[[ -d /tmp/blackduck ]] && rm -rf /tmp/blackduck
+[[ -d ~/.ssh/ ]] || mkdir -p ~/.ssh/
+chmod 600 "${GERRIT_SSH_KEY}"
+ssh-keyscan -p 12023 -H git-nbu.nvidia.com >> ~/.ssh/known_hosts
+git clone -c core.sshCommand="ssh -i ${GERRIT_SSH_KEY} -l swx-jenkins2-svc" -b master --single-branch --depth=1 ssh://git-nbu.nvidia.com:12023/DevOps/Tools/blackduck /tmp/blackduck
+cd /tmp/blackduck
+
+# disable check errors
+set +e
+timeout 3600 ./run_bd_scan.sh
+exit_code=$?
+# enable back
+set -e
+
+# copy run log to a place that jenkins job will archive it
+REPORT_NAME="BlackDuck_source_${PROJECT_NAME}_${PROJECT_VERSION}"
+cat "log/${PROJECT_NAME}_${PROJECT_VERSION}"*.log > "${WORKSPACE}/logs/${REPORT_NAME}.log" || true
+cat "log/${PROJECT_NAME}_${PROJECT_VERSION}"*.log || true
+
+if [ "$exit_code" == "0" ]; then
+    cp -v /tmp/blackduck/report/*.pdf "${WORKSPACE}/logs/${REPORT_NAME}.pdf"
+fi
+
+exit $exit_code

--- a/.ci/dockerfiles/Dockerfile.rhel8.6
+++ b/.ci/dockerfiles/Dockerfile.rhel8.6
@@ -1,0 +1,18 @@
+ARG HARBOR_URL=nbu-harbor.gtm.nvidia.com
+ARG ARCH=x86_64
+FROM $HARBOR_URL/hpcx/x86_64/rhel8.6/core:latest
+ARG WEBREPO_URL=webrepo.gtm.nvidia.com
+
+RUN sed -i "s/webrepo/${WEBREPO_URL}/" /etc/yum.repos.d/* && \
+    sed -i 's/mirrorlist/#mirrorlist/;s!#baseurl=http://mirror.centos.org!baseurl=http://vault.centos.org!' /etc/yum.repos.d/* && \
+    echo "[mlnx-opt]" > /etc/yum.repos.d/mlnx-opt.repo && \
+    echo "name=RHEL 8.6 mirror" >> /etc/yum.repos.d/mlnx-opt.repo && \
+    echo "baseurl=http://${WEBREPO_URL}/RH/optional/8.6/x86_64/" >> /etc/yum.repos.d/mlnx-opt.repo && \
+    echo "enabled=1" >> /etc/yum.repos.d/mlnx-opt.repo && \
+    echo "gpgcheck=0" >> /etc/yum.repos.d/mlnx-opt.repo && \
+    yum makecache
+
+RUN yum install --allowerasing -y \
+    java-11-openjdk jq git && \
+    yum clean all && \
+    rm -rf /var/cache/yum    

--- a/.ci/matrix_job.yaml
+++ b/.ci/matrix_job.yaml
@@ -26,6 +26,7 @@ volumes:
 credentials:
   - {credentialsId: 'media_coverity_credentials', usernameVariable: 'VMA_COV_USER', passwordVariable: 'VMA_COV_PASSWORD'}
   - {credentialsId: 'mellanox_github_credentials', usernameVariable: 'MELLANOX_GH_USER', passwordVariable: 'MELLANOX_GH_TOKEN'}
+  - {credentialsId: 'swx-jenkins2-svc-gerrit-ssh-key', keyFileVariable: 'GERRIT_SSH_KEY', type: 'sshUserPrivateKey'}
 
 env:
   build_dockers: false
@@ -43,7 +44,7 @@ runs_on_dockers:
   - {name: 'ub22.04-aarch64', url: 'harbor.mellanox.com/hpcx/aarch64/ubuntu22.04/base', category: 'base', arch: 'aarch64'}
 # tool
   - {name: 'toolbox', url: 'harbor.mellanox.com/hpcx/x86_64/rhel8.6/builder:inbox', category: 'tool', arch: 'x86_64'}
-  - {name: 'blackduck', url: 'harbor.mellanox.com/toolbox/ngci-centos:7.9.2009.2', category: 'tool', arch: 'x86_64'}
+  - {name: 'blackduck', file: '.ci/dockerfiles/Dockerfile.rhel8.6', category: 'tool', arch: 'x86_64', tag: '20250422', uri: 'vma/$arch/$name/bduck', build_args: '--no-cache'}
   - {name: 'header-check', url: 'harbor.mellanox.com/toolbox/header_check:0.0.58', category: 'tool', arch: 'x86_64', tag: '0.0.58'}
 
 runs_on_agents:
@@ -305,20 +306,14 @@ steps:
       - "{name: 'blackduck', category:'tool', variant:1}"
     agentSelector:
       - "{nodeLabel: 'skip-agent'}"
-    shell: action
-    module: ngci
-    run: NGCIBlackDuckScan
-    args:
-      projectName: "LibVMA"
-      projectVersion: "0.1.0"
-      projectSrcPath: "src"
-      attachArtifact: true
-      reportName: "BlackDuck report"
-      scanMode: "source"
-      skipDockerDaemonCheck: true
-      credentialsId: "b68aedbd-e39f-4ee2-acce-e25a5b91fe18"
-    env:
-      SPRING_APPLICATION_JSON: '{"blackduck.url":"https://blackduck.mellanox.com/","blackduck.api.token":"ODMwOWYwMzEtODA2ZC00MzBjLWI1ZDEtNmFiMjBkYzQzMzkwOjNmNjExN2M1LWE2ZmEtNDZlYS1hZjRiLTZlNDgwNjAwOTVjNw=="}'
+    run: |
+      export BLACKDUCK_API_TOKEN="ODMwOWYwMzEtODA2ZC00MzBjLWI1ZDEtNmFiMjBkYzQzMzkwOjNmNjExN2M1LWE2ZmEtNDZlYS1hZjRiLTZlNDgwNjAwOTVjNw=="
+      # WA for possible CI-Demo bug: HPCINFRA-1614
+      if ${do_blackduck} ; then
+        .ci/blackduck_source.sh
+      fi
+    archiveArtifacts: 'logs/'
+    credentialsId: "swx-jenkins2-svc-gerrit-ssh-key"
 
 pipeline_start:
   run: |


### PR DESCRIPTION
## Description
Replaced NGCI-based BlackDuck source scan with manual BlackDuck script execution

##### What
This change removes the NGCI module previously used for running BlackDuck source scans

##### Why ?
NGCI relied on a Gerrit user token for cloning BlackDuck, which was subject to frequent rotation and caused recurring CI failures.

##### How ?
We move to manual scan execution via custom script using a service account with stable ssh-based authentaction.

## Change type
What kind of change does this PR introduce?
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [x] CI related changes
- [ ] Documentation content changes
- [ ] Tests
- [ ] Other

## Check list
- [ ] Code follows the style de facto guidelines of this project
- [ ] Comments have been inserted in hard to understand places
- [ ] Documentation has been updated (if necessary)
- [ ] Test has been added (if possible)

