### PR TITLE
issue: 4504533 Fix VMA_BF environment variable

### DIFF
--- a/src/vma/util/sys_vars.cpp
+++ b/src/vma/util/sys_vars.cpp
@@ -1287,10 +1287,12 @@ void set_env_params()
 	if (safe_mce_sys().handle_bf) {
 		setenv("MLX4_POST_SEND_PREFER_BF", "1", 1);
 		setenv("MLX5_POST_SEND_PREFER_BF", "1", 1);
+		setenv("MLX5_SHUT_UP_BF", "0", 1);
 	} else {
 		/* todo - these seem not to work if inline is on, since libmlx is doing (inl || bf) when deciding to bf*/
 		setenv("MLX4_POST_SEND_PREFER_BF", "0", 1);
 		setenv("MLX5_POST_SEND_PREFER_BF", "0", 1);
+		setenv("MLX5_SHUT_UP_BF", "1", 1);
 	}
 
 	switch (safe_mce_sys().mem_alloc_type) {


### PR DESCRIPTION
To correctly enable/disable Blueflame, we should set MLX5_SHUT_UP_BF RDMA CORE environment variable.

## Description
Please provide a summary of the change.

##### What
_Subject: what this PR is doing in one line._ 

##### Why ?
_Justification for the PR. If there is existing issue/bug please reference._

##### How ?
_It is optional but for complex PRs please provide information about the design,
architecture, approach, etc._

## Change type
What kind of change does this PR introduce?
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Tests
- [ ] Other

## Check list
- [ ] Code follows the style de facto guidelines of this project
- [ ] Comments have been inserted in hard to understand places
- [ ] Documentation has been updated (if necessary)
- [ ] Test has been added (if possible)

