### PR TITLE
Use-after-free and heap-size-mismatch fix.

### DIFF
--- a/src/stats/stats_printer.cpp
+++ b/src/stats/stats_printer.cpp
@@ -11,8 +11,7 @@
 #include "vma/util/utils.h"
 #include "vma/util/vma_stats.h"
 #include "vma/lwip/tcp.h"
-#include "vma/vma_extra.h"
-#include "vma/util/sys_vars.h"
+#include "vma/util/vtypes.h"
 
 typedef enum {
 	e_K = 1024,

--- a/src/stats/stats_reader.cpp
+++ b/src/stats/stats_reader.cpp
@@ -15,9 +15,9 @@
 #include <fcntl.h>
 #include <errno.h>
 #include <list>
+#include <netinet/in.h>
 #include <signal.h>
 #include <getopt.h>		/* getopt()*/
-#include <errno.h>
 #include <dirent.h>
 #include <string.h>
 #include <vector>

--- a/src/vlogger/vlogger.cpp
+++ b/src/vlogger/vlogger.cpp
@@ -17,8 +17,6 @@
 #include <fcntl.h>
 
 #include "utils/bullseye.h"
-#include "vma/util/utils.h"
-#include "vma/util/sys_vars.h"
 
 #define VLOG_DEFAULT_MODULE_NAME "VMA"
 #define VMA_LOG_CB_ENV_VAR "VMA_LOG_CB_FUNC_PTR"
@@ -31,7 +29,7 @@ vlog_levels_t* g_p_vlogger_level = NULL;
 uint8_t      g_vlogger_details = 0;
 uint8_t*     g_p_vlogger_details = NULL;
 uint32_t     g_vlogger_usec_on_startup = 0;
-bool         g_vlogger_log_in_colors = MCE_DEFAULT_LOG_COLORS;
+bool         g_vlogger_log_in_colors = false;
 vma_log_cb_t g_vlogger_cb = NULL;
 
 namespace log_level

--- a/src/vma/dev/rfs.cpp
+++ b/src/vma/dev/rfs.cpp
@@ -120,7 +120,7 @@ rfs::~rfs()
 	delete[] m_sinks_list;
 
 	while (m_attach_flow_data_vector.size() > 0) {
-		delete m_attach_flow_data_vector.back();
+		free(m_attach_flow_data_vector.back());
 		m_attach_flow_data_vector.pop_back();
 	}
 }

--- a/src/vma/dev/rfs.h
+++ b/src/vma/dev/rfs.h
@@ -8,6 +8,8 @@
 #ifndef RFS_H
 #define RFS_H
 
+#include <stdlib.h>
+#include <type_traits>
 #include <vector>
 
 #include "vma/ib/base/verbs_extra.h"
@@ -213,6 +215,13 @@ public:
 	virtual bool 		rx_dispatch_packet(mem_buf_desc_t* p_rx_wc_buf_desc, void* pv_fd_ready_array) = 0;
 
 protected:
+	template <class T, typename ...Args>
+	T * new_malloc(Args ... args) {
+		static_assert(std::is_trivially_destructible<T>::value == true);
+		void * p = aligned_alloc(alignof(T), sizeof(T));
+		return new(p) T(args...);
+	}
+
 	flow_tuple		m_flow_tuple;
 	ring_slave*		m_p_ring;
 	rfs_rule_filter*	m_p_rule_filter;

--- a/src/vma/dev/rfs_mc.cpp
+++ b/src/vma/dev/rfs_mc.cpp
@@ -56,7 +56,7 @@ bool rfs_mc::prepare_flow_spec()
 #ifdef DEFINED_IBV_FLOW_SPEC_IB
 				attach_flow_data_ib_v1_t*  attach_flow_data_ib_v1 = NULL;
 
-				attach_flow_data_ib_v1 = new attach_flow_data_ib_v1_t(p_ring->m_p_qp_mgr);
+				attach_flow_data_ib_v1 = new_malloc<attach_flow_data_ib_v1_t>(p_ring->m_p_qp_mgr);
 
 				uint8_t dst_gid[16];
 				create_mgid_from_ipv4_mc_ip(dst_gid, p_ring->m_p_qp_mgr->get_partiton(), m_flow_tuple.get_dst_ip());
@@ -70,7 +70,7 @@ bool rfs_mc::prepare_flow_spec()
 #endif
 			}
 
-			attach_flow_data_ib_v2 = new attach_flow_data_ib_v2_t(p_ring->m_p_qp_mgr);
+			attach_flow_data_ib_v2 = new_malloc<attach_flow_data_ib_v2_t>(p_ring->m_p_qp_mgr);
 
 			ibv_flow_spec_ipv4_set(&(attach_flow_data_ib_v2->ibv_flow_attr.ipv4),
 						m_flow_tuple.get_dst_ip(),
@@ -88,7 +88,7 @@ bool rfs_mc::prepare_flow_spec()
 			{
 			attach_flow_data_eth_ipv4_tcp_udp_t*  attach_flow_data_eth = NULL;
 
-			attach_flow_data_eth = new attach_flow_data_eth_ipv4_tcp_udp_t(p_ring->m_p_qp_mgr);
+			attach_flow_data_eth = new_malloc<attach_flow_data_eth_ipv4_tcp_udp_t>(p_ring->m_p_qp_mgr);
 
 			uint8_t dst_mac[6];
 			create_multicast_mac_from_ip(dst_mac, m_flow_tuple.get_dst_ip());

--- a/src/vma/dev/rfs_uc.cpp
+++ b/src/vma/dev/rfs_uc.cpp
@@ -59,7 +59,7 @@ bool rfs_uc::prepare_flow_spec()
 			if (0 == p_ring->m_p_qp_mgr->get_underly_qpn()) {
 				attach_flow_data_ib_ipv4_tcp_udp_v1_t* attach_flow_data_ib_v1 = NULL;
 
-				attach_flow_data_ib_v1 = new attach_flow_data_ib_ipv4_tcp_udp_v1_t(p_ring->m_p_qp_mgr);
+				attach_flow_data_ib_v1 = new_malloc<attach_flow_data_ib_ipv4_tcp_udp_v1_t>(p_ring->m_p_qp_mgr);
 				ibv_flow_spec_ib_set_by_dst_qpn(&(attach_flow_data_ib_v1->ibv_flow_attr.ib),
 							htonl(((IPoIB_addr*)p_ring->m_p_l2_addr)->get_qpn()));
 				p_ipv4 = &(attach_flow_data_ib_v1->ibv_flow_attr.ipv4);
@@ -68,7 +68,7 @@ bool rfs_uc::prepare_flow_spec()
 				break;
 			}
 #endif
-			attach_flow_data_ib_v2 = new attach_flow_data_ib_ipv4_tcp_udp_v2_t(p_ring->m_p_qp_mgr);
+			attach_flow_data_ib_v2 = new_malloc<attach_flow_data_ib_ipv4_tcp_udp_v2_t>(p_ring->m_p_qp_mgr);
 
 			p_ipv4 = &(attach_flow_data_ib_v2->ibv_flow_attr.ipv4);
 			p_tcp_udp = &(attach_flow_data_ib_v2->ibv_flow_attr.tcp_udp);
@@ -77,7 +77,7 @@ bool rfs_uc::prepare_flow_spec()
 			}
 		case VMA_TRANSPORT_ETH:
 			{
-			attach_flow_data_eth = new attach_flow_data_eth_ipv4_tcp_udp_t(p_ring->m_p_qp_mgr);
+			attach_flow_data_eth = new_malloc<attach_flow_data_eth_ipv4_tcp_udp_t>(p_ring->m_p_qp_mgr);
 
 			ibv_flow_spec_eth_set(&(attach_flow_data_eth->ibv_flow_attr.eth),
 					p_ring->m_p_l2_addr->get_address(),

--- a/src/vma/dev/time_converter_ptp.h
+++ b/src/vma/dev/time_converter_ptp.h
@@ -9,6 +9,7 @@
 #define TIME_CONVERTER_PTP_H
 
 #include <infiniband/verbs.h>
+#include "vma/ib/base/verbs_extra.h"
 #include "vma/event/timer_handler.h"
 #include <vma/util/sys_vars.h>
 #include "time_converter.h"

--- a/src/vma/event/delta_timer.h
+++ b/src/vma/event/delta_timer.h
@@ -8,6 +8,7 @@
 #ifndef DELTA_TIMER_H
 #define DELTA_TIMER_H
 
+#include <atomic>
 #include <chrono>
 #include "utils/lock_wrapper.h"
 
@@ -32,18 +33,13 @@ struct timer_node_t {
 	std::chrono::milliseconds            delta_time_msec;
 	/* the orig timer requested (saved in order to re-register periodic timers) */
 	std::chrono::milliseconds            orig_time_msec;
-	/* control thread-safe access to handler. Recursive because unregister_timer_event()
-	 * can be called from handle_timer_expired()
-	 * that is under trylock() inside process_registered_timers
-	 */
-	lock_spin_recursive     lock_timer;
 	/* link to the context registered */
-	timer_handler*          handler;
-	void*                   user_data;
-	timers_group*           group;
-	timer_req_type_t        req_type;
-	struct timer_node_t*    next;
-	struct timer_node_t*    prev;
+	std::atomic<timer_handler*> handler;
+	void*                       user_data;
+	timers_group*               group;
+	timer_req_type_t            req_type;
+	struct timer_node_t*        next;
+	struct timer_node_t*        prev;
 }; // used by the list
 
 class timer 

--- a/src/vma/event/timer_handler.h
+++ b/src/vma/event/timer_handler.h
@@ -8,6 +8,11 @@
 #ifndef TIMER_HANDLER_H
 #define TIMER_HANDLER_H
 
+#include <atomic>
+
+#include "vlogger/vlogger.h"
+#include "utils/lock_wrapper.h"
+
 /**
  * simple timer notification.
  * Any class that inherit timer_handler should also inherit cleanable_obj, and use clean_obj instead of delete.
@@ -15,9 +20,58 @@
  */
 class timer_handler
 {
-public:
-	virtual ~timer_handler() {};
+private:
+	lock_spin m_handle_mutex{"timer_handler"};
+	std::atomic<bool> m_destroy_in_progress{false};
+protected:
 	virtual void handle_timer_expired(void* user_data) = 0;
+
+public:
+	timer_handler() = default;
+
+	virtual ~timer_handler() {
+		if( !m_destroy_in_progress.load()) {
+			m_destroy_in_progress = true;
+			vlog_printf(VLOG_DEBUG, "Destroying timer_handler without destroy in progress.\n
+		}
+		{
+			m_handle_mutex.lock();
+			m_handle_mutex.unlock();
+		}
+	};
+
+	void safe_handle_timer_expired(void* user_data) {
+		if(!m_destroy_in_progress.load()) {
+			if (m_handle_mutex.trylock() == 0) {
+				handle_timer_expired(user_data);
+				m_handle_mutex.unlock();
+			}
+		}
+	}
+
+/**
+  * Sets the destroying state of the object to indicate that destruction is in progress.
+  *
+  * If `wait_for_handler` is set to true, this method will ensure that the mutex
+  * used for handling operations (m_handle_mutex) is acquired and released, effectively
+  * waiting for any pending handler operation to complete.
+  *
+  * @param wait_for_handler If true, waits for the handler mutex to ensure
+  *                         handler finish before proceeding.
+  *                         Defaults to false.
+  *
+  * @return The previous state of the destruction flag.
+  *         Returns true if a destruction process was already in progress before
+  *         this method was called, otherwise false.
+  */
+	bool set_destroying_state(bool wait_for_handler = false) {
+		bool result = m_destroy_in_progress.exchange(true);
+		if( wait_for_handler ) {
+			m_handle_mutex.lock();
+			m_handle_mutex.unlock();
+		}
+		return result;
+	}
 };
 
 #endif

--- a/src/vma/sock/fd_collection.cpp
+++ b/src/vma/sock/fd_collection.cpp
@@ -635,7 +635,7 @@ void  fd_collection::handle_timer_expired(void* user_data)
 			if (si_tcp) {
 				//In case of TCP socket progress the TCP connection
 				fdcoll_logfunc("Call to handler timer of TCP socket:%d", (*itr)->get_fd());
-				si_tcp->handle_timer_expired(NULL);
+				si_tcp->safe_handle_timer_expired(NULL);
 			}
 			itr++;
 		}

--- a/src/vma/sock/sockinfo_tcp.cpp
+++ b/src/vma/sock/sockinfo_tcp.cpp
@@ -4798,8 +4798,9 @@ void tcp_timers_collection::handle_timer_expired(void* user_data)
 	NOT_IN_USE(user_data);
 	timer_node_t* iter = m_p_intervals[m_n_location];
 	while (iter) {
-		__log_funcall("timer expired on %p", iter->handler);
-		iter->handler->handle_timer_expired(iter->user_data);
+		timer_handler * handler = iter->handler.load();
+		__log_funcall("timer expired on %p", handler);
+		handler->safe_handle_timer_expired(iter->user_data);
 		iter = iter->next;
 	}
 	m_n_location = (m_n_location + 1) % m_n_intervals_size;
@@ -4859,7 +4860,7 @@ void tcp_timers_collection::remove_timer(timer_node_t* node)
 		}
 	}
 
-	__log_dbg("TCP timer handler [%p] was removed", node->handler);
+	__log_dbg("TCP timer handler [%p] was removed", node->handler.load());
 
 	free(node);
 }

--- a/src/vma/util/sys_vars.cpp
+++ b/src/vma/util/sys_vars.cpp
@@ -276,15 +276,21 @@ int mce_sys_var::hex_to_cpuset(char *start, cpu_set_t *cpu_set)
 int mce_sys_var::env_to_cpuset(char *orig_start, cpu_set_t *cpu_set)
 {
 	int ret;
-	char* start = strdup(orig_start); // save the caller string from strtok destruction.
+	memset(&(cpu_set->__bits), 0, sizeof(cpu_set->__bits));
 
+	int len = strlen(orig_start);
+	if (len == 2 && orig_start[0] == '-' && orig_start[1] == '1') {
+		return 0;
+	}
+
+	char *start = strdup(orig_start); // save the caller string from strtok destruction.
 	/*
 	 * We expect a hex number or comma delimited cpulist.  Check for 
 	 * starting characters of "0x" or "0X" and if present then parse
 	 * the string as a hexidecimal value, otherwise treat it as a 
 	 * cpulist.
 	 */
-	if ((strlen(start) > 2) &&
+	if ((len > 2) &&
 		(start[0] == '0') &&
 		((start[1] == 'x') || (start[1] == 'X'))) {
 		ret = hex_to_cpuset(start + 2, cpu_set);

--- a/src/vma/util/utils.cpp
+++ b/src/vma/util/utils.cpp
@@ -414,13 +414,24 @@ int priv_read_file(const char *path, char *buf, size_t size, vlog_levels_t log_l
 
 int read_file_to_int(const char *path, int default_value)
 {
-	int value = -1;
-	std::ifstream file_stream(path);
-	if (!file_stream || !(file_stream >> value)) {
-		__log_warn("ERROR while getting int from from file %s, we'll use default %d", path, default_value);
-		return default_value;
+	int fd, sz;
+	char c[21] = {};
+
+	fd = open(path, O_RDONLY);
+	if (fd >= 0) {
+		sz = read(fd, c, 20);
+		if (sz > 0) {
+			int value;
+			c[sz] = '\0';
+			int n = sscanf(reinterpret_cast<const char *>(&c), "%d", &value);
+			if (n == 1) {
+				return value;
+			}
+		}
 	}
-	return value;
+
+	__log_warn("ERROR while getting int from from file %s, we'll use default %d", path, default_value);
+	return default_value;
 }
 
 int get_ifinfo_from_ip(const struct sockaddr& addr, char* ifname, uint32_t& ifflags)


### PR DESCRIPTION
## Description

1. Removed redundant header dependencies to allow building vlogger and state_machine independently from the rest of the code.
2. Fixed logic of set log color output parameter.
3. Rewrote the functions read_file_to_int (src/vma/util/utils.cpp) and env_to_cpuset (src/vma/util/sys_vars.cpp) to enable running the code with ASAN.
4. Fixed a new/delete size mismatch in src/vma/dev/rfs*.
5. Fixed a use-after-free issue in timer_handler.

##### What
Use-after-free and heap-size-mismatch fix.

## Change type
What kind of change does this PR introduce?
- [X] Bugfix
- [ ] Feature
- [ ] Code style update
- [X] Refactoring (no functional changes, no api changes)
- [X] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Tests
- [ ] Other

## Check list
- [X] Code follows the style de facto guidelines of this project
- [X] Comments have been inserted in hard to understand places
- [ ] Documentation has been updated (if necessary)
- [ ] Test has been added (if possible)
