### PR TITLE
[CI] issue: 4705805 Replace rhel8.6 with rhel9.6

### DIFF
--- a/.ci/dockerfiles/Dockerfile.rhel9.6
+++ b/.ci/dockerfiles/Dockerfile.rhel9.6
@@ -1,0 +1,21 @@
+ARG HARBOR_URL=nbu-harbor.gtm.nvidia.com
+ARG ARCH=x86_64
+ARG OS_VERSION=9.6
+
+FROM $HARBOR_URL/swx-infra/media/$ARCH/base/rhel:$OS_VERSION
+ARG _UID=6213
+ARG _GID=101
+ARG _LOGIN=swx-jenkins
+ARG _HOME=/var/home/$_LOGIN
+RUN echo "${_LOGIN} ALL=(ALL) NOPASSWD: ALL" >> /etc/sudoers && \
+    echo "root ALL=(ALL) NOPASSWD: ALL" >> /etc/sudoers && \
+    mkdir -p ${_HOME} && \
+    groupadd -f -g "$_GID" "$_LOGIN" && \
+    useradd -u "$_UID" -g "$_GID" -s /bin/bash -m -d ${_HOME} "${_LOGIN}" && \
+    chown -R ${_LOGIN} ${_HOME}
+
+RUN dnf install --allowerasing -y json-c-devel curl \
+    autoconf automake make libtool \
+    gcc-c++ diffutils rpm-build \
+ && dnf clean all \
+ && rm -rf /var/cache/dnf

--- a/.ci/matrix_job.yaml
+++ b/.ci/matrix_job.yaml
@@ -42,7 +42,7 @@ env:
 
 runs_on_dockers:
 # doca-host
-  - {name: 'rhel8.6-x86_64', url: '${registry_host}/hpcx/x86_64/rhel8.6/base', category: 'base', arch: 'x86_64'}
+  - {name: 'rhel9.6-x86_64', file: '.ci/dockerfiles/Dockerfile.rhel9.6', uri: 'vma/$arch/$name/build', category: 'base', arch: 'x86_64', tag: '20261201', build_args: '--build-arg ARCH=x86_64 --no-cache'}
   - {name: 'rhel9.0-x86_64', url: '${registry_host}/hpcx/x86_64/rhel9.0/base', category: 'base', arch: 'x86_64'}
   - {name: 'rhel9.4-aarch64', file: '.ci/dockerfiles/Dockerfile.rhel9.4', category: 'base', arch: 'aarch64', tag: '20250203', uri: 'vma/$arch/$name/build', build_args: '--build-arg ARCH=aarch64 --no-cache'}
   - {name: 'ub24.04-x86_64', url: '${registry_host}/hpcx/x86_64/ubuntu24.04/base', category: 'base', arch: 'x86_64'}

--- a/.ci/proj_jjb.yaml
+++ b/.ci/proj_jjb.yaml
@@ -33,7 +33,7 @@
             description: "Enable debug prints and traces, valid values are 0-9."
         - string:
             name: "DOCA_VERSION"
-            default: "2.8.0"
+            default: "3.3.0"
             description: "DOCA version - see https://developer.nvidia.com/doca-downloads?deployment_platform=Host-Server&deployment_package=DOCA-Host"
         - choice:
             name: DOCA_BRANCH

--- a/.ci/scripts/doca_install.sh
+++ b/.ci/scripts/doca_install.sh
@@ -4,7 +4,7 @@ set -xvEe -o pipefail
 
 DOCA_REPO_PATH="https://doca-repo-prod.nvidia.com/internal/repo/doca"
 TARGET=${TARGET:=all}
-DOCA_VERSION=${DOCA_VERSION:='2.8.0'}
+DOCA_VERSION=${DOCA_VERSION:='3.3.0'}
 DOCA_BRANCH=${DOCA_BRANCH:="latest"}
 GPG_KEY="GPG-KEY-Mellanox.pub"
 
@@ -56,7 +56,8 @@ function map_os_and_arch {
             ;;
 
         rhel|ol)
-            OS="${ID}${VERSION_ID}"
+            # Extract major version only (e.g., 9.6 -> 9)
+            OS="${ID}${VERSION_ID%%.*}"
             GPG_KEY_CMD='rpm --import "${GPG_KEY}"'
             REPO_CMD='yum install -y yum-utils && yum-config-manager --add-repo "${REPO_URL}"'
             PKG_MGR="yum --nogpgcheck"
@@ -64,8 +65,8 @@ function map_os_and_arch {
             CURL_INSTALL=""
             ;;
         sles)
-            VERSION_ID=${VERSION_ID/./sp}
-            OS="${ID}${VERSION_ID}"
+            # Extract major version only (e.g., 9.6 -> 9)
+            OS="${ID}${VERSION_ID%%.*}"
             GPG_KEY_CMD='rpm --import "${GPG_KEY}"'
             REPO_CMD='zypper addrepo "${REPO_URL}" doca'
             PKG_MGR="zypper --no-gpg-checks"
@@ -90,7 +91,7 @@ function map_os_and_arch {
 map_os_and_arch
 
 # Install DOCA repo GPG key
-${CURL_INSTALL}; curl -o "${GPG_KEY}" "${DOCA_REPO_PATH}/${DOCA_VERSION}/${OS}/${ARCH}/${DOCA_BRANCH}/${GPG_KEY}" 
+${CURL_INSTALL}; curl -o "${GPG_KEY}" "${DOCA_REPO_PATH}/${DOCA_VERSION}/${OS}/${ARCH}/${DOCA_BRANCH}/${GPG_KEY}"
 eval "${GPG_KEY_CMD}"
 
 # Install DOCA repo
@@ -98,12 +99,12 @@ REPO_URL="${DOCA_REPO_PATH}/${DOCA_VERSION}/${OS}/${ARCH}/${DOCA_BRANCH}/"
 eval "${REPO_CMD}"
 
 # Install DOCA
-${PKG_MGR} ${UPDATE_CMD} 
+${PKG_MGR} ${UPDATE_CMD}
 
 ${PKG_MGR} install -y doca-ofed-userspace
 
 echo "=============================================="
-echo 
+echo
 echo "DOCA for Host has been successfully installed"
 echo
 echo "=============================================="


### PR DESCRIPTION
## Description
Please provide a summary of the change.

##### What
Replace rhel8.6 with rhel9.6 and update doca to version 3.3.0
Fix doca_install.sh to use major version for doca repo path.

##### Why ?
[HPCINFRA-4143](https://jirasw.nvidia.com/browse/HPCINFRA-4143)

##### How ?
_It is optional but for complex PRs please provide information about the design,
architecture, approach, etc._

## Change type
What kind of change does this PR introduce?
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [x] CI related changes
- [ ] Documentation content changes
- [ ] Tests
- [ ] Other

## Check list
- [ ] Code follows the style de facto guidelines of this project
- [ ] Comments have been inserted in hard to understand places
- [ ] Documentation has been updated (if necessary)
- [ ] Test has been added (if possible)

