### PR TITLE
vma/dev: Fix new/delete size mismatch.

### DIFF
--- a/src/vma/dev/rfs.cpp
+++ b/src/vma/dev/rfs.cpp
@@ -120,7 +120,7 @@ rfs::~rfs()
 	delete[] m_sinks_list;
 
 	while (m_attach_flow_data_vector.size() > 0) {
-		delete m_attach_flow_data_vector.back();
+		free(m_attach_flow_data_vector.back());
 		m_attach_flow_data_vector.pop_back();
 	}
 }

--- a/src/vma/dev/rfs.h
+++ b/src/vma/dev/rfs.h
@@ -8,6 +8,8 @@
 #ifndef RFS_H
 #define RFS_H
 
+#include <stdlib.h>
+#include <type_traits>
 #include <vector>
 
 #include "vma/ib/base/verbs_extra.h"
@@ -213,6 +215,15 @@ public:
 	virtual bool 		rx_dispatch_packet(mem_buf_desc_t* p_rx_wc_buf_desc, void* pv_fd_ready_array) = 0;
 
 protected:
+	template <class T, typename ...Args>
+	T * new_malloc(Args ... args) {
+		static_assert(std::is_trivially_destructible<T>::value == true);
+		void * p = aligned_alloc(alignof(T), sizeof(T));
+		if (!p)
+			throw std::bad_alloc{};
+		return new(p) T(args...);
+	}
+
 	flow_tuple		m_flow_tuple;
 	ring_slave*		m_p_ring;
 	rfs_rule_filter*	m_p_rule_filter;

--- a/src/vma/dev/rfs_mc.cpp
+++ b/src/vma/dev/rfs_mc.cpp
@@ -56,7 +56,7 @@ bool rfs_mc::prepare_flow_spec()
 #ifdef DEFINED_IBV_FLOW_SPEC_IB
 				attach_flow_data_ib_v1_t*  attach_flow_data_ib_v1 = NULL;
 
-				attach_flow_data_ib_v1 = new attach_flow_data_ib_v1_t(p_ring->m_p_qp_mgr);
+				attach_flow_data_ib_v1 = new_malloc<attach_flow_data_ib_v1_t>(p_ring->m_p_qp_mgr);
 
 				uint8_t dst_gid[16];
 				create_mgid_from_ipv4_mc_ip(dst_gid, p_ring->m_p_qp_mgr->get_partiton(), m_flow_tuple.get_dst_ip());
@@ -70,7 +70,7 @@ bool rfs_mc::prepare_flow_spec()
 #endif
 			}
 
-			attach_flow_data_ib_v2 = new attach_flow_data_ib_v2_t(p_ring->m_p_qp_mgr);
+			attach_flow_data_ib_v2 = new_malloc<attach_flow_data_ib_v2_t>(p_ring->m_p_qp_mgr);
 
 			ibv_flow_spec_ipv4_set(&(attach_flow_data_ib_v2->ibv_flow_attr.ipv4),
 						m_flow_tuple.get_dst_ip(),
@@ -88,7 +88,7 @@ bool rfs_mc::prepare_flow_spec()
 			{
 			attach_flow_data_eth_ipv4_tcp_udp_t*  attach_flow_data_eth = NULL;
 
-			attach_flow_data_eth = new attach_flow_data_eth_ipv4_tcp_udp_t(p_ring->m_p_qp_mgr);
+			attach_flow_data_eth = new_malloc<attach_flow_data_eth_ipv4_tcp_udp_t>(p_ring->m_p_qp_mgr);
 
 			uint8_t dst_mac[6];
 			create_multicast_mac_from_ip(dst_mac, m_flow_tuple.get_dst_ip());

--- a/src/vma/dev/rfs_uc.cpp
+++ b/src/vma/dev/rfs_uc.cpp
@@ -59,7 +59,7 @@ bool rfs_uc::prepare_flow_spec()
 			if (0 == p_ring->m_p_qp_mgr->get_underly_qpn()) {
 				attach_flow_data_ib_ipv4_tcp_udp_v1_t* attach_flow_data_ib_v1 = NULL;
 
-				attach_flow_data_ib_v1 = new attach_flow_data_ib_ipv4_tcp_udp_v1_t(p_ring->m_p_qp_mgr);
+				attach_flow_data_ib_v1 = new_malloc<attach_flow_data_ib_ipv4_tcp_udp_v1_t>(p_ring->m_p_qp_mgr);
 				ibv_flow_spec_ib_set_by_dst_qpn(&(attach_flow_data_ib_v1->ibv_flow_attr.ib),
 							htonl(((IPoIB_addr*)p_ring->m_p_l2_addr)->get_qpn()));
 				p_ipv4 = &(attach_flow_data_ib_v1->ibv_flow_attr.ipv4);
@@ -68,7 +68,7 @@ bool rfs_uc::prepare_flow_spec()
 				break;
 			}
 #endif
-			attach_flow_data_ib_v2 = new attach_flow_data_ib_ipv4_tcp_udp_v2_t(p_ring->m_p_qp_mgr);
+			attach_flow_data_ib_v2 = new_malloc<attach_flow_data_ib_ipv4_tcp_udp_v2_t>(p_ring->m_p_qp_mgr);
 
 			p_ipv4 = &(attach_flow_data_ib_v2->ibv_flow_attr.ipv4);
 			p_tcp_udp = &(attach_flow_data_ib_v2->ibv_flow_attr.tcp_udp);
@@ -77,7 +77,7 @@ bool rfs_uc::prepare_flow_spec()
 			}
 		case VMA_TRANSPORT_ETH:
 			{
-			attach_flow_data_eth = new attach_flow_data_eth_ipv4_tcp_udp_t(p_ring->m_p_qp_mgr);
+			attach_flow_data_eth = new_malloc<attach_flow_data_eth_ipv4_tcp_udp_t>(p_ring->m_p_qp_mgr);
 
 			ibv_flow_spec_eth_set(&(attach_flow_data_eth->ibv_flow_attr.eth),
 					p_ring->m_p_l2_addr->get_address(),


### PR DESCRIPTION
## Description
Trivial child class was created with `new` operator, but `delete` operator were applied to base class instance. Changing the classes to non-trivial is impossible, because they used in external rdma-core library.

##### What
Fix mismatch in size of `new` and `delete` structure.

##### Why ?
Fixed memory leak problem.

## Change type
What kind of change does this PR introduce?
- [X] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Tests
- [ ] Other

## Check list
- [X] Code follows the style de facto guidelines of this project
- [ ] Comments have been inserted in hard to understand places
- [ ] Documentation has been updated (if necessary)
- [ ] Test has been added (if possible)

