### PR TITLE
git issue: 5022366 Valgrind sockperf leak suppression

### DIFF
--- a/contrib/jenkins_tests/vg.sh
+++ b/contrib/jenkins_tests/vg.sh
@@ -95,7 +95,7 @@ for test_link in $test_ip_list; do
 
 		if [ `ps -ef | grep $test_app | wc -l` -gt 1 ];
 		then
-			${sudo_cmd} pkill -9 -f $test_app 2>/dev/null || true
+			${sudo_cmd} pkill -SIGINT -f $test_app 2>/dev/null || true
 			sleep 10
 			# in case SIGINT didn't work
 			if [ `ps -ef | grep $test_app | wc -l` -gt 1 ];

--- a/contrib/valgrind/valgrind_vma.supp
+++ b/contrib/valgrind/valgrind_vma.supp
@@ -491,6 +491,33 @@
    fun:_ZN6ServerI10IoRecvfrom9SwitchOffS1_E13server_acceptEi
    fun:_ZN6ServerI10IoRecvfrom9SwitchOffS1_E6doLoopEv
 }
+{
+   sockperf_free_check
+   Memcheck:Free
+   fun:free
+   fun:_Z9close_ifdiiP8fds_data
+   fun:server_receive_then_send_impl<RecvFromInputHandler>
+   fun:server_receive_then_send<>
+   fun:_ZN6ServerI10IoRecvfrom9SwitchOffE6doLoopEv
+   fun:doHandler
+   fun:server_handler<IoRecvfrom, SwitchOff>
+   fun:_Z14server_handlerI10IoRecvfromEviii
+   fun:_Z7do_testv
+   fun:main
+}
+{
+   sockperf_leak_on_sigint
+   Memcheck:Leak
+   match-leak-kinds: definite
+   fun:_Znwm
+   fun:_ZN6ServerI10IoRecvfrom9SwitchOffE13server_acceptEi
+   fun:_ZN6ServerI10IoRecvfrom9SwitchOffE6doLoopEv
+   fun:doHandler
+   fun:server_handler<IoRecvfrom, SwitchOff>
+   fun:_Z14server_handlerI10IoRecvfromEviii
+   fun:_Z7do_testv
+   fun:main
+}
 ###########################################################
 # libnl1
 {


### PR DESCRIPTION
Backport from xlio RM 4642229 & 4642229
Add Valgrind suppression for a sockperf memory leaks, This is a genuine sockperf leak unrelated to libxlio.

## Description
Please provide a summary of the change.

##### What
_Subject: what this PR is doing in one line._ 

##### Why ?
_Justification for the PR. If there is existing issue/bug please reference._

##### How ?
_It is optional but for complex PRs please provide information about the design,
architecture, approach, etc._

## Change type
What kind of change does this PR introduce?
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Tests
- [ ] Other

## Check list
- [ ] Code follows the style de facto guidelines of this project
- [ ] Comments have been inserted in hard to understand places
- [ ] Documentation has been updated (if necessary)
- [ ] Test has been added (if possible)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Refined memory-analysis suppression rules to separate definite leaks from cleanup/free paths, yielding more accurate Valgrind reports.
  * Updated test harness to attempt graceful termination of test processes (send SIGINT) instead of using a forceful kill, improving cleanup and log capture.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Mellanox/libvma/pull/1179)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->