### PR TITLE
issue: 4917201 Fix non-c-typedef-for-linkage build error

### DIFF
--- a/src/vma/dev/ring_simple.cpp
+++ b/src/vma/dev/ring_simple.cpp
@@ -833,6 +833,9 @@ int ring_simple::put_tx_buffers(mem_buf_desc_t* buff_list)
 		count++;
 		buff_list = next;
 	}
+
+	// to suppress warning in case ring_logfunc is compiled out
+	NOT_IN_USE(freed);
 	ring_logfunc("buf_list: %p count: %d freed: %d\n", buff_list, count, freed);
 
 	return_to_global_pool();

--- a/src/vma/dev/ring_tap.cpp
+++ b/src/vma/dev/ring_tap.cpp
@@ -495,8 +495,6 @@ void ring_tap::mem_buf_desc_return_single_to_owner_tx(mem_buf_desc_t* p_mem_buf_
 {
 	auto_unlocker lock(m_lock_ring_tx);
 
-	int count = 0;
-
 	if (likely(p_mem_buf_desc)) {
 		//potential race, ref is protected here by ring_tx lock, and in dst_entry_tcp & sockinfo_tcp by tcp lock
 		if (likely(p_mem_buf_desc->lwip_pbuf.pbuf.ref))
@@ -508,7 +506,6 @@ void ring_tap::mem_buf_desc_return_single_to_owner_tx(mem_buf_desc_t* p_mem_buf_
 			p_mem_buf_desc->p_next_desc = NULL;
 			free_lwip_pbuf(&p_mem_buf_desc->lwip_pbuf);
 			m_tx_pool.push_back(p_mem_buf_desc);
-			count++;
 		}
 	}
 
@@ -547,6 +544,8 @@ int ring_tap::mem_buf_tx_release(mem_buf_desc_t* buff_list, bool b_accounting, b
 		count++;
 		buff_list = next;
 	}
+	// to suppress warning in case ring_logfunc is compiled out
+	NOT_IN_USE(freed);
 	ring_logfunc("buf_list: %p count: %d freed: %d\n", buff_list, count, freed);
 
 	return_to_global_pool();

--- a/src/vma/ib/base/verbs_extra.cpp
+++ b/src/vma/ib/base/verbs_extra.cpp
@@ -317,6 +317,7 @@ int priv_ibv_modify_qp_ratelimit(struct ibv_qp *qp, struct vma_rate_limit_t &rat
 		return -2;
 	} ENDIF_VERBS_FAILURE;
 	BULLSEYE_EXCLUDE_BLOCK_END
+	NOT_IN_USE(attr_mask); /* vma_ibv_modify_qp_rate_limit may drop mask under DEFINED_IBV_QP_SUPPORT_BURST */
 #ifdef DEFINED_IBV_QP_SUPPORT_BURST
 	vlog_printf(VLOG_DEBUG, "qp was set to rate limit %d, burst size %d, packet size %d\n",
 			rate_limit.rate, rate_limit.max_burst_sz, rate_limit.typical_pkt_sz);

--- a/src/vma/iomux/io_mux_call.cpp
+++ b/src/vma/iomux/io_mux_call.cpp
@@ -368,6 +368,7 @@ void io_mux_call::polling_loops()
 	}
 
 	__if_dbg("2nd scenario exit (loop %d, elapsed %d)", poll_counter, m_elapsed.tv_usec);
+	NOT_IN_USE(poll_counter); /* to suppress warning in case VMA_MAX_DEFINED_LOG_LEVEL */
 }
 
 void io_mux_call::blocking_loops()

--- a/src/vma/sock/sockinfo_udp.cpp
+++ b/src/vma/sock/sockinfo_udp.cpp
@@ -1498,6 +1498,8 @@ int sockinfo_udp::rx_request_notification(uint64_t poll_sn)
 	}
 	m_rx_ring_map_lock.unlock();
 
+    // to suppress warning in case si_udp_logfunc is compiled out
+	NOT_IN_USE(ring_armed_count);
 	si_udp_logfunc("armed or busy %d ring(s) and %d ring are pending processing", ring_armed_count, ring_ready_count);
 	return ring_ready_count;
 }

--- a/src/vma/util/vma_stats.h
+++ b/src/vma/util/vma_stats.h
@@ -139,7 +139,7 @@ typedef struct {
 	uint32_t    n_tx_dummy;
 } socket_counters_t;
 
-typedef struct {
+typedef struct socket_stats_t {
 	int         fd;
 	uint32_t                     inode;
 	uint32_t                     tcp_state;   // enum tcp_state
@@ -184,7 +184,7 @@ typedef struct {
 	};
 } socket_stats_t;
 
-typedef struct {
+typedef struct socket_instance_block_t {
 	bool            b_enabled;
 	socket_stats_t  skt_stats;
 


### PR DESCRIPTION
## Description
Name anonymous structs socket_stats_t and socket_instance_block_t to fix -Werror=non-c-typedef-for-linkage with newer compilers. Structs with member functions require a tag name for C++ linkage. Matches the existing pattern used by sh_mem_t in the same file.

##### What
Fix non-c-typedef-for-linkage build error

##### Why ?
Resolve build failures.

##### How ?
_It is optional but for complex PRs please provide information about the design,
architecture, approach, etc._

## Change type
What kind of change does this PR introduce?
- [X] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Tests
- [ ] Other

## Check list
- [ ] Code follows the style de facto guidelines of this project
- [ ] Comments have been inserted in hard to understand places
- [ ] Documentation has been updated (if necessary)
- [ ] Test has been added (if possible)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Suppressed several compiler warnings to improve build cleanliness.
  * Adjusted internal type declarations for clearer code organization.
  * No behavioral or user-facing changes; purely internal maintenance.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Mellanox/libvma/pull/1175)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->