### PR TITLE
[CI] issue: 4684071Terminate Valgrind gracefully

### DIFF
--- a/contrib/jenkins_tests/vg.sh
+++ b/contrib/jenkins_tests/vg.sh
@@ -95,7 +95,7 @@ for test_link in $test_ip_list; do
 
 		if [ `ps -ef | grep $test_app | wc -l` -gt 1 ];
 		then
-			${sudo_cmd} pkill -9 -f $test_app 2>/dev/null || true
+			${sudo_cmd} pkill -SIGINT -f $test_app 2>/dev/null || true
 			sleep 10
 			# in case SIGINT didn't work
 			if [ `ps -ef | grep $test_app | wc -l` -gt 1 ];


### PR DESCRIPTION
## Description
Valgrind today is being terminated with -9 which prevents it from printing all the summaries at the end which are needed for debuging.


##### What
Change -9 signal to -SIGINT af the first try of shutting down Valgrind

##### Why ?
[HPCINFRA-3989](https://jirasw.nvidia.com/browse/HPCINFRA-3989)

##### How ?
_It is optional but for complex PRs please provide information about the design,
architecture, approach, etc._

## Change type
What kind of change does this PR introduce?
- [X] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [X] CI related changes
- [ ] Documentation content changes
- [ ] Tests
- [ ] Other

## Check list
- [ ] Code follows the style de facto guidelines of this project
- [ ] Comments have been inserted in hard to understand places
- [ ] Documentation has been updated (if necessary)
- [ ] Test has been added (if possible)

