### PR TITLE
Fix lock logic in timers handlers.

### DIFF
--- a/src/vma/event/delta_timer.cpp
+++ b/src/vma/event/delta_timer.cpp
@@ -208,9 +208,7 @@ void timer::process_registered_timers()
 		 * Object can be destoyed from another thread (lock protection)
 		 * and from current thread (lock and lock count condition)
 		 */
-		if (iter->handler &&
-			!iter->lock_timer.trylock() &&
-			(1 == iter->lock_timer.is_locked_by_me())) {
+		if (iter->handler && iter->lock_timer.trylock()) {
 			iter->handler->handle_timer_expired(iter->user_data);
 			iter->lock_timer.unlock();
 		}


### PR DESCRIPTION
## Description
Possible fix of lock logic in timer handlers.

##### What
Change locking condition.

##### Why ?
Crash of program, which uses libvma.

##### How ?
Trivial change

## Change type
What kind of change does this PR introduce?
- [X] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Tests
- [ ] Other

## Check list
- [x] Code follows the style de facto guidelines of this project
- [x] Comments have been inserted in hard to understand places
- [ ] Documentation has been updated (if necessary)
- [ ] Test has been added (if possible)

