### PR TITLE
[CI] issue: 4416570 Move hardcoded BD token to Jenkins Credentials

### DIFF
--- a/.ci/matrix_job.yaml
+++ b/.ci/matrix_job.yaml
@@ -27,6 +27,7 @@ credentials:
   - {credentialsId: 'media_coverity_credentials', usernameVariable: 'VMA_COV_USER', passwordVariable: 'VMA_COV_PASSWORD'}
   - {credentialsId: 'mellanox_github_credentials', usernameVariable: 'MELLANOX_GH_USER', passwordVariable: 'MELLANOX_GH_TOKEN'}
   - {credentialsId: 'swx-jenkins2-svc-gerrit-ssh-key', keyFileVariable: 'GERRIT_SSH_KEY', type: 'sshUserPrivateKey'}
+  - {credentialsId: 'blackduck_api_token', type: 'string', variable: 'BLACKDUCK_API_TOKEN'}
 
 env:
   build_dockers: false
@@ -307,13 +308,14 @@ steps:
     agentSelector:
       - "{nodeLabel: 'skip-agent'}"
     run: |
-      export BLACKDUCK_API_TOKEN="ODMwOWYwMzEtODA2ZC00MzBjLWI1ZDEtNmFiMjBkYzQzMzkwOjNmNjExN2M1LWE2ZmEtNDZlYS1hZjRiLTZlNDgwNjAwOTVjNw=="
       # WA for possible CI-Demo bug: HPCINFRA-1614
       if ${do_blackduck} ; then
         .ci/blackduck_source.sh
       fi
     archiveArtifacts: 'logs/'
-    credentialsId: "swx-jenkins2-svc-gerrit-ssh-key"
+    credentialsId: 
+      - "swx-jenkins2-svc-gerrit-ssh-key"
+      - "blackduck_api_token"
 
 pipeline_start:
   run: |


### PR DESCRIPTION
## Description
Replaced NGCI-based BlackDuck source scan with manual BlackDuck script execution

##### What
This change removes the NGCI module previously used for running BlackDuck source scans

##### Why ?
NGCI relied on a Gerrit user token for cloning BlackDuck, which was subject to frequent rotation and caused recurring CI failures.

##### How ?
We move to manual scan execution via custom script using a service account with stable SSH-based authentication.

## Change type
What kind of change does this PR introduce?
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [x] CI related changes
- [ ] Documentation content changes
- [ ] Tests
- [ ] Other

## Check list
- [ ] Code follows the style de facto guidelines of this project
- [ ] Comments have been inserted in hard to understand places
- [ ] Documentation has been updated (if necessary)
- [ ] Test has been added (if possible)

