### PR TITLE
[CI] Issue: HPCINFRA-3502 Change default JNLP image

### DIFF
--- a/.ci/matrix_job.yaml
+++ b/.ci/matrix_job.yaml
@@ -14,6 +14,13 @@ kubernetes:
   nodeSelector: 'beta.kubernetes.io/os=linux'
   limits: '{memory: 8Gi, cpu: 8000m}'
   requests: '{memory: 8Gi, cpu: 8000m}'
+  arch_table:
+    x86_64:
+      nodeSelector: 'kubernetes.io/arch=amd64'
+      jnlpImage: 'harbor.mellanox.com/toolbox/c3po-jnlp:latest'
+    aarch64:
+      nodeSelector: 'kubernetes.io/arch=arm64'
+      jnlpImage: 'harbor.mellanox.com/toolbox/c3po-jnlp:latest'
 
 volumes:
   - {mountPath: /hpc/local/bin, hostPath: /hpc/local/bin}
@@ -330,4 +337,4 @@ failFast: false
 
 taskName: '${flags}/${name}/${axis_index}'
 
-timeout_minutes: 120
+timeout_minutes: 150

--- a/.ci/pipeline/release_matrix_job.yaml
+++ b/.ci/pipeline/release_matrix_job.yaml
@@ -11,6 +11,10 @@ kubernetes:
   namespace: swx-media
   limits: '{memory: 8Gi, cpu: 7000m}'
   requests: '{memory: 8Gi, cpu: 7000m}'
+  arch_table:
+    x86_64:
+      nodeSelector: 'kubernetes.io/arch=amd64'
+      jnlpImage: 'harbor.mellanox.com/toolbox/c3po-jnlp:latest'
 
 env:
   MAIL_FROM: jenkins@nvidia.com

--- a/.ci/redmine_matrix_job.yaml
+++ b/.ci/redmine_matrix_job.yaml
@@ -11,6 +11,10 @@ kubernetes:
   nodeSelector: 'beta.kubernetes.io/os=linux'
   limits: '{memory: 1Gi, cpu: 1000m}'
   requests: '{memory: 1Gi, cpu: 1000m}'
+  arch_table:
+    x86_64:
+      nodeSelector: 'kubernetes.io/arch=amd64'
+      jnlpImage: 'harbor.mellanox.com/toolbox/c3po-jnlp:latest'
 
 failFast: false
 timeout_minutes: 20


### PR DESCRIPTION
## Description
The current default JNLP image used is the one from jenkins itself, which does not support retries, this causes issues on connectivity issues to the kubernetes cloud

##### What
Add jnlpImage definition to the matrix files - Image is multi arch

##### Why ?
[HPCINFRA-3805](https://jirasw.nvidia.com/browse/HPCINFRA-3805)
[HPCINFRA-3502](https://jirasw.nvidia.com/browse/HPCINFRA-3502)

## Change type
What kind of change does this PR introduce?
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [X] CI related changes
- [ ] Documentation content changes
- [ ] Tests
- [ ] Other

## Check list
- [ ] Code follows the style de facto guidelines of this project
- [ ] Comments have been inserted in hard to understand places
- [ ] Documentation has been updated (if necessary)
- [ ] Test has been added (if possible)

