### PR TITLE
stats: Fix crash with dangling pointers.

### DIFF
--- a/src/stats/stats_printer.cpp
+++ b/src/stats/stats_printer.cpp
@@ -11,8 +11,7 @@
 #include "vma/util/utils.h"
 #include "vma/util/vma_stats.h"
 #include "vma/lwip/tcp.h"
-#include "vma/vma_extra.h"
-#include "vma/util/sys_vars.h"
+#include "vma/util/vtypes.h"
 
 typedef enum {
 	e_K = 1024,

--- a/src/stats/stats_reader.cpp
+++ b/src/stats/stats_reader.cpp
@@ -15,9 +15,9 @@
 #include <fcntl.h>
 #include <errno.h>
 #include <list>
+#include <netinet/in.h>
 #include <signal.h>
 #include <getopt.h>		/* getopt()*/
-#include <errno.h>
 #include <dirent.h>
 #include <string.h>
 #include <vector>

--- a/src/vma/dev/time_converter_ptp.h
+++ b/src/vma/dev/time_converter_ptp.h
@@ -9,6 +9,7 @@
 #define TIME_CONVERTER_PTP_H
 
 #include <infiniband/verbs.h>
+#include "vma/ib/base/verbs_extra.h"
 #include "vma/event/timer_handler.h"
 #include <vma/util/sys_vars.h>
 #include "time_converter.h"

--- a/src/vma/event/delta_timer.h
+++ b/src/vma/event/delta_timer.h
@@ -8,6 +8,7 @@
 #ifndef DELTA_TIMER_H
 #define DELTA_TIMER_H
 
+#include <atomic>
 #include <chrono>
 #include "utils/lock_wrapper.h"
 
@@ -32,18 +33,13 @@ struct timer_node_t {
 	std::chrono::milliseconds            delta_time_msec;
 	/* the orig timer requested (saved in order to re-register periodic timers) */
 	std::chrono::milliseconds            orig_time_msec;
-	/* control thread-safe access to handler. Recursive because unregister_timer_event()
-	 * can be called from handle_timer_expired()
-	 * that is under trylock() inside process_registered_timers
-	 */
-	lock_spin_recursive     lock_timer;
 	/* link to the context registered */
-	timer_handler*          handler;
-	void*                   user_data;
-	timers_group*           group;
-	timer_req_type_t        req_type;
-	struct timer_node_t*    next;
-	struct timer_node_t*    prev;
+	std::atomic<timer_handler*> handler;
+	void*                       user_data;
+	timers_group*               group;
+	timer_req_type_t            req_type;
+	struct timer_node_t*        next;
+	struct timer_node_t*        prev;
 }; // used by the list
 
 class timer 

--- a/src/vma/event/timer_handler.h
+++ b/src/vma/event/timer_handler.h
@@ -8,6 +8,11 @@
 #ifndef TIMER_HANDLER_H
 #define TIMER_HANDLER_H
 
+#include <atomic>
+
+#include "vlogger/vlogger.h"
+#include "utils/lock_wrapper.h"
+
 /**
  * simple timer notification.
  * Any class that inherit timer_handler should also inherit cleanable_obj, and use clean_obj instead of delete.
@@ -15,9 +20,58 @@
  */
 class timer_handler
 {
-public:
-	virtual ~timer_handler() {};
+private:
+	lock_spin m_handle_mutex{"timer_handler"};
+	std::atomic<bool> m_destroy_in_progress{false};
+protected:
 	virtual void handle_timer_expired(void* user_data) = 0;
+
+public:
+	timer_handler() = default;
+
+	virtual ~timer_handler() {
+		if( !m_destroy_in_progress.load()) {
+			m_destroy_in_progress.store(true);
+			vlog_printf(VLOG_DEBUG, "Destroying timer_handler without destroy in progress.\n");
+		}
+		{
+			m_handle_mutex.lock();
+			m_handle_mutex.unlock();
+		}
+	}
+
+	void safe_handle_timer_expired(void* user_data) {
+		if (m_handle_mutex.trylock() == 0) {
+			if(!m_destroy_in_progress.load()) {
+				handle_timer_expired(user_data);
+			}
+			m_handle_mutex.unlock();
+		}
+	}
+
+/**
+  * Sets the destroying state of the object to indicate that destruction is in progress.
+  *
+  * If `wait_for_handler` is set to true, this method will ensure that the mutex
+  * used for handling operations (m_handle_mutex) is acquired and released, effectively
+  * waiting for any pending handler operation to complete.
+  *
+  * @param wait_for_handler If true, waits for the handler mutex to ensure
+  *                         handler finish before proceeding.
+  *                         Defaults to false.
+  *
+  * @return The previous state of the destruction flag.
+  *         Returns true if a destruction process was already in progress before
+  *         this method was called, otherwise false.
+  */
+	bool set_destroying_state(bool wait_for_handler = false) {
+		bool result = m_destroy_in_progress.exchange(true);
+		if( wait_for_handler ) {
+			m_handle_mutex.lock();
+			m_handle_mutex.unlock();
+		}
+		return result;
+	}
 };
 
 #endif

--- a/src/vma/sock/fd_collection.cpp
+++ b/src/vma/sock/fd_collection.cpp
@@ -635,7 +635,7 @@ void  fd_collection::handle_timer_expired(void* user_data)
 			if (si_tcp) {
 				//In case of TCP socket progress the TCP connection
 				fdcoll_logfunc("Call to handler timer of TCP socket:%d", (*itr)->get_fd());
-				si_tcp->handle_timer_expired(NULL);
+				si_tcp->safe_handle_timer_expired(NULL);
 			}
 			itr++;
 		}

--- a/src/vma/sock/sockinfo_tcp.cpp
+++ b/src/vma/sock/sockinfo_tcp.cpp
@@ -4798,8 +4798,12 @@ void tcp_timers_collection::handle_timer_expired(void* user_data)
 	NOT_IN_USE(user_data);
 	timer_node_t* iter = m_p_intervals[m_n_location];
 	while (iter) {
-		__log_funcall("timer expired on %p", iter->handler);
-		iter->handler->handle_timer_expired(iter->user_data);
+		timer_handler * handler = iter->handler.load();
+		__log_funcall("timer expired on %p", handler);
+		if ( handler )
+		{
+			handler->safe_handle_timer_expired(iter->user_data);
+		}
 		iter = iter->next;
 	}
 	m_n_location = (m_n_location + 1) % m_n_intervals_size;
@@ -4810,7 +4814,7 @@ void tcp_timers_collection::handle_timer_expired(void* user_data)
 
 void tcp_timers_collection::add_new_timer(timer_node_t* node, timer_handler* handler, void* user_data)
 {
-	node->handler = handler;
+	node->handler.store(handler);
 	node->user_data = user_data;
 	node->group = this;
 	node->next = NULL;
@@ -4859,7 +4863,7 @@ void tcp_timers_collection::remove_timer(timer_node_t* node)
 		}
 	}
 
-	__log_dbg("TCP timer handler [%p] was removed", node->handler);
+	__log_dbg("TCP timer handler [%p] was removed", node->handler.load());
 
 	free(node);
 }


### PR DESCRIPTION
## Description
Sometimes it happens, that timer handlers are destroyed, but it still can run in timer thread. Current solution with `lock_timer` can't prevent this in case of closing the library. The new solution uses mutex for every handler and prevent execution of the handler in case of destruction, and pause destruction, when the handler is running.

##### What
Fix crash with dangling pointers in timers.

## Change type
What kind of change does this PR introduce?
- [X] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Tests
- [ ] Other

## Check list
- [X] Code follows the style de facto guidelines of this project
- [X] Comments have been inserted in hard to understand places
- [ ] Documentation has been updated (if necessary)
- [ ] Test has been added (if possible)

