### PR TITLE
vma/util: ASAN problem fix.

### DIFF
--- a/src/vma/util/sys_vars.cpp
+++ b/src/vma/util/sys_vars.cpp
@@ -276,15 +276,21 @@ int mce_sys_var::hex_to_cpuset(char *start, cpu_set_t *cpu_set)
 int mce_sys_var::env_to_cpuset(char *orig_start, cpu_set_t *cpu_set)
 {
 	int ret;
-	char* start = strdup(orig_start); // save the caller string from strtok destruction.
 
+	int len = strlen(orig_start);
+	if (len == 2 && orig_start[0] == '-' && orig_start[1] == '1') {
+		CPU_ZERO(cpu_set);
+		return 0;
+	}
+
+	char *start = strdup(orig_start); // save the caller string from strtok destruction.
 	/*
 	 * We expect a hex number or comma delimited cpulist.  Check for 
 	 * starting characters of "0x" or "0X" and if present then parse
 	 * the string as a hexidecimal value, otherwise treat it as a 
 	 * cpulist.
 	 */
-	if ((strlen(start) > 2) &&
+	if ((len > 2) &&
 		(start[0] == '0') &&
 		((start[1] == 'x') || (start[1] == 'X'))) {
 		ret = hex_to_cpuset(start + 2, cpu_set);


### PR DESCRIPTION
## Description
The changes is required to run the code compiled with ASAN. The problem is that both ASAN and libvma override libc standard functions and during initialization process some kind of "racing conditions" is possible. Function `read_file_to_int` most probably, has false-positive alert, but function `env_to_cpuset` is not. The default value `-1` is passed to from `env_to_cpuset` to `list_to_cpuset` function, which can't parse it correctly. 

##### What
Fix ASAN problems.

##### Why ?
ASAN can help to debug memory problems in some cases much more efficient, than e.g. valgrind.

## Change type
What kind of change does this PR introduce?
- [X] Bugfix
- [X] Feature
- [ ] Code style update
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Tests
- [ ] Other

## Check list
- [ ] Code follows the style de facto guidelines of this project
- [ ] Comments have been inserted in hard to understand places
- [ ] Documentation has been updated (if necessary)
- [ ] Test has been added (if possible)

