### PR TITLE
issue: 4670088 add valgrind suppression

### DIFF
--- a/contrib/valgrind/valgrind_vma.supp
+++ b/contrib/valgrind/valgrind_vma.supp
@@ -87,6 +87,23 @@
    fun:rdma_create_event_channel
    fun:_ZN15neigh_table_mgrC1Ev
 }
+{
+   rdma_create_event_channel_fp_leak
+   Memcheck:Leak
+   match-leak-kinds: possible
+   fun:calloc
+   obj:/usr/lib/x86_64-linux-gnu/librdmacm.so.1.3.54.0
+   obj:/usr/lib/x86_64-linux-gnu/librdmacm.so.1.3.54.0
+   obj:/usr/lib/x86_64-linux-gnu/librdmacm.so.1.3.54.0
+   fun:rdma_create_event_channel
+   fun:_ZN15neigh_table_mgrC1Ev
+   fun:do_global_ctors_helper
+   fun:_Z15do_global_ctorsv
+   fun:socket_internal
+   fun:socket
+   fun:_Z7bringupPKi
+   fun:main
+}
 # false positive verbs
 {
    libibverbs Param ibv_exp_cmd_create_qp


### PR DESCRIPTION
## Description
Add a new Valgrind suppression rule to handle false positive memory leak reports from rdma_create_event_channel() in librdmacm.

The suppression matches the specific call stack from socket() through the global constructors and into rdma_create_event_channel().

##### What
valgrind: Add suppression for rdma_create_event_channel false positive

##### Why ?
Pass Valgrind in CI once CI is fixed

##### How ?
_It is optional but for complex PRs please provide information about the design,
architecture, approach, etc._

## Change type
What kind of change does this PR introduce?
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Tests
- [ ] Other

## Check list
- [ ] Code follows the style de facto guidelines of this project
- [ ] Comments have been inserted in hard to understand places
- [ ] Documentation has been updated (if necessary)
- [ ] Test has been added (if possible)

