### PR TITLE
[CI] issue #4377705: Create tar.gz from src.rpm

### DIFF
--- a/.ci/do_release.sh
+++ b/.ci/do_release.sh
@@ -43,14 +43,18 @@ if [ -z "${do_release}" ]; then
     do_release=false
 fi
 
-env PRJ_RELEASE="${revision}" contrib/build_pkg.sh -s
-
 MAJOR_VERSION=$(grep -e "define(\[prj_ver_major\]" configure.ac | awk '{ printf $2 };' | sed  's/)//g')
 MINOR_VERSION=$(grep -e "define(\[prj_ver_minor\]" configure.ac | awk '{ printf $2 };' | sed  's/)//g')
 REVISION_VERSION=$(grep -e "define(\[prj_ver_revision\]" configure.ac | awk '{ printf $2 };' | sed  's/)//g')
 configure_ac_version="${MAJOR_VERSION}.${MINOR_VERSION}.${REVISION_VERSION}"
+pkg_folder=pkg/packages
+pkg_name="libvma-${release_tag}-${revision}.src.rpm"
+tarball_name="libvma-${release_tag}.tar.gz"
 DST_DIR=${release_folder}/vma_v_${release_tag}-0/src
 echo "FULL_VERSION from configure.ac: [${configure_ac_version}]"
+
+# Creating both tarball and src.rpm
+env PRJ_RELEASE="${revision}" contrib/build_pkg.sh -s -t
 
 if [[ "${release_tag}" != "${configure_ac_version}" ]]; then
     echo "ERROR: FULL_VERSION: ${configure_ac_version} from configure.ac doesn't match tag: ${release_tag} provided! Exit"
@@ -60,20 +64,25 @@ fi
 if [ "${do_release}" = true ] ; then
     echo "do_release is set to true, will release package into ${DST_DIR}"
 
-    cd pkg/packages || { echo "pkg folder is missing, exiting..."; exit 1; }
-    pkg_name=$(ls -1 libvma-"${release_tag}"-"${revision}".src.rpm)
-
-    if [[ -e "${DST_DIR}/${pkg_name}" ]]; then 
-        echo "ERROR: [${DST_DIR}/${pkg_name}] file already exist. Exit"
+    if [ ! -d "${pkg_folder}" ]; then
+        echo "ERROR: [${pkg_folder}] directory doesn't exist. Exit"
         exit 1
     fi
 
+    if [[ -e "${DST_DIR}/${pkg_name}" || -e "${DST_DIR}/${tarball_name}" ]]; then 
+        echo "ERROR: [${DST_DIR}/${pkg_name}] or [${DST_DIR}/${tarball_name}] file already exist. Exit"
+        exit 1
+    fi
+    files_dir=$(pwd)
+    pushd "${release_folder}" || { echo "ERROR: Failed to pushd to ${release_folder}. Exit" ; exit 1; }
     sudo -E -u swx-jenkins mkdir -p "$DST_DIR"
-    sudo -E -u swx-jenkins cp -v "${pkg_name}" "$DST_DIR"
-    sudo -E -u swx-jenkins ln -s "${DST_DIR}/${pkg_name}" "${release_folder}/source_rpms/${pkg_name}"
-    echo "Release found at $DST_DIR"
+    sudo -E -u swx-jenkins cp -v "${files_dir}/${pkg_folder}/${pkg_name}" "$DST_DIR"
+    sudo -E -u swx-jenkins cp -v "${files_dir}/${pkg_folder}/${tarball_name}" "$DST_DIR"
+    popd || { echo "ERROR: Failed to popd from ${release_folder}. Exit" ; exit 1; }
+
+    echo "INFO: Release found at $DST_DIR"
 else
-     echo "do_release is set to false, skipping package release."
+     echo "INFO: do_release is set to false, skipping package release."
 fi
 
 set +x


### PR DESCRIPTION




## Description
Released packed should be tar.gz instead of src.rpm, with a small change to the dir stucture
For now we will create both the src.rpm and the tar.gz created in the build_pkg.sh , and moves it to the release folder.

Pointers to the new tar.gz file are not being created by the script

##### What
Move libvma.spec to the root of the directory being compressed. 
Remove libvma.spec from contrib/scripts/libvma.spec

##### Why ?
Issue #4377705

## Change type
What kind of change does this PR introduce?
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [x] CI related changes
- [ ] Documentation content changes
- [ ] Tests
- [ ] Other

## Check list
- [ ] Code follows the style de facto guidelines of this project
- [ ] Comments have been inserted in hard to understand places
- [ ] Documentation has been updated (if necessary)
- [ ] Test has been added (if possible)

